### PR TITLE
GetAvoidDetective compatibility

### DIFF
--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -715,6 +715,7 @@ end
 -- @note This gives compatibility for some legacy ttt addons
 -- @return boolean
 -- @realm server
+-- @deprecated
 function plymeta:GetAvoidDetective()
 	return self:GetAvoidRole(ROLE_DETECTIVE)
 end

--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -711,6 +711,15 @@ function plymeta:GetAvoidRole(role)
 end
 
 ---
+-- Returns whether a @{Player} has disabled the selection of the detective role
+-- @note This gives compatibility for some legacy ttt addons
+-- @return boolean
+-- @realm server
+function plymeta:GetAvoidDetective()
+	return self:GetAvoidRole(ROLE_DETECTIVE)
+end
+
+---
 -- Returns whether a @{Player} is able to select a specific @{ROLE}
 -- @param ROLE roleData
 -- @param number choice_count


### PR DESCRIPTION
Damagelog depends on this function, other ttt addons might as well. Therefore i thought fixing the problem with damagelogs in the ttt2 project is the better approach.
Also feel free to change my documentation :)