### PR TITLE
introduced new hooks

### DIFF
--- a/gamemodes/terrortown/gamemode/server/sv_player.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player.lua
@@ -128,7 +128,7 @@ function GM:PlayerSpawn(ply)
 	-- a hook to handle the rolespecific stuff that should be done on
 	-- rolechange and respawn (while a round is active)
 	if ply:IsActive() then -- round is active and player is terror player
-		hook.Run("TTT2PlayerInitRole", ply, false, ply:GetSubRole(), ply:GetTeam())
+		hook.Run("TTT2GiveRoleLoadout", ply, false, ply:GetSubRole(), ply:GetTeam())
 	end
 end
 
@@ -909,7 +909,7 @@ function GM:PlayerDeath(victim, infl, attacker)
 			-- a hook to handle the rolespecific stuff that should be done on death or rolechange
 			-- this hook is called prior to setting the player team to spectator!
 			if victim:IsActive() then -- round is active and player was terror player
-				hook.Run("TTT2PlayerDeinitRole", victim, victim:GetSubRole(), victim:GetTeam())
+				hook.Run("TTT2RemoveRoleLoadout", victim, false, victim:GetSubRole(), victim:GetTeam())
 			end
 			
 			victim:SetTeam(TEAM_SPEC)

--- a/gamemodes/terrortown/gamemode/server/sv_player.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player.lua
@@ -128,7 +128,7 @@ function GM:PlayerSpawn(ply)
 	-- a hook to handle the rolespecific stuff that should be done on
 	-- rolechange and respawn (while a round is active)
 	if ply:IsActive() then -- round is active and player is terror player
-		hook.Run("TTT2PlayerRoleInit", ply, ply:GetSubRole(), ply:GetTeam())
+		hook.Run("TTT2PlayerInitRole", ply, false, ply:GetSubRole(), ply:GetTeam())
 	end
 end
 
@@ -906,6 +906,12 @@ function GM:PlayerDeath(victim, infl, attacker)
 
 	timer.Simple(0, function()
 		if IsValid(victim) then
+			-- a hook to handle the rolespecific stuff that should be done on death or rolechange
+			-- this hook is called prior to setting the player team to spectator!
+			if victim:IsActive() then -- round is active and player was terror player
+				hook.Run("TTT2PlayerDeinitRole", victim, victim:GetSubRole(), victim:GetTeam())
+			end
+			
 			victim:SetTeam(TEAM_SPEC)
 			victim:Freeze(false)
 			victim:SetRagdollSpec(true)
@@ -929,12 +935,6 @@ function GM:PlayerDeath(victim, infl, attacker)
 			end
 
 			hook.Run("TTT2PostPlayerDeath", victim, infl, attacker)
-		end
-
-		-- a hook to handle the rolespecific stuff that should be done on
-		-- rolechange and respawn (while a round is active)
-		if GetRoundState() == ROUND_ACTIVE then -- round is active and player is terror player
-			hook.Run("TTT2PlayerRoleDeinit", victim, victim:GetSubRole(), victim:GetTeam())
 		end
 	end)
 end

--- a/gamemodes/terrortown/gamemode/server/sv_player.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player.lua
@@ -124,6 +124,12 @@ function GM:PlayerSpawn(ply)
 	ply:SetupHands()
 
 	SCORE:HandleSpawn(ply)
+
+	-- a hook to handle the rolespecific stuff that should be done on
+	-- rolechange and respawn (while a round is active)
+	if ply:IsActive() then -- round is active and player is terror player
+		hook.Run("TTT2PlayerRoleInit", ply, ply:GetSubRole(), ply:GetTeam())
+	end
 end
 
 ---
@@ -923,6 +929,12 @@ function GM:PlayerDeath(victim, infl, attacker)
 			end
 
 			hook.Run("TTT2PostPlayerDeath", victim, infl, attacker)
+		end
+
+		-- a hook to handle the rolespecific stuff that should be done on
+		-- rolechange and respawn (while a round is active)
+		if GetRoundState() == ROUND_ACTIVE then -- round is active and player is terror player
+			hook.Run("TTT2PlayerRoleDeinit", victim, victim:GetSubRole(), victim:GetTeam())
 		end
 	end)
 end

--- a/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
@@ -140,9 +140,9 @@ function plymeta:SetRole(subrole, team, forceHooks)
 
 	-- a hook to handle the rolespecific stuff that should be done on
 	-- rolechange and respawn (while a round is active)
-	if forceHooks or oldSubrole ~= newSubrole or oldTeam ~= newTeam then
-		hook.Run("TTT2PlayerRoleDeinit", self, oldSubrole, oldTeam)
-		hook.Run("TTT2PlayerRoleInit", self, newSubrole, newTeam)
+	if SERVER then
+		hook.Run("TTT2PlayerDeinitRole", self, oldSubrole, oldTeam)
+		hook.Run("TTT2PlayerInitRole", self, true, newSubrole, newTeam)
 	end
 end
 

--- a/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
@@ -141,8 +141,8 @@ function plymeta:SetRole(subrole, team, forceHooks)
 	-- a hook to handle the rolespecific stuff that should be done on
 	-- rolechange and respawn (while a round is active)
 	if SERVER then
-		hook.Run("TTT2PlayerDeinitRole", self, oldSubrole, oldTeam)
-		hook.Run("TTT2PlayerInitRole", self, true, newSubrole, newTeam)
+		hook.Run("TTT2RemoveRoleLoadout", self, true, oldSubrole, oldTeam)
+		hook.Run("TTT2GiveRoleLoadout", self, true, newSubrole, newTeam)
 	end
 end
 

--- a/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
@@ -137,6 +137,13 @@ function plymeta:SetRole(subrole, team, forceHooks)
 			hook.Run("TTTPlayerSetColor", self)
 		end
 	end
+
+	-- a hook to handle the rolespecific stuff that should be done on
+	-- rolechange and respawn (while a round is active)
+	if forceHooks or oldSubrole ~= newSubrole or oldTeam ~= newTeam then
+		hook.Run("TTT2PlayerRoleDeinit", self, oldSubrole, oldTeam)
+		hook.Run("TTT2PlayerRoleInit", self, newSubrole, newTeam)
+	end
 end
 
 ---


### PR DESCRIPTION
Right now there exists one problem in TTT2. If you want to give a player a rolespecific loadout, you have to rely on the RoleChange hook. But if you want to give the same loadout on respawn (e.g if the player was revived) you have to use the PlayerSpawn Hook. There exists the problem that this hook is called on every spawn and a player would get the loadout of the role he was in the previous round on some ocasions. There are workarounds to this, but it is not intuitive.

Right now there exist quite a few loadout specific hooks, but none of them is particular useful in this scenario. Therefore let me introduce these two new hooks: `TTT2PlayerRoleInit` and `TTT2PlayerRoleDeinit`. Why two of them? At first I had this functionality in one hook. But this caused the problem that two roles, that give the same item, could create raceconditions if the hook of the old role is called after the hook of the new role.

The new hook is called on roleChange, teamChange, death and spawn and can be easily used like this:

```lua

hook.Add('TTT2PlayerRoleInit', 'TTT2MarkerInit', function(ply, new_role, new_team)
	if new_role ~= ROLE_MARKER then return end
	
	InitRoleMarker(ply)
end)

hook.Add('TTT2PlayerRoleDeinit', 'TTT2MarkerDeinit', function(ply, old_role, old_team)
	if old_role ~= ROLE_MARKER then return end

	DeinitRoleMarker(ply)
	MARKER_DATA:MarkerDied()
end)

```