### PR TITLE
sprint modifier hook

### DIFF
--- a/gamemodes/terrortown/gamemode/shared/sh_main.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_main.lua
@@ -73,10 +73,11 @@ function GM:Move(ply, mv)
 		local mul = hook.Call("TTTPlayerSpeedModifier", GAMEMODE, ply, slowed, mv, noLag) or 1
 		mul = basemul * mul * noLag[1]
 
-		local sprintMultiplierModifier = {1}
-		hook.Run("TTT2PlayerSprintMultiplier", ply, sprintMultiplierModifier)
-
 		if ply.sprintMultiplier and (ply.sprintProgress or 0) > 0 then
+			local sprintMultiplierModifier = {1}
+			
+			hook.Run("TTT2PlayerSprintMultiplier", ply, sprintMultiplierModifier)
+			
 			mul = mul * ply.sprintMultiplier * sprintMultiplierModifier[1]
 		end
 

--- a/gamemodes/terrortown/gamemode/shared/sh_main.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_main.lua
@@ -73,8 +73,11 @@ function GM:Move(ply, mv)
 		local mul = hook.Call("TTTPlayerSpeedModifier", GAMEMODE, ply, slowed, mv, noLag) or 1
 		mul = basemul * mul * noLag[1]
 
+		local sprintMultiplierModifier = {1}
+		hook.Run("TTT2PlayerSprintMultiplier", ply, sprintMultiplierModifier)
+
 		if ply.sprintMultiplier and (ply.sprintProgress or 0) > 0 then
-			mul = mul * ply.sprintMultiplier * (ply.sprintMultiplierModifier or 1)
+			mul = mul * ply.sprintMultiplier * sprintMultiplierModifier[1]
 		end
 
 		mv:SetMaxClientSpeed(mv:GetMaxClientSpeed() * mul)


### PR DESCRIPTION
A really simple change to remove the static player sprint multiplier in favor of a hook. Right now the sprint multiplier ist set with  `ply.sprintMultiplierModifier`, this hook allows to do the same (but stackable) with a hook:

```lua
hook.Add("TTT2PlayerSprintMultiplier", "sprintchange", function(ply, multi)
	multi[1] = 10 * multi[1]
end)
```