### PR TITLE
Role loading

### DIFF
--- a/lua/includes/modules/roles.lua
+++ b/lua/includes/modules/roles.lua
@@ -484,3 +484,28 @@ function GetSortedRoles()
 
 	return rls
 end
+
+---
+-- Connects a SubRole with its BaseRole.
+-- @notice This will also set the defaultTeam variable to the BaseRole's team.
+-- @param ROLE roleTable the role table (of the SubRole)
+-- @param ROLE baserole the BaseRole
+-- @realm shared
+function SetBaseRole(roleTable, baserole)
+	if roleTable.baserole then
+		error("[TTT2][ROLE-SYSTEM][ERROR] BaseRole of " .. roleTable.name .. " already set (" .. roleTable.baserole .. ")!")
+	else
+		local br = roles.GetByIndex(baserole)
+
+		if br.baserole then
+			error("[TTT2][ROLE-SYSTEM][ERROR] Your requested BaseRole can't be any BaseRole of another SubRole because it's a SubRole as well.")
+
+			return
+		end
+
+		roleTable.baserole = baserole
+		roleTable.defaultTeam = br.defaultTeam
+
+		print("[TTT2][ROLE-SYSTEM] Connected '" .. roleTable.name .. "' subrole with baserole '" .. br.name .. "'")
+	end
+end

--- a/lua/includes/modules/roles.lua
+++ b/lua/includes/modules/roles.lua
@@ -194,14 +194,21 @@ function OnLoaded()
 		baseclass.Set(k, v)
 
 		if k ~= BASE_ROLE_CLASS then
+			v:PreInitialize()
+		end
+	end
+
+	-- Setup data (eg. convars for all roles)
+	for _, v in pairs(RoleList) do
+		if v.name ~= BASE_ROLE_CLASS then
 			SetupData(v)
 		end
 	end
 
-	-- Call PreInitialize on all roles
+	-- Call Initialize() on all roles
 	for _, v in pairs(RoleList) do
 		if v.name ~= BASE_ROLE_CLASS then
-			v:PreInitialize()
+			v:Initialize()
 		end
 	end
 end

--- a/lua/terrortown/entities/roles/ttt_role_base/shared.lua
+++ b/lua/terrortown/entities/roles/ttt_role_base/shared.lua
@@ -41,7 +41,7 @@ end
 -- @return boolean
 -- @realm shared
 function ROLE:IsBaseRole()
-	return self.baserole
+	return self.baserole == nil
 end
 
 ---

--- a/lua/terrortown/entities/roles/ttt_role_base/shared.lua
+++ b/lua/terrortown/entities/roles/ttt_role_base/shared.lua
@@ -63,26 +63,10 @@ end
 ---
 -- Connects a SubRole with its BaseRole
 -- @param ROLE baserole the BaseRole
--- @usage -- inside of e.g. this hook:
--- @usage hook.Add("TTT2BaseRoleInit", "TTT2ConnectBaseRole" .. baserole .. "With_" .. roleData.name, ...)
 -- @realm shared
 function ROLE:SetBaseRole(baserole)
-	if self.baserole then
-		error("[TTT2][ROLE-SYSTEM][ERROR] BaseRole of " .. self.name .. " already set (" .. self.baserole .. ")!")
-	else
-		local br = roles.GetByIndex(baserole)
-
-		if br.baserole then
-			error("[TTT2][ROLE-SYSTEM][ERROR] Your requested BaseRole can't be any BaseRole of another SubRole because it's a SubRole as well.")
-
-			return
-		end
-
-		self.baserole = baserole
-		self.defaultTeam = br.defaultTeam
-
-		print("[TTT2][ROLE-SYSTEM] Connected '" .. self.name .. "' subrole with baserole '" .. br.name .. "'")
-	end
+	print("[TTT2][DEPRECATION] ROLE:SetBaseRole will be removed in the near future! You should call roles.SetBaseRole(self, ROLENAME) in the ROLE:Initialize() function!")
+	roles.SetBaseRole(self, baserole)
 end
 
 ---

--- a/lua/terrortown/entities/roles/ttt_role_base/shared.lua
+++ b/lua/terrortown/entities/roles/ttt_role_base/shared.lua
@@ -1,12 +1,28 @@
 ---
 -- @module ROLE
 -- @author Alf21
+-- @author saibotk
 
 ---
--- This function is called before initializing a @{ROLE}
--- @hook
+-- This function is called before initializing a @{ROLE}, but after all
+-- global variables like "ROLE_TRAITOR" have been initialized.
+-- Use this function to define role attributes, which is dependant on other
+-- global variables (eg. from other roles).
+-- This is mostly used to register the defaultTeam, shopFallback, etc...
 -- @realm shared
 function ROLE:PreInitialize()
+
+end
+
+---
+-- This function is called after all roles have been loaded with their
+-- ConVars, that are created for each role automatically, and their global
+-- variables.
+-- Please use this function to register your SubRole with the BaseRole, by
+-- calling @{roles.SetBaseRole} and initialize any other needed data
+-- (eg. @{LANG} function calls).
+-- @realm shared
+function ROLE:Initialize()
 
 end
 

--- a/lua/terrortown/entities/roles/ttt_role_base/shared.lua
+++ b/lua/terrortown/entities/roles/ttt_role_base/shared.lua
@@ -9,6 +9,7 @@
 -- Use this function to define role attributes, which is dependant on other
 -- global variables (eg. from other roles).
 -- This is mostly used to register the defaultTeam, shopFallback, etc...
+-- @hook
 -- @realm shared
 function ROLE:PreInitialize()
 
@@ -21,6 +22,7 @@ end
 -- Please use this function to register your SubRole with the BaseRole, by
 -- calling @{roles.SetBaseRole} and initialize any other needed data
 -- (eg. @{LANG} function calls).
+-- @hook
 -- @realm shared
 function ROLE:Initialize()
 
@@ -63,6 +65,7 @@ end
 ---
 -- Connects a SubRole with its BaseRole
 -- @param ROLE baserole the BaseRole
+-- @deprecated
 -- @realm shared
 function ROLE:SetBaseRole(baserole)
 	print("[TTT2][DEPRECATION] ROLE:SetBaseRole will be removed in the near future! You should call roles.SetBaseRole(self, ROLENAME) in the ROLE:Initialize() function!")


### PR DESCRIPTION
This is a first approach at cleaning up the ROLE system.

The change is not that big, but should make it more clear for other developers, on how to use the 
`ROLE:PreInitialize()` and `ROLE:Initialize()` functions.  
They are used to clean up the messy hook usage that has since been used to eg. set the `BaseRole` or set the `LANG` entries.

But this mainly addresses the issue with roles that are loaded before other roles, which they reference with their global variables to eg. set the fallback Shop or the `defaultTeam` variable.
Now the loading is ordered in a way, that the global variables of all roles are initialized, then the `ROLE:PreInitialize()` function is called on each role and after setting up the internal default ConVars, etc for each role (see SetupData(v) in the roles module) the `ROLE:Initialize()` function is called on each role.

@Alf21 i did not know how to use the documentation symbols correctly, so i will need some input of you on how to make this approvable.

The code is tested and is compatible with the existing roles (non-breaking).

General feedback is welcome.