### PR TITLE
Ragdoll Model/Skin "fix"

### DIFF
--- a/gamemodes/terrortown/gamemode/server/sv_corpse.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_corpse.lua
@@ -514,6 +514,7 @@ function CORPSE.Create(ply, attacker, dmginfo)
 
 	rag:SetPos(ply:GetPos())
 	rag:SetModel(ply:GetModel())
+	rag:SetSkin(ply:GetSkin())
 	rag:SetAngles(ply:GetAngles())
 	rag:SetColor(ply:GetColor())
 


### PR DESCRIPTION
Some models have different skins (for example different hair styles, or outfits). By now, the ragdoll will always drop without that skin, which is sometimes annoying for players with customized skins.