### PR TITLE
ConVar for compatibility with Enhanced Playermodel Selector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
+# IntelliJ-based IDE files
+.idea/*
+
 # Custom files
 .ftpconfig
 .glualint.json

--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -113,6 +113,7 @@ CreateConVar("ttt_max_roles", "0", {FCVAR_NOTIFY, FCVAR_ARCHIVE}, "Maximum amoun
 CreateConVar("ttt_max_roles_pct", "0", {FCVAR_NOTIFY, FCVAR_ARCHIVE}, "Maximum amount of different roles based on player amount. ttt_max_roles needs to be 0")
 CreateConVar("ttt_max_baseroles", "0", {FCVAR_NOTIFY, FCVAR_ARCHIVE}, "Maximum amount of different baseroles")
 CreateConVar("ttt_max_baseroles_pct", "0", {FCVAR_NOTIFY, FCVAR_ARCHIVE}, "Maximum amount of different baseroles based on player amount. ttt_max_baseroles needs to be 0")
+CreateConVar("ttt_enforce_playermodel", "1", {FCVAR_NOTIFY, FCVAR_ARCHIVE}, "Whether or not to enforce terrorist playermodels. Set to 0 for compatibility with Enhanced Playermodel Selector")
 
 -- debuggery
 local ttt_dbgwin = CreateConVar("ttt_debug_preventwin", "0", {FCVAR_NOTIFY, FCVAR_ARCHIVE})

--- a/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
@@ -127,8 +127,10 @@ function plymeta:SetRole(subrole, team, forceHooks)
 		if SERVER then
 			hook.Call("PlayerLoadout", GAMEMODE, self)
 
-			-- update subroleModel
-			self:SetModel(self:GetSubRoleModel())
+			if GetConVar("ttt_enforce_playermodel"):GetBool() then
+				-- update subroleModel
+				self:SetModel(self:GetSubRoleModel())
+			end
 
 			-- Always clear color state, may later be changed in TTTPlayerSetColor
 			self:SetColor(COLOR_WHITE)


### PR DESCRIPTION
Rounds fail to start when using [Enhanced Playermodel Selector](https://steamcommunity.com/workshop/filedetails/?id=504945881), as it blocks changes to playermodels and this causes an error. 
This PR adds a ttt_enforce_playermodel ConVar. When set to 0, this disables automatic playermodel-setting at the start of a round, fixing this issue.

I've also added the .idea directory to the .gitignore, for users of IntelliJ IDEA-based IDEs, such as myself. Feel free to cherry-pick out if desired.