### PR TITLE
Allow hold aim instead of toggle

### DIFF
--- a/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -9,8 +9,6 @@ local util = util
 local IsValid = IsValid
 local surface = surface
 local draw = draw
-local CLIENT = CLIENT
-local SERVER = SERVER
 local CreateClientConVar = CreateClientConVar
 
 if SERVER then
@@ -152,8 +150,8 @@ SWEP.IronSightPos = Vector(0, 0, 0)
 -- The rotational offset applied when entering the ironsight
 SWEP.IronSightsAng = Vector(0, 0, 0)
 
-local sparkle = CLIENT and CreateClientConVar("ttt_crazy_sparks", "0", true)
-local ttt2_hold_aim = CLIENT and CreateClientConVar("ttt2_hold_aim", 0, true, false, LANG.GetTranslationFromLanguage("hold_aim", "english"), 0, 1)
+local sparkle = CLIENT and CreateClientConVar("ttt_crazy_sparks", "0", true) or nil
+local ttt2_hold_aim = CLIENT and CreateClientConVar("ttt2_hold_aim", 0, true, false, LANG.GetTranslationFromLanguage("hold_aim", "english"), 0, 1) or nil
 
 -- crosshair
 if CLIENT then
@@ -455,10 +453,10 @@ end
 function SWEP:SecondaryAttack()
 	if self.NoSights or not self.IronSightsPos then return end
 
-	local bIronsights = self:GetIronsights()
+	local bNotIronsights = not self:GetIronsights()
 
-	self:SetIronsights(not bIronsights)
-	self:SetZoom(not bIronsights)
+	self:SetIronsights(bNotIronsights)
+	self:SetZoom(bNotIronsights)
 	self:SetNextSecondaryFire(CurTime() + 0.3)
 end
 

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -637,12 +637,14 @@ function SWEP:GetIronsightsTime()
 	return -1
 end
 
+---
 -- Dummy functions that will be replaced when SetupDataTables runs. These are
 -- here for when that does not happen (due to e.g. stacking base classes)
 function SWEP:SetIronsightsTime()
 
 end
 
+---
 -- Dummy functions that will be replaced when SetupDataTables runs. These are
 -- here for when that does not happen (due to e.g. stacking base classes)
 -- @return[default=false] boolean
@@ -651,6 +653,7 @@ function SWEP:GetIronsightsPredicted()
 	return false
 end
 
+---
 -- Dummy functions that will be replaced when SetupDataTables runs. These are
 -- here for when that does not happen (due to e.g. stacking base classes)
 -- @realm shared
@@ -817,12 +820,12 @@ end
 -- Tell the server about the users preference regarding holding aim or toggle aim,
 -- necessary to avoid prediction issues
 local function UpdateHoldAimCV()
-	net.Start("TTT2ResetIronSights")
+	net.Start("TTT2UpdateHoldAimConvar")
 	net.WriteBool(ttt2_hold_aim:GetBool())
 	net.SendToServer()
 end
 
-hook.Add("KeyRelease", "TTT2ResetIronSightsHook", function(ply, key)
+hook.Add("KeyRelease", "TTT2ResetIronSights", function(ply, key)
 	if key ~= IN_ATTACK2 or not IsValid(ply) then return end
 
 	if not (CLIENT and ttt2_hold_aim:GetBool() or SERVER and ply.holdAim) then return end
@@ -844,7 +847,7 @@ if CLIENT then
 		UpdateHoldAimCV()
 	end)
 else
-	net.Receive("TTT2ResetIronSights", function(len, ply)
+	net.Receive("TTT2UpdateHoldAimConvar", function(len, ply)
 		ply.holdAim = net.ReadBool()
 	end)
 end

--- a/gamemodes/terrortown/gamemode/client/cl_help.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_help.lua
@@ -583,6 +583,9 @@ function HELPSCRN:CreateGameplaySettings(parent)
 	cb = form:CheckBox(GetTranslation("set_fastsw"), "ttt_weaponswitcher_fast")
 	cb:SetTooltip(GetTranslation("set_fastsw_tip"))
 
+	cb = form:CheckBox(GetTranslation("hold_aim"), "ttt2_hold_aim")
+	cb:SetTooltip(GetTranslation("hold_aim_tip"))
+
 	cb = form:CheckBox(GetTranslation("doubletap_sprint_anykey"), "ttt2_doubletap_sprint_anykey")
 	cb:SetTooltip(GetTranslation("doubletap_sprint_anykey_tip"))
 

--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -173,6 +173,7 @@ util.AddNetworkString("TTT2RequestTButtonConfig")
 util.AddNetworkString("TTT2OrderEquipment")
 util.AddNetworkString("TTT2RoleGlobalVoice")
 util.AddNetworkString("TTT2MuteTeam")
+util.AddNetworkString("TTT2ResetIronSights")
 
 CHANGED_EQUIPMENT = {}
 

--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -173,7 +173,7 @@ util.AddNetworkString("TTT2RequestTButtonConfig")
 util.AddNetworkString("TTT2OrderEquipment")
 util.AddNetworkString("TTT2RoleGlobalVoice")
 util.AddNetworkString("TTT2MuteTeam")
-util.AddNetworkString("TTT2ResetIronSights")
+util.AddNetworkString("TTT2UpdateHoldAimConvar")
 
 CHANGED_EQUIPMENT = {}
 

--- a/gamemodes/terrortown/gamemode/shared/lang/english.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/english.lua
@@ -1258,3 +1258,7 @@ L.doubletap_sprint_anykey_tip = "You will keep sprinting as long as you keep mov
 
 L.disable_doubletap_sprint = "Disable double tap sprinting"
 L.disable_doubletap_sprint_tip = "Double tapping a movement key will no longer cause you to sprint"
+
+-- 2020-02-03
+L.hold_aim = "Hold to aim"
+L.hold_aim_tip = "You will keep using the ironsights as long as you keep holding secondary attack (default: right mouse button)"

--- a/gamemodes/terrortown/gamemode/shared/lang/german.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/german.lua
@@ -1249,3 +1249,7 @@ L.doubletap_sprint_anykey_tip = "So lange du dich weiterhin bewegst, wird das Sp
 
 L.disable_doubletap_sprint = "Deaktiviere Double-Tap Sprinten"
 L.disable_doubletap_sprint_tip = "Deaktiviert das Auslösen des Sprinten durch Double-Tap einer Bewegungstaste"
+
+-- 2020-02-03
+L.hold_aim = "Halten zum Anvisieren"
+L.hold_aim_tip = "Solange du die Sekundärfeuertaste hältst, bleibst du anvisiert (Standard: Rechte Maustaste)"


### PR DESCRIPTION
You no longer have to press secondary attack a second time to stop aiming and instead will stop aiming as soon as you let go of the button. This is disabled by default and can be enabled using the clientside convar ttt2_hold_aim or by checking the checkbox in the gameplay menu. I tried to change as little as possible about how the ironsight actually works in order to keep it compatible with old stuff. I also made sure this doesn't mess with prediction, making this change very stable even at high latency like 300ms. I added some missing functions and fields in order to give people an idea of how they should implement ironsights and zoom and added some missing doc.