### PR TITLE
Fix replicated convars

### DIFF
--- a/gamemodes/terrortown/entities/entities/ttt_traitor_button/shared.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_traitor_button/shared.lua
@@ -1,6 +1,6 @@
 --- Special button usable from range if your role has access to it
 
-CreateConVar("ttt2_tbutton_admin_show", 0, { FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED }, "Always show the buttons to admins in range", 0, 1)
+CreateConVar("ttt2_tbutton_admin_show", 0, SERVER and { FCVAR_ARCHIVE, FCVAR_NOTIFY, FCVAR_REPLICATED } or FCVAR_REPLICATED, "Always show the buttons to admins in range", 0, 1)
 
 if CLIENT then
 	net.Receive("TTT2SendTButtonConfig", function(len, ply)

--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -77,8 +77,8 @@ CreateConVar("ttt_credits_alonebonus", "1", {FCVAR_NOTIFY, FCVAR_ARCHIVE})
 CreateConVar("ttt_use_weapon_spawn_scripts", "1", {FCVAR_NOTIFY, FCVAR_ARCHIVE})
 CreateConVar("ttt_weapon_spawn_count", "0", {FCVAR_NOTIFY, FCVAR_ARCHIVE})
 
-local round_limit = CreateConVar("ttt_round_limit", "6", {FCVAR_NOTIFY, FCVAR_ARCHIVE, FCVAR_REPLICATED})
-local time_limit = CreateConVar("ttt_time_limit_minutes", "75", {FCVAR_NOTIFY, FCVAR_ARCHIVE, FCVAR_REPLICATED})
+local round_limit = CreateConVar("ttt_round_limit", "6", SERVER and {FCVAR_NOTIFY, FCVAR_ARCHIVE, FCVAR_REPLICATED} or FCVAR_REPLICATED)
+local time_limit = CreateConVar("ttt_time_limit_minutes", "75", SERVER and {FCVAR_NOTIFY, FCVAR_ARCHIVE, FCVAR_REPLICATED} or FCVAR_REPLICATED)
 
 local idle_enabled = CreateConVar("ttt_idle", "1", {FCVAR_NOTIFY, FCVAR_ARCHIVE})
 local idle_time = CreateConVar("ttt_idle_limit", "180", {FCVAR_NOTIFY, FCVAR_ARCHIVE})

--- a/lua/autorun/ttt_bem_autorun.lua
+++ b/lua/autorun/ttt_bem_autorun.lua
@@ -1,11 +1,8 @@
 -- create serverside ConVars
-local allowChange = CreateConVar("ttt_bem_allow_change", 1, {FCVAR_ARCHIVE, FCVAR_REPLICATED, FCVAR_SERVER_CAN_EXECUTE}, "Allow clients to change the look of the Traitor/Detective menu")
---local servercols = CreateConVar("ttt_bem_sv_cols", 4, {FCVAR_ARCHIVE, FCVAR_REPLICATED, FCVAR_SERVER_CAN_EXECUTE}, "Sets the number of columns in the Traitor/Detective menu's item list (serverside)")
-CreateConVar("ttt_bem_sv_cols", 4, {FCVAR_ARCHIVE, FCVAR_REPLICATED, FCVAR_SERVER_CAN_EXECUTE}, "Sets the number of columns in the Traitor/Detective menu's item list (serverside)")
---local serverrow = CreateConVar("ttt_bem_sv_rows", 5, {FCVAR_ARCHIVE, FCVAR_REPLICATED, FCVAR_SERVER_CAN_EXECUTE}, "Sets the number of rows in the Traitor/Detective menu's item list (serverside)")
-CreateConVar("ttt_bem_sv_rows", 5, {FCVAR_ARCHIVE, FCVAR_REPLICATED, FCVAR_SERVER_CAN_EXECUTE}, "Sets the number of rows in the Traitor/Detective menu's item list (serverside)")
---local serversize = CreateConVar("ttt_bem_sv_size", 64, {FCVAR_ARCHIVE, FCVAR_REPLICATED, FCVAR_SERVER_CAN_EXECUTE}, "Sets the item size in the Traitor/Detective menu's item list (serverside)")
-CreateConVar("ttt_bem_sv_size", 64, {FCVAR_ARCHIVE, FCVAR_REPLICATED, FCVAR_SERVER_CAN_EXECUTE}, "Sets the item size in the Traitor/Detective menu's item list (serverside)")
+local allowChange = CreateConVar("ttt_bem_allow_change", 1, SERVER and {FCVAR_ARCHIVE, FCVAR_REPLICATED} or FCVAR_REPLICATED, "Allow clients to change the look of the Traitor/Detective menu")
+CreateConVar("ttt_bem_sv_cols", 4, SERVER and {FCVAR_ARCHIVE, FCVAR_REPLICATED} or FCVAR_REPLICATED, "Sets the number of columns in the Traitor/Detective menu's item list (serverside)")
+CreateConVar("ttt_bem_sv_rows", 5, SERVER and {FCVAR_ARCHIVE, FCVAR_REPLICATED} or FCVAR_REPLICATED, "Sets the number of rows in the Traitor/Detective menu's item list (serverside)")
+CreateConVar("ttt_bem_sv_size", 64, SERVER and {FCVAR_ARCHIVE, FCVAR_REPLICATED} or FCVAR_REPLICATED, "Sets the item size in the Traitor/Detective menu's item list (serverside)")
 
 -- add Favourites DB functions
 AddCSLuaFile("favorites_db.lua")

--- a/lua/includes/modules/roles.lua
+++ b/lua/includes/modules/roles.lua
@@ -115,7 +115,7 @@ local function SetupData(roleData)
 		end
 	end
 
-	CreateConVar("ttt_" .. roleData.name .. "_traitor_button", tostring(conVarData.traitorButton or 0), {FCVAR_NOTIFY, FCVAR_ARCHIVE, FCVAR_REPLICATED})
+	CreateConVar("ttt_" .. roleData.name .. "_traitor_button", tostring(conVarData.traitorButton or 0), SERVER and {FCVAR_NOTIFY, FCVAR_ARCHIVE, FCVAR_REPLICATED} or FCVAR_REPLICATED)
 
 	CreateConVar("ttt_" .. roleData.abbr .. "_credits_starting", tostring(conVarData.credits or 0), {FCVAR_NOTIFY, FCVAR_ARCHIVE})
 	CreateConVar("ttt_" .. roleData.abbr .. "_credits_traitorkill", tostring(conVarData.creditsTraitorKill or 0), {FCVAR_NOTIFY, FCVAR_ARCHIVE})


### PR DESCRIPTION
Fixes replicated convars by removing unnecessary FCVAR flags clientside, specifically FCVAR_ARCHIVE.
This is a bug and has been fixed on the dev branch, but for now this is an easy workaround.
This also removes the FCVAR_SERVER_CAN_EXECUTE flag from the bem serverside cvars:
https://github.com/TTT-2/TTT2/blob/9a29e06a5688dcd455cff9ede5375cb0a249edbf/lua/autorun/ttt_bem_autorun.lua#L2-L8
The server could never change them by running a concommand clientside anyways, since replicated convars can only be changed serverside.
