### PR TITLE
Some more shop func rework

### DIFF
--- a/gamemodes/terrortown/gamemode/client/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_equip.lua
@@ -313,7 +313,7 @@ local function CreateEquipmentList(t)
 	for k = 1, #itms do
 		local item = itms[k]
 
-		local buyable, icon, message = EquipmentIsBuyable(item, ply)
+		local buyable = EquipmentIsBuyable(item, ply)
 
 		local hide = hook.Run("TTT2HideEquipment", ply, item.ClassName, items.IsItem(item.ClassName), buyable)
 

--- a/gamemodes/terrortown/gamemode/client/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_equip.lua
@@ -273,13 +273,8 @@ local function CreateEquipmentList(t)
 		local wep = weps[i]
 
 		if wep.IsEquipment and wep:IsEquipment() then
-			owned_ids[#owned_ids + 1] = wep:GetClass()
+			owned_ids[wep:GetClass()] = true
 		end
-	end
-
-	-- Stick to one value for no equipment
-	if #owned_ids == 0 then
-		owned_ids = nil
 	end
 
 	local itms = {}
@@ -382,13 +377,8 @@ local function CreateEquipmentList(t)
 				-- If we cannot order this item, darken it
 				if not t.role and ((
 						-- already owned
-						table.HasValue(owned_ids, item.id)
-						or items.IsItem(item.id) and item.limited and ply:HasEquipmentItem(item.id)
-						-- already carrying a weapon for this slot
-						or ItemIsWeapon(item) and not CanCarryWeapon(item)
+						owned_ids[item.ClassName]
 						or not EquipmentIsBuyable(item, ply)
-						-- already bought the item before
-						or item.limited and ply:HasBought(item.id)
 					) or (item.credits or 1) > credits
 				) then
 					ic:SetIconColor(color_darkened)

--- a/gamemodes/terrortown/gamemode/client/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_equip.lua
@@ -39,7 +39,6 @@ local color_darkened = Color(255, 255, 255, 80)
 local eqframe = eqframe
 local dlist = dlist
 local curSearch = curSearch
-local SafeTranslate = LANG.TryTranslation
 
 --
 --     GENERAL HELPER FUNCTIONS
@@ -115,12 +114,12 @@ local Comparator = ComparatorTranslatedNameCategorisedCaseInsensitiveAscending
 ---
 -- Sorts an equipment table
 -- @param table tbl the equipment table
--- @param function Comparator receives two equipments as argument and returns true if the first equipment should come first in the sorted table and false else
+-- @param function Comp A comparator function that receives two equipments as argument and returns true if the first equipment should come first in the sorted table and false else
 -- @realm client
-function SortEquipmentTable(tbl, Comparator)
-	if not tbl or #tbl < 2 or not isfunction(Comparator) then return end
+function SortEquipmentTable(tbl, Comp)
+	if not tbl or #tbl < 2 or not isfunction(Comp) then return end
 
-	table.sort(tbl, Comparator)
+	table.sort(tbl, Comp)
 end
 
 local function RolenameToRole(val)

--- a/gamemodes/terrortown/gamemode/client/cl_shopeditor.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_shopeditor.lua
@@ -9,12 +9,15 @@ local itemBoxColor = Color(100, 100, 100)
 
 local Equipmentnew
 local SafeTranslate = LANG.TryTranslation
+local SortEquipmentTable = SortEquipmentTable
 
 local math = math
 local table = table
 local net = net
 local pairs = pairs
 local IsValid = IsValid
+
+local Comparator = ComparatorClassNameCaseSensitiveAscending
 
 ---
 -- Returns whether the given equipment is not an @{ITEM} (so whether it's a @{Weapon})
@@ -328,7 +331,7 @@ function ShopEditor.CreateItemEditor()
 
 	local itms = ShopEditor.GetEquipmentForRoleAll()
 
-	SortEquipmentTable(itms)
+	SortEquipmentTable(itms, Comparator)
 
 	ShopEditor.CreateItemList(frame, w, h, itms, function(s)
 		ShopEditor.EditItem(s.item)
@@ -445,7 +448,7 @@ function ShopEditor.CreateOwnShopEditor(roleData, onCreate)
 
 	local itms = ShopEditor.GetEquipmentForRoleAll()
 
-	SortEquipmentTable(itms)
+	SortEquipmentTable(itms, Comparator)
 
 	ShopEditor.CreateItemList(frame, w, h, itms, function(slf)
 		local eq = not items.IsItem(slf.item) and weapons.GetStored(slf.item.id) or items.GetStored(slf.item.id)

--- a/gamemodes/terrortown/gamemode/server/sv_shop.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_shop.lua
@@ -97,18 +97,7 @@ local function OrderEquipment(ply, cls)
 	-- keep compatibility with old addons
 	if not hook.Run("TTTCanOrderEquipment", ply, idOrCls, is_item) then return end
 
-	-- add our own hook with more consistent class parameter and some more information
-	local allow, ignoreCost, message = hook.Run("TTT2CanOrderEquipment", ply, cls, is_item, credits)
-
-	if message then
-		LANG.Msg(ply, message, nil, MSG_MSTACK_ROLE)
-	end
-
-	if allow == false then return end
-
-	if not ignoreCost then
-		ply:SubtractCredits(credits)
-	end
+	ply:SubtractCredits(credits)
 
 	ply:AddBought(cls)
 

--- a/gamemodes/terrortown/gamemode/shared/sh_equip_items.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_equip_items.lua
@@ -398,22 +398,18 @@ if SERVER then
 					if equip.notBuyable then continue end
 
 					if equip.NoRandom then
-						amount = amount - 1
-
 						teamShops[fallback][#teamShops[fallback] + 1] = equip
 					else
 						tmp2[#tmp2 + 1] = equip
 					end
 				end
 
-				if amount > 0 then
-					for i = 1, amount do
-						local rndm = math.random(#tmp2)
+				for i = 1, amount do
+					local rndm = math.random(#tmp2)
 
-						teamShops[fallback][#teamShops[fallback] + 1] = tmp2[rndm]
+					teamShops[fallback][#teamShops[fallback] + 1] = tmp2[rndm]
 
-						table.remove(tmp2, rndm)
-					end
+					table.remove(tmp2, rndm)
 				end
 			else
 				teamShops[fallback] = fallbackTable
@@ -490,22 +486,18 @@ if SERVER then
 					if equip.notBuyable then continue end
 
 					if equip.NoRandom then
-						amount = amount - 1
-
 						RANDOMSHOP[ply][#RANDOMSHOP[ply] + 1] = equip
 					else
 						tmp2[#tmp2 + 1] = equip
 					end
 				end
 
-				if amount > 0 then
-					for k = 1, amount do
-						local rndm = mathrandom(#tmp2)
+				for k = 1, amount do
+					local rndm = mathrandom(#tmp2)
 
-						RANDOMSHOP[ply][#RANDOMSHOP[ply] + 1] = tmp2[rndm]
+					RANDOMSHOP[ply][#RANDOMSHOP[ply] + 1] = tmp2[rndm]
 
-						tableremove(tmp2, rndm)
-					end
+					tableremove(tmp2, rndm)
 				end
 			end
 		end

--- a/gamemodes/terrortown/gamemode/shared/sh_init.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_init.lua
@@ -385,58 +385,6 @@ function table.Randomize(t)
 	t = out
 end
 
--- TODO move to client file
-if CLIENT then
-	local SafeTranslate
-
-	---
-	-- Returns an equipment's translation based on the user's language
-	-- @param string name
-	-- @param string printName
-	-- @return string the translated text
-	-- @realm client
-	function GetEquipmentTranslation(name, printName)
-		SafeTranslate = SafeTranslate or LANG.TryTranslation
-
-		local val = printName
-		local str = SafeTranslate(val)
-
-		if str == val and name then
-			val = name
-			str = SafeTranslate(val)
-		end
-
-		if str == val and printName then
-			str = printName
-		end
-
-		return str
-	end
-
-	---
-	-- Sorts an equipment table
-	-- @param table tbl the equipment table
-	-- @realm client
-	function SortEquipmentTable(tbl)
-		if not tbl or #tbl < 2 then return end
-
-		local _func = function(adata, bdata)
-			a = adata.id
-			b = bdata.id
-
-			if tonumber(a) and not tonumber(b) then
-				return true
-			elseif tonumber(b) and not tonumber(a) then
-				return false
-			else
-				return a < b
-			end
-		end
-
-		table.sort(tbl, _func)
-	end
-end
-
 -- Game event log defs
 EVENT_KILL = 1
 EVENT_SPAWN = 2

--- a/gamemodes/terrortown/gamemode/shared/sh_init.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_init.lua
@@ -689,5 +689,16 @@ function EquipmentIsBuyable(tbl, ply)
 		return false, "X", "Your role can't buy this equipment."
 	end
 
+	-- add our own hook with more consistent class parameter and some more information
+	local allow, ignoreCost, message = hook.Run("TTT2CanOrderEquipment", ply, table.ClassName, isItem, tbl.credits)
+
+	if allow == false then
+		return false, "X", message or "You can't buy this."
+	end
+
+	if not ignoreCost and (tbl.credits or 1) > ply:GetCredits() then
+		return false, "X", "You can't afford this equipment."
+	end
+
 	return true, "✔", "ok"
 end

--- a/gamemodes/terrortown/gamemode/shared/sh_init.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_init.lua
@@ -671,7 +671,17 @@ function EquipmentIsBuyable(tbl, ply)
 	end
 
 	if tbl.globalLimited and BUYTABLE[tbl.id] or team and tbl.teamLimited and TEAMS[team] and not TEAMS[team].alone and TEAMBUYTABLE[team] and TEAMBUYTABLE[team][tbl.id] or tbl.limited and ply:HasBought(tbl.ClassName) then
-		return false, "X", "This equipment is limited and is already bought."
+		return false, "X", "This equipment is limited and was already bought."
+	end
+
+	local isItem = items.IsItem(tbl.id)
+
+	if isItem and tbl.limited and ply:HasEquipmentItem(tbl.id) then
+		return false, "X", "You can only have this item once."
+	end
+
+	if not isItem and not ply:CanCarryWeapon(tbl) then
+		return false, "X", "You have no free space in your inventory for this weapon."
 	end
 
 	-- weapon whitelist check


### PR DESCRIPTION
Removed another table.HasValue
Move affordability into EquipmentIsBuyable for consistency
Move CanOrder hook into EquipmentIsBuyable (opens it up to shared realm)
Add Hide hook, which can be used to hide any icon clientside. This turns out to be pretty useful in combination with CanOrder
Changing RandomShops to X now provides you with X random items + .NoRandom items, rather than X items total. This seems more intuitive. If I want an item to be non-random, I don't want less random items, I just want to make that one item always accessible. Currently if you have 5 .NoRandom items and RandomShops set to 4, you will have 0 random items in your shop, which is inconsistent and rather strange. Also, if you add an addon and that addon happens to contain equipment that is flagged .NoRandom, it shouldn't require you to readjust your shop settings
Add some default sorting to the shop