### PR TITLE
added addon language file support

### DIFF
--- a/gamemodes/terrortown/gamemode/client/cl_lang.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_lang.lua
@@ -167,12 +167,29 @@ function LANG.GetUnsafeLanguageTable()
 end
 
 ---
--- Returns a translated @{string} text (if possible) directly from the language table
--- @param string name string key identifier for the translated @{string}
--- @return nil|string
+-- Returns the reference to a language table if it exists
+-- @param string name string key identifier for the language
+-- @return nil|table
 -- @realm client
-function LANG.GetUnsafeNamed(name)
-	return LANG.Strings[name]
+function LANG.GetUnsafeNamed(lang_name)
+	lang_name = lang_name and string.lower(lang_name)
+
+	return LANG.Strings[lang_name]
+end
+
+---
+-- Returns the reference to a language table if it exists, creates a new language if it did not exist
+-- @param string name string key identifier for the language
+-- @return nil|table
+-- @realm client
+function LANG.GetOrCreateLanguage(lang_name)
+	lang_name = lang_name and string.lower(lang_name)
+
+	if not LANG.Strings[lang_name] then
+		LANG.CreateLanguage(lang_name)
+	end
+
+	return LANG.Strings[lang_name]
 end
 
 ---

--- a/gamemodes/terrortown/gamemode/client/cl_lang.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_lang.lua
@@ -66,7 +66,7 @@ end
 -- @return string the inserted string_name parameter
 -- @realm client
 function LANG.AddToLanguage(lang_name, string_name, string_text)
-	lang_name = lang_name and string.lower(lang_name)
+	lang_name = lang_name and string.lower(lang_name) or nil
 
 	if not LANG.IsLanguage(lang_name) then
 		ErrorNoHalt(Format("Failed to add '%s' to language '%s': language does not exist.\n", tostring(string_name), tostring(lang_name)))
@@ -172,7 +172,7 @@ end
 -- @return nil|table
 -- @realm client
 function LANG.GetUnsafeNamed(lang_name)
-	lang_name = lang_name and string.lower(lang_name)
+	lang_name = lang_name and string.lower(lang_name) or nil
 
 	if not LANG.IsLanguage(lang_name) then
 		ErrorNoHalt(Format("Failed to get '%s': language does not exist.\n", tostring(lang_name)))
@@ -188,8 +188,8 @@ end
 -- @param string name string key identifier for the language
 -- @return nil|table
 -- @realm client
-function LANG.GetLanguageTable(lang_name)
-	lang_name = lang_name and string.lower(lang_name)
+function LANG.GetLanguageTableReference(lang_name)
+	lang_name = lang_name and string.lower(lang_name) or nil
 
 	if not LANG.IsLanguage(lang_name) then
 		LANG.CreateLanguage(lang_name)
@@ -239,7 +239,7 @@ end
 -- @param string lang_name the new language name
 -- @realm client
 function LANG.SetActiveLanguage(lang_name)
-	lang_name = lang_name and string.lower(lang_name)
+	lang_name = lang_name and string.lower(lang_name) or nil
 
 	if LANG.IsLanguage(lang_name) then
 		local old_name = LANG.ActiveLanguage
@@ -302,7 +302,7 @@ end
 function LANG.IsLanguage(lang_name)
 	if not lang_name then return end
 
-	return LANG.Strings[string.lower(lang_name)]
+	return LANG.Strings[string.lower(lang_name)] ~= nil
 end
 
 local function LanguageChanged(cv, old, new)

--- a/gamemodes/terrortown/gamemode/client/cl_lang.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_lang.lua
@@ -174,6 +174,12 @@ end
 function LANG.GetUnsafeNamed(lang_name)
 	lang_name = lang_name and string.lower(lang_name)
 
+	if not LANG.IsLanguage(lang_name) then
+		ErrorNoHalt(Format("Failed to get '%s': language does not exist.\n", tostring(lang_name)))
+
+		return
+	end
+
 	return LANG.Strings[lang_name]
 end
 
@@ -182,10 +188,10 @@ end
 -- @param string name string key identifier for the language
 -- @return nil|table
 -- @realm client
-function LANG.GetOrCreateLanguage(lang_name)
+function LANG.GetLanguageTable(lang_name)
 	lang_name = lang_name and string.lower(lang_name)
 
-	if not LANG.Strings[lang_name] then
+	if not LANG.IsLanguage(lang_name) then
 		LANG.CreateLanguage(lang_name)
 	end
 

--- a/gamemodes/terrortown/gamemode/client/cl_main.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_main.lua
@@ -88,6 +88,9 @@ function GM:Initialize()
 
 	GAMEMODE.round_state = ROUND_WAIT
 
+	-- load addon language files
+	LANG.SetupFiles("lang/")
+
 	LANG.Init()
 
 	self.BaseClass:Initialize()

--- a/gamemodes/terrortown/gamemode/client/cl_main.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_main.lua
@@ -89,7 +89,7 @@ function GM:Initialize()
 	GAMEMODE.round_state = ROUND_WAIT
 
 	-- load addon language files
-	LANG.SetupFiles("lang/")
+	LANG.SetupFiles("lang/", true)
 
 	LANG.Init()
 

--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -192,6 +192,9 @@ function GM:Initialize()
 
 	hook.Run("TTT2FinishedLoading")
 
+	-- load addon language files
+	LANG.SetupFiles("lang/")
+
 	ShopEditor.SetupShopEditorCVars()
 	ShopEditor.CreateShopDBs()
 

--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -193,7 +193,7 @@ function GM:Initialize()
 	hook.Run("TTT2FinishedLoading")
 
 	-- check for language files to mark them as downloadable for clients
-	LANG.SetupFiles("lang/")
+	LANG.SetupFiles("lang/", true)
 
 	ShopEditor.SetupShopEditorCVars()
 	ShopEditor.CreateShopDBs()

--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -192,7 +192,7 @@ function GM:Initialize()
 
 	hook.Run("TTT2FinishedLoading")
 
-	-- load addon language files
+	-- check for language files to mark them as downloadable for clients
 	LANG.SetupFiles("lang/")
 
 	ShopEditor.SetupShopEditorCVars()

--- a/gamemodes/terrortown/gamemode/shared/sh_lang.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_lang.lua
@@ -38,18 +38,24 @@ function LANG.SetupFiles(lang_path, deepsearch)
 	local file_paths = {}
 
 	if deepsearch then
-		local sub_folders = ({file.Find(lang_path .. "*", "LUA")})[2] or {}
+		local _, sub_folders = file.Find(lang_path .. "*", "LUA")
+
+		if not sub_folders then return end
 
 		for k = 1, #sub_folders do
 			local subname = sub_folders[k]
-			local files = ({file.Find(lang_path .. subname .. "/*.lua", "LUA")})[1] or {}
+			local files = file.Find(lang_path .. subname .. "/*.lua", "LUA")
+
+			if not files then return end
 
 			for i = 1, #files do
 				file_paths[#file_paths + 1] = lang_path .. subname .. "/" .. files[i]
 			end
 		end
 	else
-		local files = ({file.Find(lang_path .. "*.lua", "LUA")})[1] or {}
+		local files = file.Find(lang_path .. "*.lua", "LUA")
+
+		if not files then return end
 
 		for i = 1, #files do
 			file_paths[#file_paths + 1] = lang_path .. files[i]

--- a/gamemodes/terrortown/gamemode/shared/sh_lang.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_lang.lua
@@ -24,25 +24,52 @@ util.IncludeClientFile("terrortown/gamemode/client/cl_lang.lua")
 local net = net
 local table = table
 local pairs = pairs
+local file = file
+local string = string
 
-function LANG.SetupFiles(lang_path)
-	-- Add all lua files in our /lang/ dir
-	local files = file.Find(lang_path .. "*.lua", "LUA")
+---
+-- Sets up the language by scanning through the given directory; has to be run on both
+-- server and client!
+-- @param string lang_path The path to search in
+-- @param boolean deepsearch If true, subfolders are scanned
+-- @internal
+-- @realm shared
+function LANG.SetupFiles(lang_path, deepsearch)
+	local file_paths = {}
 
-	for _, fname in pairs(files) do
-		local path = lang_path .. fname
+	if deepsearch then
+		local sub_folders = ({file.Find(lang_path .. "*", "LUA")})[2] or {}
+
+		for k = 1, #sub_folders do
+			local subname = sub_folders[k]
+			local files = ({file.Find(lang_path .. subname .. "/*.lua", "LUA")})[1] or {}
+
+			for i = 1, #files do
+				file_paths[#file_paths + 1] = lang_path .. subname .. "/" .. files[i]
+			end
+		end
+	else
+		local files = ({file.Find(lang_path .. "*.lua", "LUA")})[1] or {}
+
+		for i = 1, #files do
+			file_paths[#file_paths + 1] = lang_path .. files[i]
+		end
+	end
+
+	for i = 1, #file_paths do
+		local path = file_paths[i]
 
 		-- filter out directories and temp files (like .lua~)
-		if string.Right(fname, 3) == "lua" then
+		if string.Right(path, 3) == "lua" then
 			util.IncludeClientFile(path)
 
-			MsgN("Included TTT language file: " .. fname)
+			MsgN("Included TTT language file: " .. path)
 		end
 	end
 end
 
 -- load default TTT2 language files or mark them as downloadable on the server
-LANG.SetupFiles((GM.FolderName or "terrortown") .. "/gamemode/shared/lang/")
+LANG.SetupFiles((GM.FolderName or "terrortown") .. "/gamemode/shared/lang/", false)
 
 if SERVER then
 	local count = table.Count

--- a/gamemodes/terrortown/gamemode/shared/sh_lang.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_lang.lua
@@ -25,20 +25,24 @@ local net = net
 local table = table
 local pairs = pairs
 
--- Add all lua files in our /lang/ dir
-local dir = GM.FolderName or "terrortown"
-local files = file.Find(dir .. "/gamemode/shared/lang/*.lua", "LUA")
+function LANG.SetupFiles(lang_path)
+	-- Add all lua files in our /lang/ dir
+	local files = file.Find(lang_path .. "*.lua", "LUA")
 
-for _, fname in pairs(files) do
-	local path = dir .. "/gamemode/shared/lang/" .. fname
+	for _, fname in pairs(files) do
+		local path = lang_path .. fname
 
-	-- filter out directories and temp files (like .lua~)
-	if string.Right(fname, 3) == "lua" then
-		util.IncludeClientFile(path)
+		-- filter out directories and temp files (like .lua~)
+		if string.Right(fname, 3) == "lua" then
+			util.IncludeClientFile(path)
 
-		MsgN("Included TTT language file: " .. fname)
+			MsgN("Included TTT language file: " .. fname)
+		end
 	end
 end
+
+-- load default TTT2 language files
+LANG.SetupFiles((GM.FolderName or "terrortown") .. "/gamemode/shared/lang/")
 
 if SERVER then
 	local count = table.Count

--- a/gamemodes/terrortown/gamemode/shared/sh_lang.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_lang.lua
@@ -41,7 +41,7 @@ function LANG.SetupFiles(lang_path)
 	end
 end
 
--- load default TTT2 language files
+-- load default TTT2 language files or mark them as downloadable on the server
 LANG.SetupFiles((GM.FolderName or "terrortown") .. "/gamemode/shared/lang/")
 
 if SERVER then

--- a/gamemodes/terrortown/gamemode/shared/sh_lang.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_lang.lua
@@ -46,7 +46,7 @@ function LANG.SetupFiles(lang_path, deepsearch)
 			local subname = sub_folders[k]
 			local files = file.Find(lang_path .. subname .. "/*.lua", "LUA")
 
-			if not files then return end
+			if not files then continue end
 
 			for i = 1, #files do
 				file_paths[#file_paths + 1] = lang_path .. subname .. "/" .. files[i]


### PR DESCRIPTION
In an attempt to clean up the chaotic language handling in TTT2 addons, I added language file support for addons. After this merge, addons can place their language files in `lua/lang/`.

Example for the jester:
![image](https://user-images.githubusercontent.com/13639408/74333318-fd1a9680-4d97-11ea-98cc-76f1b9df0424.png)

```lua
L = LANG.GetLanguageTable("english")

L[JESTER.name] = "Jester"
L[JESTER.defaultTeam] = "TEAM Jesters"
-- ...
```

The TTT2 language files stay untouched and are loaded on file load. However addon language files are loaded in the `GM:Initialialize` hook to make sure all files are ready and available. The files are included prior to `LANG.Init()`.

I also fixed the docs for `function LANG.GetUnsafeNamed(name)`