### PR TITLE
improved epop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
   - Removed the overcomplicated UI menu (simple handling with default keys instead)
   - The new default scanner behavior shows the direction and distance to the target
 - Changed TargetID colors for confirmed bodies
+- Reworked the event popup
+  - texts can now be blocking or non blocking
+  - there's now a popup queue
+  - popups are now also shown to dead players as well
 
 ### Fixed
 

--- a/gamemodes/terrortown/gamemode/client/cl_eventpopup.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_eventpopup.lua
@@ -9,7 +9,7 @@ local defaultMessage = {
 	title = {
 		text = "A Test Popup, now with a multiline title, how NICE."
 	},
-	text = {
+	subtitle = {
 		text = "Well, hello there! This is a fancy popup with some special information. The text can be also multiline, how fancy! Ugh, I could add so much more text if I'd had any ideas..."
 	},
 	iconTable = {},
@@ -99,7 +99,7 @@ end
 -- @return table The message table
 -- @realm client
 function EPOP:GetMessage()
-	return self.messageQueue[1] or defaultMessage
+	return self.messageQueue[1] or table.Copy(defaultMessage)
 end
 
 function EPOP:RemoveMessageByIndex(index)

--- a/gamemodes/terrortown/gamemode/client/cl_eventpopup.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_eventpopup.lua
@@ -72,7 +72,7 @@ function EPOP:ActivateMessage()
 
 	-- register a timer to remove the message
 	timer.Create(TIMER_IDENTIFIER, elem.displayTime, 1, function()
-		EPOP:RemoveMessageByIndex(1)
+		EPOP:RemoveMessage(elem.id)
 	end)
 
 	print("[TTT2] " .. elem.title.text .. " // " .. elem.subtitle.text or "")

--- a/gamemodes/terrortown/gamemode/client/cl_eventpopup.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_eventpopup.lua
@@ -100,11 +100,18 @@ end
 
 ---
 -- Returns the neweset message in the queue that should be rendered right now.
--- If there is no message in the queue, a template message is returned.
 -- @return table The message table
 -- @realm client
 function EPOP:GetMessage()
-	return self.messageQueue[1] or table.Copy(defaultMessage)
+	return self.messageQueue[1]
+end
+
+---
+-- Returns the default message.
+-- @return table The message table
+-- @realm client
+function EPOP:GetDefaultMessage()
+	return table.Copy(defaultMessage)
 end
 
 ---

--- a/gamemodes/terrortown/gamemode/client/cl_eventpopup.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_eventpopup.lua
@@ -32,7 +32,7 @@ EPOP.messageQueue = EPOP.messageQueue or {}
 -- @return string Returns a unique id generated for this message
 -- @realm client
 function EPOP:AddMessage(title, subtitle, displayTime, iconTable, blocking)
-	local id = "epop_unique_id_" .. tostring(counter)
+	local id = "epop_unique_id_" .. counter
 
 	counter = counter + 1
 

--- a/gamemodes/terrortown/gamemode/client/cl_eventpopup.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_eventpopup.lua
@@ -16,6 +16,8 @@ local defaultMessage = {
 	time = CurTime() + 5
 }
 
+local counter = 0
+
 EPOP = EPOP or {}
 
 EPOP.messageQueue = EPOP.messageQueue or {}
@@ -30,7 +32,9 @@ EPOP.messageQueue = EPOP.messageQueue or {}
 -- @return string Returns a unique id generated for this message
 -- @realm client
 function EPOP:AddMessage(title, subtitle, displayTime, iconTable, blocking)
-	local id = "epop_unique_id_" .. tostring(CurTime() * 10000)
+	local id = "epop_unique_id_" .. tostring(counter)
+
+	counter = counter + 1
 
 	local queueSize = #self.messageQueue
 

--- a/gamemodes/terrortown/gamemode/client/cl_eventpopup.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_eventpopup.lua
@@ -5,6 +5,17 @@
 
 local TIMER_IDENTIFIER = "epop_removal_timer"
 
+local defaultMessage = {
+	title = {
+		text = "A Test Popup, now with a multiline title, how NICE."
+	},
+	text = {
+		text = "Well, hello there! This is a fancy popup with some special information. The text can be also multiline, how fancy! Ugh, I could add so much more text if I'd had any ideas..."
+	},
+	iconTable = {},
+	time = CurTime() + 5
+}
+
 EPOP = EPOP or {}
 
 EPOP.messageQueue = EPOP.messageQueue or {}
@@ -57,6 +68,10 @@ function EPOP:AddMessage(title, subtitle, displayTime, iconTable, blocking)
 	return id
 end
 
+---
+-- Activates a new message by setting up all internal values
+-- @internal
+-- @realm client
 function EPOP:ActivateMessage()
 	if #self.messageQueue == 0 then return end
 
@@ -78,8 +93,13 @@ function EPOP:ShouldRender()
 	return #self.messageQueue > 0
 end
 
+---
+-- Returns the neweset message in the queue that should be rendered right now.
+-- If there is no message in the queue, a template message is returned.
+-- @return table The message table
+-- @realm client
 function EPOP:GetMessage()
-	return self.messageQueue[1]
+	return self.messageQueue[1] or defaultMessage
 end
 
 function EPOP:RemoveMessageByIndex(index)
@@ -123,6 +143,9 @@ function EPOP:RemoveMessage(id)
 	return false
 end
 
+---
+-- Clears the whole message queue
+-- @realm client
 function EPOP:Clear()
 	self.messageQueue = {}
 

--- a/gamemodes/terrortown/gamemode/client/cl_eventpopup.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_eventpopup.lua
@@ -22,10 +22,10 @@ EPOP.messageQueue = EPOP.messageQueue or {}
 
 ---
 -- Updates the message queue
--- @note Called every @{GM:Tick}
+-- @note Called every @{GM:Think}
 -- @realm client
 -- @internal
-function EPOP:Tick()
+function EPOP:Think()
 	if #self.messageQueue == 0 then return end
 
 	local elem = self.messageQueue[1]

--- a/gamemodes/terrortown/gamemode/client/cl_eventpopup.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_eventpopup.lua
@@ -3,8 +3,6 @@
 -- @author Mineotopia
 -- @desc An event popup system that works alongside the MSTACK system to display important messages
 
-local TIMER_IDENTIFIER = "epop_removal_timer"
-
 local defaultMessage = {
 	title = {
 		text = "A Test Popup, now with a multiline title, how NICE."
@@ -21,6 +19,21 @@ local counter = 0
 EPOP = EPOP or {}
 
 EPOP.messageQueue = EPOP.messageQueue or {}
+
+---
+-- Updates the message queue
+-- @note Called every @{GM:Tick}
+-- @realm client
+-- @internal
+function EPOP:Tick()
+	if #self.messageQueue == 0 then return end
+
+	local elem = self.messageQueue[1]
+
+	if CurTime() >= elem.time then
+		EPOP:RemoveMessage(elem.id)
+	end
+end
 
 ---
 -- Adds a popup message to the @{EPOP}
@@ -74,11 +87,6 @@ function EPOP:ActivateMessage()
 
 	elem.time = CurTime() + elem.displayTime
 
-	-- register a timer to remove the message
-	timer.Create(TIMER_IDENTIFIER, elem.displayTime, 1, function()
-		EPOP:RemoveMessage(elem.id)
-	end)
-
 	print("[TTT2] " .. elem.title.text .. " // " .. elem.subtitle.text or "")
 end
 
@@ -105,8 +113,6 @@ end
 -- @realm client
 function EPOP:RemoveMessageByIndex(index)
 	table.remove(self.messageQueue, index)
-
-	timer.Remove(TIMER_IDENTIFIER)
 
 	-- if the removed message was the first in the queue, the next one should be activated
 	if index == 1 then
@@ -149,6 +155,4 @@ end
 -- @realm client
 function EPOP:Clear()
 	self.messageQueue = {}
-
-	timer.Remove(TIMER_IDENTIFIER)
 end

--- a/gamemodes/terrortown/gamemode/client/cl_eventpopup.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_eventpopup.lua
@@ -34,17 +34,8 @@ function EPOP:AddMessage(title, subtitle, displayTime, iconTable, blocking)
 
 	local queueSize = #self.messageQueue
 
-	print(queueSize > 0)
-	if self.messageQueue[queueSize] then
-		print(self.messageQueue[queueSize].blocking)
-	else
-		print("no previous entry")
-	end
-
 	-- delete previous message if it is nonblocking
 	if queueSize > 0 and not self.messageQueue[queueSize].blocking then
-		print("removing blocking message")
-
 		table.remove(self.messageQueue, queueSize)
 
 		queueSize = queueSize - 1
@@ -83,6 +74,8 @@ function EPOP:ActivateMessage()
 	timer.Create(TIMER_IDENTIFIER, elem.displayTime, 1, function()
 		EPOP:RemoveMessageByIndex(1)
 	end)
+
+	print("[TTT2] " .. elem.title.text .. " // " .. elem.subtitle.text or "")
 end
 
 ---
@@ -102,6 +95,10 @@ function EPOP:GetMessage()
 	return self.messageQueue[1] or table.Copy(defaultMessage)
 end
 
+---
+-- Removes a message from the stack by a numeric index
+-- @param number index The nimeric index
+-- @realm client
 function EPOP:RemoveMessageByIndex(index)
 	table.remove(self.messageQueue, index)
 

--- a/gamemodes/terrortown/gamemode/client/cl_main.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_main.lua
@@ -311,8 +311,29 @@ local function PlaySoundCue()
 	surface.PlaySound(cues[math.random(#cues)])
 end
 
-GM.TTTBeginRound = PlaySoundCue
-GM.TTTEndRound = PlaySoundCue
+---
+-- A hook that is called when the preparation phase starts
+-- @hook
+-- @realm client
+function GM:TTTPrepareRound()
+	EPOP:Clear()
+end
+
+---
+-- A hook that is called when the round begins
+-- @hook
+-- @realm client
+function GM:TTTBeginRound()
+	PlaySoundCue()
+end
+
+---
+-- A hook that is called when the round ends
+-- @hook
+-- @realm client
+function GM:TTTEndRound()
+	PlaySoundCue()
+end
 
 -- usermessages
 

--- a/gamemodes/terrortown/gamemode/client/cl_main.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_main.lua
@@ -223,6 +223,20 @@ function GM:HUDClear()
 	TBHUD:Clear()
 end
 
+-- optional sound cues on round start and end
+local ttt_cl_soundcues = CreateConVar("ttt_cl_soundcues", "0", FCVAR_ARCHIVE)
+
+local cues = {
+	Sound("ttt/thump01e.mp3"),
+	Sound("ttt/thump02e.mp3")
+}
+
+local function PlaySoundCue()
+	if not ttt_cl_soundcues:GetBool() then return end
+
+	surface.PlaySound(cues[math.random(#cues)])
+end
+
 ---
 -- Returns the current round state
 -- @return boolean
@@ -238,6 +252,8 @@ local function RoundStateChange(o, n)
 		-- prep starts
 		GAMEMODE:ClearClientState()
 		GAMEMODE:CleanUpMap()
+
+		EPOP:Clear()
 
 		-- show warning to spec mode players
 		if GetConVar("ttt_spectator_mode"):GetBool() and IsValid(LocalPlayer()) then
@@ -264,8 +280,12 @@ local function RoundStateChange(o, n)
 		util.ClearDecals()
 
 		GAMEMODE.StartingPlayers = #util.GetAlivePlayers()
+
+		PlaySoundCue()
 	elseif n == ROUND_POST then
 		RunConsoleCommand("ttt_cl_traitorpopup_close")
+
+		PlaySoundCue()
 	end
 
 	-- stricter checks when we're talking about hooks, because this function may
@@ -297,42 +317,28 @@ local function ttt_print_playercount()
 end
 concommand.Add("ttt_print_playercount", ttt_print_playercount)
 
--- optional sound cues on round start and end
-local ttt_cl_soundcues = CreateConVar("ttt_cl_soundcues", "0", FCVAR_ARCHIVE)
-
-local cues = {
-	Sound("ttt/thump01e.mp3"),
-	Sound("ttt/thump02e.mp3")
-}
-
-local function PlaySoundCue()
-	if not ttt_cl_soundcues:GetBool() then return end
-
-	surface.PlaySound(cues[math.random(#cues)])
-end
-
 ---
--- A hook that is called when the preparation phase starts
+-- A hook that is called when the preparation phase starts.
 -- @hook
 -- @realm client
 function GM:TTTPrepareRound()
-	EPOP:Clear()
+
 end
 
 ---
--- A hook that is called when the round begins
+-- A hook that is called when the round begins.
 -- @hook
 -- @realm client
 function GM:TTTBeginRound()
-	PlaySoundCue()
+
 end
 
 ---
--- A hook that is called when the round ends
+-- A hook that is called when the round ends.
 -- @hook
 -- @realm client
 function GM:TTTEndRound()
-	PlaySoundCue()
+
 end
 
 -- usermessages

--- a/gamemodes/terrortown/gamemode/client/cl_main.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_main.lua
@@ -80,6 +80,20 @@ ttt_include("cl_weapon_pickup")
 -- all files are loaded
 local TryT = LANG.TryTranslation
 
+-- optional sound cues on round start and end
+local ttt_cl_soundcues = CreateConVar("ttt_cl_soundcues", "0", FCVAR_ARCHIVE)
+
+local cues = {
+	Sound("ttt/thump01e.mp3"),
+	Sound("ttt/thump02e.mp3")
+}
+
+local function PlaySoundCue()
+	if not ttt_cl_soundcues:GetBool() then return end
+
+	surface.PlaySound(cues[math.random(#cues)])
+end
+
 ---
 -- Called after the gamemode loads and starts.
 -- @hook
@@ -221,20 +235,6 @@ end
 function GM:HUDClear()
 	RADAR:Clear()
 	TBHUD:Clear()
-end
-
--- optional sound cues on round start and end
-local ttt_cl_soundcues = CreateConVar("ttt_cl_soundcues", "0", FCVAR_ARCHIVE)
-
-local cues = {
-	Sound("ttt/thump01e.mp3"),
-	Sound("ttt/thump02e.mp3")
-}
-
-local function PlaySoundCue()
-	if not ttt_cl_soundcues:GetBool() then return end
-
-	surface.PlaySound(cues[math.random(#cues)])
 end
 
 ---

--- a/gamemodes/terrortown/gamemode/shared/hud_elements/ttteventpopup/pure_skin_eventpopup.lua
+++ b/gamemodes/terrortown/gamemode/shared/hud_elements/ttteventpopup/pure_skin_eventpopup.lua
@@ -117,20 +117,6 @@ if CLIENT then
 		local size = self:GetSize()
 		local msg = EPOP:GetMessage()
 
-		-- fallback for hud-editor
-		if not msg then
-			msg = {
-				title = {
-					text = "A Test Popup, now with a multiline title, how NICE."
-				},
-				text = {
-					text = "Well, hello there! This is a fancy popup with some special information. The text can be also multiline, how fancy! Ugh, I could add so much more text if I'd had any ideas..."
-				},
-				iconTable = {},
-				time = CurTime() + 5
-			}
-		end
-
 		-- prepare item, caches the data of the element to improve performance
 		if not msg.ready then
 			self:PrepareItem(msg)

--- a/gamemodes/terrortown/gamemode/shared/hud_elements/ttteventpopup/pure_skin_eventpopup.lua
+++ b/gamemodes/terrortown/gamemode/shared/hud_elements/ttteventpopup/pure_skin_eventpopup.lua
@@ -115,7 +115,7 @@ if CLIENT then
 
 	function HUDELEMENT:Draw()
 		local size = self:GetSize()
-		local msg = EPOP:GetMessage()
+		local msg = HUDEditor.IsEditing and EPOP:GetDefaultMessage() or EPOP:GetMessage()
 
 		-- prepare item, caches the data of the element to improve performance
 		if not msg.ready then

--- a/gamemodes/terrortown/gamemode/shared/hud_elements/ttteventpopup/pure_skin_eventpopup.lua
+++ b/gamemodes/terrortown/gamemode/shared/hud_elements/ttteventpopup/pure_skin_eventpopup.lua
@@ -40,9 +40,7 @@ if CLIENT then
 	end
 
 	function HUDELEMENT:ShouldDraw()
-		local client = LocalPlayer()
-
-		return HUDEditor.IsEditing or client:Alive() and EPOP:ShouldRender()
+		return HUDEditor.IsEditing or EPOP:ShouldRender()
 	end
 
 	function HUDELEMENT:PerformLayout()
@@ -67,10 +65,10 @@ if CLIENT then
 		local pad2 = 2 * self.pad
 
 		-- wrap title if needed
-		item.title_wrapped, width_title, height_title = draw.GetWrappedText(item.title.text, size.w - pad2, titlefont, self.scale)
+		item.wrappedTitle, width_title, height_title = draw.GetWrappedText(item.title.text, size.w - pad2, titlefont, self.scale)
 
 		-- wrap text if needed
-		item.text_wrapped, width_text, height_text = draw.GetWrappedText(item.text.text, size.w - pad2, textfont, self.scale)
+		item.wrappedSubtitle, width_text, height_text = draw.GetWrappedText(item.subtitle.text, size.w - pad2, textfont, self.scale)
 
 		item.size = {}
 		item.size.w = ((width_title > width_text) and width_title or width_text) + pad2
@@ -81,8 +79,8 @@ if CLIENT then
 		item.pos.x = pos.x + math.Round(0.5 * (size.w - item.size.w))
 		item.pos.center_x = pos.x + math.Round(0.5 * size.w)
 
-		local wrappedItems = #item.title_wrapped
-		local wrappedTexts = #item.text_wrapped
+		local wrappedItems = #item.wrappedTitle
+		local wrappedTexts = #item.wrappedSubtitle
 
 		-- precalculate text positions
 		local height_title_line = height_title / wrappedItems
@@ -101,7 +99,7 @@ if CLIENT then
 		end
 
 		-- add item positions
-		local icon_amt = #item.icon_tbl
+		local icon_amt = #item.iconTable
 		local icon_start_x = item.pos.center_x - math.Round(0.5 * (icon_amt * self.icon_size + math.max(0, icon_amt - 1) * self.pad))
 
 		item.pos.icon_y = item.pos.y + item.size.h + self.pad
@@ -117,7 +115,7 @@ if CLIENT then
 
 	function HUDELEMENT:Draw()
 		local size = self:GetSize()
-		local msg = EPOP.msg
+		local msg = EPOP:GetMessage()
 
 		-- fallback for hud-editor
 		if not msg then
@@ -128,7 +126,7 @@ if CLIENT then
 				text = {
 					text = "Well, hello there! This is a fancy popup with some special information. The text can be also multiline, how fancy! Ugh, I could add so much more text if I'd had any ideas..."
 				},
-				icon_tbl = {},
+				iconTable = {},
 				time = CurTime() + 5
 			}
 		end
@@ -143,23 +141,23 @@ if CLIENT then
 		local timediff = HUDEditor.IsEditing and 5 or (msg.time - CurTime())
 		local opacity = (timediff > fadetime) and 255 or math.Round(255 * timediff / fadetime)
 
-		local ctmp_title = msg.title.color or COLOR_WHITE
-		local ctmp_text = msg.text.color or COLOR_WHITE
+		local colorTitle = msg.title.color or COLOR_WHITE
+		local colorSubtitle = msg.subtitle.color or COLOR_WHITE
 
 		-- draw content
-		local wrappedTitles = msg.title_wrapped
+		local wrappedTitles = msg.wrappedTitle
 
 		for i = 1, #wrappedTitles do
-			draw.AdvancedText(wrappedTitles[i], titlefont, msg.pos.center_x, msg.pos.title_y[i], Color(ctmp_title.r, ctmp_title.g, ctmp_title.b, opacity), TEXT_ALIGN_CENTER, TEXT_ALIGN_TOP, true, self.scale)
+			draw.AdvancedText(wrappedTitles[i], titlefont, msg.pos.center_x, msg.pos.title_y[i], Color(colorTitle.r, colorTitle.g, colorTitle.b, opacity), TEXT_ALIGN_CENTER, TEXT_ALIGN_TOP, true, self.scale)
 		end
 
-		local wrappedTexts = msg.text_wrapped
+		local wrappedTexts = msg.wrappedSubtitle
 
 		for i = 1, #wrappedTexts do
-			draw.AdvancedText(wrappedTexts[i], textfont, msg.pos.center_x, msg.pos.text_y[i], Color(ctmp_text.r, ctmp_text.g, ctmp_text.b, opacity), TEXT_ALIGN_CENTER, TEXT_ALIGN_TOP, true, self.scale)
+			draw.AdvancedText(wrappedTexts[i], textfont, msg.pos.center_x, msg.pos.text_y[i], Color(colorSubtitle.r, colorSubtitle.g, colorSubtitle.b, opacity), TEXT_ALIGN_CENTER, TEXT_ALIGN_TOP, true, self.scale)
 		end
 
-		local wrappedIcons = msg.icon_tbl
+		local wrappedIcons = msg.iconTable
 
 		for i = 1, #wrappedIcons do
 			draw.FilteredTexture(msg.pos.icon_x[i], msg.pos.icon_y, self.icon_size, self.icon_size, wrappedIcons[i], opacity)

--- a/gamemodes/terrortown/gamemode/shared/sh_main.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_main.lua
@@ -228,5 +228,6 @@ function GM:Tick()
 		end
 
 		VOICE.Tick()
+		EPOP:Tick()
 	end
 end

--- a/gamemodes/terrortown/gamemode/shared/sh_main.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_main.lua
@@ -143,6 +143,10 @@ end
 -- @realm shared
 function GM:Think()
 	UpdateSprint()
+
+	if CLIENT then
+		EPOP:Think()
+	end
 end
 
 -- Drowning and such
@@ -228,6 +232,5 @@ function GM:Tick()
 		end
 
 		VOICE.Tick()
-		EPOP:Tick()
 	end
 end


### PR DESCRIPTION
improved the EPOP based on stuff learned while using it

- EPOPs are now always redered, even when dead since they are really good to inform players about upcoming respawns
- even if the system was originally designed to display always only one element, a queue was added since otherwise multiple addons trying to display text might clash
- messages now have a `blocking` flag, if set to false a new message can overwrite the message without waiting in a queue
- also I added a few convenience functions
- improved docs and coding style improvements