### PR TITLE
Radar Rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 - Added a new ConVar to allow armor to also block headshots (`ttt_item_armor_block_headshots`, default value: 0). Thanks @TheNickSkater
 - Added essential items: 8 different types of items that are often used in other addons. You can remove them from the shop if you don't like them.
-- Added a convenience function for the creation of radar points: `RADAR.CreateNewTarget(ply, pos, ent, color)`
+- Added a convenience function for the creation of radar points: `RADAR.CreateTargetTable(ply, pos, ent, color)`
 - Added the possibility to change the radar time by either setting `ROLE.radarTime` or calling `RADAR.SetRadarTime(ply, time)`
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 - Added a new ConVar to allow armor to also block headshots (`ttt_item_armor_block_headshots`, default value: 0). Thanks @TheNickSkater
 - Added essential items: 8 different types of items that are often used in other addons. You can remove them from the shop if you don't like them.
+- Added a convenience function for the creation of radar points: `RADAR.CreateNewTarget(ply, pos, ent, color)`
+- Added the possibility to change the radar time by either setting `ROLE.radarTime` or calling `RADAR.SetRadarTime(ply, time)`
 
 ### Changed
 
@@ -21,6 +23,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
   - Removed the overcomplicated UI menu (simple handling with default keys instead)
   - The new default scanner behavior shows the direction and distance to the target
 - Changed TargetID colors for confirmed bodies
+- Moved radar handling from client to server
 
 ### Fixed
 
@@ -30,6 +33,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed propsurfing with the magneto stick
 - Fixed healthstation TargetID text
 - Fixed keyinfo for doors where no key can be used
+- Fixed roles having sometimes the wrong radar color
 
 ## [v0.6.4b](https://github.com/TTT-2/TTT2/tree/v0.6.4b) (2020-04-03)
 

--- a/lua/terrortown/entities/items/item_ttt_radar/cl_init.lua
+++ b/lua/terrortown/entities/items/item_ttt_radar/cl_init.lua
@@ -211,7 +211,7 @@ function RADAR:Draw(client)
 			if tgt.color then
 				surface.SetDrawColor(tgt.color.r, tgt.color.g, tgt.color.b, alpha)
 				surface.SetTextColor(tgt.color.r, tgt.color.g, tgt.color.b, alpha)
-			elseif c then
+			elseif tgt.hasSubrole and c then
 				surface.SetDrawColor(c.r, c.g, c.b, alpha)
 				surface.SetTextColor(c.r, c.g, c.b, alpha)
 			else
@@ -262,14 +262,19 @@ local function ReceiveRadarScan()
 			net.ReadInt(32)
 		)
 
-		local subrole = net.ReadInt(2 * ROLE_BITS)
+		local hasSubrole = net.ReadBool()
+		local subrole
+
+		if hasSubrole then
+			subrole = net.ReadUInt(ROLE_BITS)
+		end
 
 		local color
 		if net.ReadBool() then
 			color = net.ReadColor()
 		end
 
-		RADAR.targets[#RADAR.targets + 1] = {pos = pos, subrole = subrole, color = color}
+		RADAR.targets[#RADAR.targets + 1] = {pos = pos, subrole = subrole, hasSubrole = hasSubrole, color = color}
 	end
 
 	RADAR.enable = true

--- a/lua/terrortown/entities/items/item_ttt_radar/cl_init.lua
+++ b/lua/terrortown/entities/items/item_ttt_radar/cl_init.lua
@@ -9,7 +9,6 @@ local GetPTranslation
 local table = table
 local net = net
 local pairs = pairs
-local timer = timer
 local IsValid = IsValid
 
 local indicator = surface.GetTextureID("effects/select_ring")
@@ -18,11 +17,10 @@ local sample_scan = surface.GetTextureID("vgui/ttt/sample_scan")
 local det_beacon = surface.GetTextureID("vgui/ttt/det_beacon")
 local near_cursor_dist = 180
 
-RADAR = {}
+RADAR = RADAR or {}
 RADAR.targets = {}
 RADAR.enable = false
-RADAR.duration = 30
-RADAR.endtime = 0
+RADAR.startTime = 0
 RADAR.bombs = {}
 RADAR.bombs_count = 0
 RADAR.repeating = true
@@ -36,7 +34,7 @@ RADAR.called_corpses = {}
 -- @realm client
 function RADAR:EndScan()
 	self.enable = false
-	self.endtime = CurTime()
+	self.startTime = 0
 end
 
 ---
@@ -50,20 +48,6 @@ function RADAR:Clear()
 	self.samples = {}
 	self.bombs_count = 0
 	self.samples_count = 0
-end
-
----
--- Updates the radar OR disables it
--- @internal
--- @realm client
-function RADAR:Timeout()
-	self:EndScan()
-
-	local client = LocalPlayer()
-
-	if not self.repeating or not IsValid(client) or not client:HasEquipmentItem("item_ttt_radar") then return end
-
-	RunConsoleCommand("ttt_radar_scan")
 end
 
 ---
@@ -106,7 +90,7 @@ end
 -- @internal
 -- @realm client
 function ITEM:DrawInfo()
-	return tostring(math.Round(math.max(0, RADAR.endtime - CurTime())))
+	return math.ceil(math.max(0, LocalPlayer():TTT2NETGetUInt("radar_time", 30) - (CurTime() - RADAR.startTime)))
 end
 
 local function DrawTarget(tgt, size, offset, no_shrink)
@@ -199,15 +183,17 @@ function RADAR:Draw(client)
 
 	surface.SetTexture(indicator)
 
-	local remaining = math.max(0, RADAR.endtime - CurTime())
-	local alpha_base = 50 + 180 * (remaining / RADAR.duration)
+	local radarTime = client:TTT2NETGetUInt("radar_time", 30)
+	local remaining = math.max(0, radarTime - (CurTime() - RADAR.startTime))
+	local alpha_base = 50 + 180 * (remaining / radarTime)
 	local mpos = Vector(ScrW() * 0.5, ScrH() * 0.5, 0)
 
 	local subrole, alpha, scrpos, md
 
-	for _, tgt in pairs(RADAR.targets) do
-		alpha = alpha_base
+	for i = 1, #RADAR.targets do
+		local tgt = RADAR.targets[i]
 
+		alpha = alpha_base
 		scrpos = tgt.pos:ToScreen()
 
 		if scrpos.visible then
@@ -220,20 +206,14 @@ function RADAR:Draw(client)
 			subrole = tgt.subrole or ROLE_INNOCENT
 
 			local roleData = roles.GetByIndex(subrole)
-			local c = roleData.radarColor
+			local c = roleData.radarColor or TEAMS[roleData.defaultTeam].color
 
-			if c then
+			if tgt.color then
+				surface.SetDrawColor(tgt.color.r, tgt.color.g, tgt.color.b, alpha)
+				surface.SetTextColor(tgt.color.r, tgt.color.g, tgt.color.b, alpha)
+			elseif c then
 				surface.SetDrawColor(c.r, c.g, c.b, alpha)
 				surface.SetTextColor(c.r, c.g, c.b, alpha)
-			elseif subrole == ROLE_DETECTIVE or roleData.baserole == ROLE_DETECTIVE then
-				surface.SetDrawColor(0, 0, 255, alpha)
-				surface.SetTextColor(0, 0, 255, alpha)
-			elseif subrole == ROLE_INNOCENT or roleData.baserole == ROLE_INNOCENT then
-				surface.SetDrawColor(0, 255, 0, alpha)
-				surface.SetTextColor(0, 255, 0, alpha)
-			elseif subrole == ROLE_TRAITOR or roleData.baserole == ROLE_TRAITOR then
-				surface.SetDrawColor(255, 0, 0, alpha)
-				surface.SetTextColor(255, 0, 0, alpha)
 			else
 				surface.SetDrawColor(150, 150, 150, alpha)
 				surface.SetTextColor(150, 150, 150, alpha)
@@ -271,29 +251,29 @@ end
 net.Receive("TTT_CorpseCall", TTT_CorpseCall)
 
 local function ReceiveRadarScan()
-	local num_targets = net.ReadUInt(8)
+	local num_targets = net.ReadUInt(16)
 
 	RADAR.targets = {}
 
 	for i = 1, num_targets do
-		local sr = net.ReadUInt(ROLE_BITS)
+		local pos = Vector(
+			net.ReadInt(32),
+			net.ReadInt(32),
+			net.ReadInt(32)
+		)
 
-		local pos = Vector()
-		pos.x = net.ReadInt(32)
-		pos.y = net.ReadInt(32)
-		pos.z = net.ReadInt(32)
+		local subrole = net.ReadInt(2 * ROLE_BITS)
 
-		RADAR.targets[#RADAR.targets + 1] = {subrole = sr, pos = pos}
+		local color
+		if net.ReadBool() then
+			color = net.ReadColor()
+		end
+
+		RADAR.targets[#RADAR.targets + 1] = {pos = pos, subrole = subrole, color = color}
 	end
 
 	RADAR.enable = true
-	RADAR.endtime = CurTime() + RADAR.duration
-
-	timer.Create("radartimeout", RADAR.duration + 1, 1, function()
-		if not RADAR then return end
-
-		RADAR:Timeout()
-	end)
+	RADAR.startTime = CurTime()
 end
 net.Receive("TTT_Radar", ReceiveRadarScan)
 
@@ -325,8 +305,6 @@ function RADAR.CreateMenu(parent, frame)
 	dscan:SetText(GetTranslation("radar_scan"))
 
 	dscan.DoClick = function(s)
-		s:SetDisabled(true)
-
 		RunConsoleCommand("ttt_radar_scan")
 
 		frame:Close()
@@ -335,7 +313,7 @@ function RADAR.CreateMenu(parent, frame)
 	dform:AddItem(dscan)
 
 	local dlabel = vgui.Create("DLabel", dform)
-	dlabel:SetText(GetPTranslation("radar_help", {num = RADAR.duration}))
+	dlabel:SetText(GetPTranslation("radar_help", {num = LocalPlayer():TTT2NETGetUInt("radar_time", 30)}))
 	dlabel:SetWrap(true)
 	dlabel:SetTall(50)
 
@@ -347,13 +325,17 @@ function RADAR.CreateMenu(parent, frame)
 	dcheck:SetValue(RADAR.repeating)
 
 	dcheck.OnChange = function(s, val)
+		net.Start("TTT2RadarUpdateAutoScan")
+		net.WriteBool(val)
+		net.SendToServer()
+
 		RADAR.repeating = val
 	end
 
 	dform:AddItem(dcheck)
 
 	dform.Think = function(s)
-		if RADAR.enable or not owned then
+		if RADAR.repeating or not owned then
 			dscan:SetDisabled(true)
 		else
 			dscan:SetDisabled(false)

--- a/lua/terrortown/entities/items/item_ttt_radar/cl_init.lua
+++ b/lua/terrortown/entities/items/item_ttt_radar/cl_init.lua
@@ -90,7 +90,7 @@ end
 -- @internal
 -- @realm client
 function ITEM:DrawInfo()
-	return math.ceil(math.max(0, LocalPlayer():TTT2NETGetUInt("radar_time", 30) - (CurTime() - RADAR.startTime)))
+	return math.ceil(math.max(0, (LocalPlayer().radarTime or 30) - (CurTime() - RADAR.startTime)))
 end
 
 local function DrawTarget(tgt, size, offset, no_shrink)
@@ -183,7 +183,7 @@ function RADAR:Draw(client)
 
 	surface.SetTexture(indicator)
 
-	local radarTime = client:TTT2NETGetUInt("radar_time", 30)
+	local radarTime = client.radarTime or 30
 	local remaining = math.max(0, radarTime - (CurTime() - RADAR.startTime))
 	local alpha_base = 50 + 180 * (remaining / radarTime)
 	local mpos = Vector(ScrW() * 0.5, ScrH() * 0.5, 0)
@@ -282,6 +282,11 @@ local function ReceiveRadarScan()
 end
 net.Receive("TTT_Radar", ReceiveRadarScan)
 
+local function ReceiveRadarTime()
+	LocalPlayer().radarTime = net.ReadUInt(8)
+end
+net.Receive("TTT2RadarUpdateTime", ReceiveRadarTime)
+
 ---
 -- Creates the settings menu
 -- @internal
@@ -318,7 +323,7 @@ function RADAR.CreateMenu(parent, frame)
 	dform:AddItem(dscan)
 
 	local dlabel = vgui.Create("DLabel", dform)
-	dlabel:SetText(GetPTranslation("radar_help", {num = LocalPlayer():TTT2NETGetUInt("radar_time", 30)}))
+	dlabel:SetText(GetPTranslation("radar_help", {num = LocalPlayer().radarTime or 30}))
 	dlabel:SetWrap(true)
 	dlabel:SetTall(50)
 

--- a/lua/terrortown/entities/items/item_ttt_radar/init.lua
+++ b/lua/terrortown/entities/items/item_ttt_radar/init.lua
@@ -145,9 +145,9 @@ end
 
 local function SetupRadarScan(ply)
 	timer.Create("radarTimeout_" .. ply:SteamID64(), ply.radarTime, 1, function()
-		if not IsValid(ply) or not ply:HasEquipmentItem("item_ttt_radar") then return end
-
-		if ply.radarDoesNotRepeat then return end
+		if not IsValid(ply) or not ply:HasEquipmentItem("item_ttt_radar")
+			or ply.radarDoesNotRepeat
+		then return end
 
 		TriggerRadarScan(ply)
 		SetupRadarScan(ply)

--- a/lua/terrortown/entities/items/item_ttt_radar/init.lua
+++ b/lua/terrortown/entities/items/item_ttt_radar/init.lua
@@ -71,7 +71,12 @@ local function TriggerRadarScan(ply)
 		net.WriteInt(tgt.pos.y, 32)
 		net.WriteInt(tgt.pos.z, 32)
 
-		net.WriteInt(tgt.subrole, 2 * ROLE_BITS)
+		if tgt.subrole == -1 then
+			net.WriteBool(false)
+		else
+			net.WriteBool(true)
+			net.WriteUInt(tgt.subrole, ROLE_BITS)
+		end
 
 		if tgt.color then
 			net.WriteBool(true)

--- a/lua/terrortown/entities/items/item_ttt_radar/shared.lua
+++ b/lua/terrortown/entities/items/item_ttt_radar/shared.lua
@@ -12,6 +12,16 @@ ITEM.material = "vgui/ttt/icon_radar"
 ITEM.CanBuy = {ROLE_TRAITOR, ROLE_DETECTIVE}
 ITEM.oldId = EQUIP_RADAR or 2
 
+function ITEM:Equip(buyer)
+	if SERVER then
+		RADAR.Init(buyer)
+	end
+end
+
 function ITEM:Reset(buyer)
+	if SERVER then
+		RADAR.Deinit(buyer)
+	end
+
 	buyer.radar_charge = 0
 end


### PR DESCRIPTION
This is a farily small radar rework. These things were changed:

- removed old TTT code
- fixed a rare bug where the radar color had the wrong color
- moved the important radar stuff from client to server (like seriously, why was this on the client in the first place?!)
- added the possibility to give radar points a custom color
- added a convenience function for the creation of radar points: `RADAR.CreateNewTarget(ply, pos, ent, color)`
- added the possibility to change the radar time by either setting `ROLE.radarTime` or calling `RADAR.SetRadarTime(ply, time)`