### PR TITLE
TTT2NET: Fix naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Remove GetWeapons and HasWeapon overrides (see https://github.com/Facepunch/garrysmod/pull/1648)
 - Improved role module to also use `isAbstract` instead of a base role class name
 - Migrated the HUDManager settings to the new network sync system
-- The TTT2NET library can now also synchronize small to medium sized tables (adds the metadata type "table")
+- Renamed `TTT2NET` to `ttt2net` and removed unnecessary self references
+- The `ttt2net` library can now also synchronize small to medium sized tables (adds the metadata type "table")
 - Reworked the old DNA Scanner 
   - New world- and viewmodel with an interactive screen
   - Removed the overcomplicated UI menu (simple handling with default keys instead)

--- a/gamemodes/terrortown/gamemode/client/cl_help.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_help.lua
@@ -638,7 +638,7 @@ function HELPSCRN:CreateAdministrationForm(parent)
 	defaultHUDlabel:Dock(TOP)
 
 	local defaultHUDCb = vgui.Create("DComboBox", parent)
-	defaultHUDCb:SetValue(TTT2NET.GetGlobal({"hud_manager", "defaultHUD"}) or "None")
+	defaultHUDCb:SetValue(ttt2net.GetGlobal({"hud_manager", "defaultHUD"}) or "None")
 
 	defaultHUDCb.OnSelect = function(_, _, value)
 		net.Start("TTT2DefaultHUDRequest")
@@ -657,7 +657,7 @@ function HELPSCRN:CreateAdministrationForm(parent)
 	forceHUDlabel:Dock(TOP)
 
 	local forceHUDCb = vgui.Create("DComboBox", parent)
-	forceHUDCb:SetValue(TTT2NET.GetGlobal({"hud_manager", "forcedHUD"}) or "None")
+	forceHUDCb:SetValue(ttt2net.GetGlobal({"hud_manager", "forcedHUD"}) or "None")
 
 	forceHUDCb.OnSelect = function(_, _, value)
 		net.Start("TTT2ForceHUDRequest")
@@ -683,7 +683,7 @@ function HELPSCRN:CreateAdministrationForm(parent)
 	admin_dlv_rhuds:AddColumn("HUD")
 	admin_dlv_rhuds:AddColumn("Restricted")
 
-	local restrictedHUDs = TTT2NET.GetGlobal({"hud_manager", "restrictedHUDs"})
+	local restrictedHUDs = ttt2net.GetGlobal({"hud_manager", "restrictedHUDs"})
 	local allHUDs = huds.GetList()
 
 	for _, v in ipairs(allHUDs) do
@@ -700,7 +700,7 @@ function HELPSCRN:CreateAdministrationForm(parent)
 	end
 end
 
-TTT2NET.OnUpdateGlobal({"hud_manager", "restrictedHUDs"}, function(_, value)
+ttt2net.OnUpdateGlobal({"hud_manager", "restrictedHUDs"}, function(_, value)
 	if not admin_dlv_rhuds or not IsValid(admin_dlv_rhuds) then return end
 
 	admin_dlv_rhuds:Clear()

--- a/gamemodes/terrortown/gamemode/client/cl_help.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_help.lua
@@ -638,7 +638,7 @@ function HELPSCRN:CreateAdministrationForm(parent)
 	defaultHUDlabel:Dock(TOP)
 
 	local defaultHUDCb = vgui.Create("DComboBox", parent)
-	defaultHUDCb:SetValue(TTT2NET:GetGlobal({"hud_manager", "defaultHUD"}) or "None")
+	defaultHUDCb:SetValue(TTT2NET.GetGlobal({"hud_manager", "defaultHUD"}) or "None")
 
 	defaultHUDCb.OnSelect = function(_, _, value)
 		net.Start("TTT2DefaultHUDRequest")
@@ -657,7 +657,7 @@ function HELPSCRN:CreateAdministrationForm(parent)
 	forceHUDlabel:Dock(TOP)
 
 	local forceHUDCb = vgui.Create("DComboBox", parent)
-	forceHUDCb:SetValue(TTT2NET:GetGlobal({"hud_manager", "forcedHUD"}) or "None")
+	forceHUDCb:SetValue(TTT2NET.GetGlobal({"hud_manager", "forcedHUD"}) or "None")
 
 	forceHUDCb.OnSelect = function(_, _, value)
 		net.Start("TTT2ForceHUDRequest")
@@ -683,7 +683,7 @@ function HELPSCRN:CreateAdministrationForm(parent)
 	admin_dlv_rhuds:AddColumn("HUD")
 	admin_dlv_rhuds:AddColumn("Restricted")
 
-	local restrictedHUDs = TTT2NET:GetGlobal({"hud_manager", "restrictedHUDs"})
+	local restrictedHUDs = TTT2NET.GetGlobal({"hud_manager", "restrictedHUDs"})
 	local allHUDs = huds.GetList()
 
 	for _, v in ipairs(allHUDs) do
@@ -700,7 +700,7 @@ function HELPSCRN:CreateAdministrationForm(parent)
 	end
 end
 
-TTT2NET:OnUpdateGlobal({"hud_manager", "restrictedHUDs"}, function(_, value)
+TTT2NET.OnUpdateGlobal({"hud_manager", "restrictedHUDs"}, function(_, value)
 	if not admin_dlv_rhuds or not IsValid(admin_dlv_rhuds) then return end
 
 	admin_dlv_rhuds:Clear()

--- a/gamemodes/terrortown/gamemode/client/cl_hud_manager.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_hud_manager.lua
@@ -3,7 +3,7 @@
 
 ttt_include("vgui__cl_hudswitcher")
 
-local current_hud_cvar = CreateClientConVar("ttt2_current_hud", TTT2NET:GetGlobal({"hud_manager", "defaultHUD"}) or "pure_skin", true, true)
+local current_hud_cvar = CreateClientConVar("ttt2_current_hud", TTT2NET.GetGlobal({"hud_manager", "defaultHUD"}) or "pure_skin", true, true)
 local current_hud_table = nil
 
 HUDManager = {}
@@ -173,7 +173,7 @@ function HUDManager.GetHUD()
 	local hudvar = current_hud_cvar:GetString()
 
 	if not huds.GetStored(hudvar) then
-		hudvar = TTT2NET:GetGlobal({"hud_manager", "defaultHUD"}) or "pure_skin"
+		hudvar = TTT2NET.GetGlobal({"hud_manager", "defaultHUD"}) or "pure_skin"
 	end
 
 	return hudvar

--- a/gamemodes/terrortown/gamemode/client/cl_hud_manager.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_hud_manager.lua
@@ -3,7 +3,7 @@
 
 ttt_include("vgui__cl_hudswitcher")
 
-local current_hud_cvar = CreateClientConVar("ttt2_current_hud", TTT2NET.GetGlobal({"hud_manager", "defaultHUD"}) or "pure_skin", true, true)
+local current_hud_cvar = CreateClientConVar("ttt2_current_hud", ttt2net.GetGlobal({"hud_manager", "defaultHUD"}) or "pure_skin", true, true)
 local current_hud_table = nil
 
 HUDManager = {}
@@ -173,7 +173,7 @@ function HUDManager.GetHUD()
 	local hudvar = current_hud_cvar:GetString()
 
 	if not huds.GetStored(hudvar) then
-		hudvar = TTT2NET.GetGlobal({"hud_manager", "defaultHUD"}) or "pure_skin"
+		hudvar = ttt2net.GetGlobal({"hud_manager", "defaultHUD"}) or "pure_skin"
 	end
 
 	return hudvar

--- a/gamemodes/terrortown/gamemode/client/cl_network_sync.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_network_sync.lua
@@ -3,7 +3,7 @@
 -- The system is intended for syncing data from the server to the client only.
 -- So a client will only be able to read / get data and will receive updates from the server.
 --
--- @module TTT2NET
+-- @module ttt2net
 -- @author saibotk
 
 -- The meta data table to store information about the type of the data
@@ -19,7 +19,7 @@ local data_listeners = {}
 --
 -- @param any|table path The path to get the value from (this is the absolute path from the root so "global"/"players" etc is not yet included)
 -- @return any The value at the given path or nil if the path does not exist, the value is actually nil or there is no metadata entry for the path
-function TTT2NET.Get(path)
+function ttt2net.Get(path)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -36,13 +36,13 @@ function TTT2NET.Get(path)
 end
 
 ---
--- The same as {@TTT2NET.Get} but this will take care of prepending the key
+-- The same as {@ttt2net.Get} but this will take care of prepending the key
 -- to access the global values. Global values are generally accessible synced values,
 -- that the server sends to its clients.
 --
 -- @param any|table path The path to get the value from (no need to prepend a "global" as this will be done already)
 -- @return any The value at the given path or nil if the path does not exist, the value is actually nil or there is no metadata entry for the path
-function TTT2NET.GetGlobal(path)
+function ttt2net.GetGlobal(path)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -55,18 +55,18 @@ function TTT2NET.GetGlobal(path)
 	-- Add the prefix for the correct table
 	table.insert(tmpPath, 1, "global")
 
-	return TTT2NET.Get(tmpPath)
+	return ttt2net.Get(tmpPath)
 end
 
 ---
--- The same as {@TTT2NET.Get} but this will take care of prepending the key to access the player specific values.
+-- The same as {@ttt2net.Get} but this will take care of prepending the key to access the player specific values.
 -- Player specific values are synced values on player entities (can be thought of as data per player that this client knows of),
 -- that the server sends to its clients.
 --
 -- @param any|table path The path to get the value from (no need to prepend a "players" etc. as this will be done already)
 -- @param Entity The player from which we want to get the data
 -- @return any The value at the given path or nil if the path does not exist, the value is actually nil or there is no metadata entry for the path
-function TTT2NET.GetOnPlayer(path, ply)
+function ttt2net.GetOnPlayer(path, ply)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -80,12 +80,12 @@ function TTT2NET.GetOnPlayer(path, ply)
 	table.insert(tmpPath, 1, "players")
 	table.insert(tmpPath, 2, ply:EntIndex())
 
-	return TTT2NET.Get(tmpPath, client)
+	return ttt2net.Get(tmpPath, client)
 end
 
 ---
--- Prints out all TTT2NET related tables, for debugging purposes.
-function TTT2NET.Debug()
+-- Prints out all ttt2net related tables, for debugging purposes.
+function ttt2net.Debug()
 	print("[TTT2NET] Debug:")
 	print("Registered listeners:")
 	PrintTable(data_listeners)
@@ -114,10 +114,10 @@ local function CallCallbacksOnTree(oldData, curPath)
 		if nextNode.type then
 			-- The node is a leaf node -> is a node with meta data
 			local oldval = table.GetWithPath(oldData, nextPath)
-			local newval = TTT2NET.Get(nextPath)
+			local newval = ttt2net.Get(nextPath)
 
 			-- Call the listeners for this change
-			TTT2NET.CallOnUpdate(nextPath, oldval, newval)
+			ttt2net.CallOnUpdate(nextPath, oldval, newval)
 		else
 			-- Descend a level deeper
 			CallCallbacksOnTree(oldData, nextPath)
@@ -144,7 +144,7 @@ local function ReceiveFullStateUpdate(result)
 	-- Call all callback functions for all paths
 	CallCallbacksOnTree(oldData, oldMetaData)
 end
-net.ReceiveStream(TTT2NET.NET_STREAM_FULL_STATE_UPDATE, ReceiveFullStateUpdate)
+net.ReceiveStream(ttt2net.NET_STREAM_FULL_STATE_UPDATE, ReceiveFullStateUpdate)
 
 ---
 -- This is the callback that is executed when a meta data update message was received from the server.
@@ -153,8 +153,8 @@ net.ReceiveStream(TTT2NET.NET_STREAM_FULL_STATE_UPDATE, ReceiveFullStateUpdate)
 --
 -- @internal
 local function ReceiveMetaDataUpdate()
-	local path = TTT2NET.NetReadPath()
-	local metadata = TTT2NET.NetReadMetaData()
+	local path = ttt2net.NetReadPath()
+	local metadata = ttt2net.NetReadMetaData()
 
 	-- Set the new metadata
 	table.SetWithPath(data_store_metadata, path, metadata)
@@ -166,9 +166,9 @@ local function ReceiveMetaDataUpdate()
 	table.SetWithPath(data_store, path, nil)
 
 	-- Call callbacks that registered on data updates
-	TTT2NET.CallOnUpdate(path, oldval, nil)
+	ttt2net.CallOnUpdate(path, oldval, nil)
 end
-net.Receive(TTT2NET.NETMSG_META_UPDATE, ReceiveMetaDataUpdate)
+net.Receive(ttt2net.NETMSG_META_UPDATE, ReceiveMetaDataUpdate)
 
 ---
 -- This is the callback that is executed when a data update message was received from the server.
@@ -177,24 +177,24 @@ net.Receive(TTT2NET.NETMSG_META_UPDATE, ReceiveMetaDataUpdate)
 --
 -- @internal
 local function ReceiveDataUpdate()
-	local path = TTT2NET.NetReadPath()
+	local path = ttt2net.NetReadPath()
 
 	-- Get the metadata for the path, this will also error if there is no metadata entry for the path
 	local metadata = table.GetWithPath(data_store_metadata, path)
 
 	-- Read the new value based on the metadata entry
-	local newval = TTT2NET.NetReadData(metadata)
+	local newval = ttt2net.NetReadData(metadata)
 
 	-- Save the old value as we need to tell the update listeners about it
-	local oldval = TTT2NET.Get(path)
+	local oldval = ttt2net.Get(path)
 
 	-- Save the new data
 	table.SetWithPath(data_store, path, newval)
 
 	-- Call the update listeners
-	TTT2NET.CallOnUpdate(path, oldval, newval)
+	ttt2net.CallOnUpdate(path, oldval, newval)
 end
-net.Receive(TTT2NET.NETMSG_DATA_UPDATE, ReceiveDataUpdate)
+net.Receive(ttt2net.NETMSG_DATA_UPDATE, ReceiveDataUpdate)
 
 ---
 -- This will call all registered listeners for a specific path.
@@ -203,7 +203,7 @@ net.Receive(TTT2NET.NETMSG_DATA_UPDATE, ReceiveDataUpdate)
 -- @param any|table path The path that this update was executed on
 -- @param any oldval The old value, before the update
 -- @param any newval The new value, after the update
-function TTT2NET.CallOnUpdate(path, oldval, newval)
+function ttt2net.CallOnUpdate(path, oldval, newval)
 	-- Skip if the value did not change
 	if oldval == newval then return end
 
@@ -244,8 +244,8 @@ end
 
 ---
 -- Request a full state update from the server.
-function TTT2NET.RequestFullStateUpdate()
-	net.Start(TTT2NET.NETMSG_REQUEST_FULL_STATE_UPDATE)
+function ttt2net.RequestFullStateUpdate()
+	net.Start(ttt2net.NETMSG_REQUEST_FULL_STATE_UPDATE)
 	net.SendToServer()
 end
 
@@ -253,7 +253,7 @@ end
 -- Reads a path table from the current network message.
 --
 -- @return table The path table
-function TTT2NET.NetReadPath()
+function ttt2net.NetReadPath()
 	local result = net.ReadString()
 
 	return pon.decode(result)
@@ -263,7 +263,7 @@ end
 -- Reads a meta data table from the current network message.
 --
 -- @return table The metadata table
-function TTT2NET.NetReadMetaData()
+function ttt2net.NetReadMetaData()
 	-- If the null flag is set, then return null
 	if net.ReadBool() then return end
 
@@ -285,7 +285,7 @@ end
 --
 -- @param table metadata The meta data table for the data that is expected
 -- @return any The data that was read
-function TTT2NET.NetReadData(metadata)
+function ttt2net.NetReadData(metadata)
 	-- If the null flag is set, then return null
 	if net.ReadBool() then return end
 
@@ -312,7 +312,7 @@ end
 --
 -- @param the path to watch for changes
 -- @param function func
-function TTT2NET.OnUpdate(path, func)
+function ttt2net.OnUpdate(path, func)
 	assert(isfunction(func), "[TTT2NET] OnUpdate called with an invalid function.")
 
 	local tmpPath
@@ -345,7 +345,7 @@ end
 --
 -- @param any|table path The path to register the callback on
 -- @param function func The callback function that should be executed
-function TTT2NET.OnUpdateGlobal(path, func)
+function ttt2net.OnUpdateGlobal(path, func)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -358,7 +358,7 @@ function TTT2NET.OnUpdateGlobal(path, func)
 	-- Add the prefix for the correct table
 	table.insert(tmpPath, 1, "global")
 
-	TTT2NET.OnUpdate(tmpPath, func)
+	ttt2net.OnUpdate(tmpPath, func)
 end
 
 ---
@@ -367,7 +367,7 @@ end
 -- @param any|table path The path to register the callback on
 -- @param Entity ply The player that this data entry is from
 -- @param function func The callback function that should be executed
-function TTT2NET.OnUpdateOnPlayer(path, ply, func)
+function ttt2net.OnUpdateOnPlayer(path, ply, func)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -381,5 +381,5 @@ function TTT2NET.OnUpdateOnPlayer(path, ply, func)
 	table.insert(tmpPath, 1, "players")
 	table.insert(tmpPath, 2, ply:EntIndex())
 
-	TTT2NET.OnUpdate(tmpPath, func)
+	ttt2net.OnUpdate(tmpPath, func)
 end

--- a/gamemodes/terrortown/gamemode/client/cl_network_sync.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_network_sync.lua
@@ -19,7 +19,7 @@ local data_listeners = {}
 --
 -- @param any|table path The path to get the value from (this is the absolute path from the root so "global"/"players" etc is not yet included)
 -- @return any The value at the given path or nil if the path does not exist, the value is actually nil or there is no metadata entry for the path
-function TTT2NET:Get(path)
+function TTT2NET.Get(path)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -36,13 +36,13 @@ function TTT2NET:Get(path)
 end
 
 ---
--- The same as {@TTT2NET:Get} but this will take care of prepending the key
+-- The same as {@TTT2NET.Get} but this will take care of prepending the key
 -- to access the global values. Global values are generally accessible synced values,
 -- that the server sends to its clients.
 --
 -- @param any|table path The path to get the value from (no need to prepend a "global" as this will be done already)
 -- @return any The value at the given path or nil if the path does not exist, the value is actually nil or there is no metadata entry for the path
-function TTT2NET:GetGlobal(path)
+function TTT2NET.GetGlobal(path)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -55,18 +55,18 @@ function TTT2NET:GetGlobal(path)
 	-- Add the prefix for the correct table
 	table.insert(tmpPath, 1, "global")
 
-	return self:Get(tmpPath)
+	return TTT2NET.Get(tmpPath)
 end
 
 ---
--- The same as {@TTT2NET:Get} but this will take care of prepending the key to access the player specific values.
+-- The same as {@TTT2NET.Get} but this will take care of prepending the key to access the player specific values.
 -- Player specific values are synced values on player entities (can be thought of as data per player that this client knows of),
 -- that the server sends to its clients.
 --
 -- @param any|table path The path to get the value from (no need to prepend a "players" etc. as this will be done already)
 -- @param Entity The player from which we want to get the data
 -- @return any The value at the given path or nil if the path does not exist, the value is actually nil or there is no metadata entry for the path
-function TTT2NET:GetOnPlayer(path, ply)
+function TTT2NET.GetOnPlayer(path, ply)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -80,12 +80,12 @@ function TTT2NET:GetOnPlayer(path, ply)
 	table.insert(tmpPath, 1, "players")
 	table.insert(tmpPath, 2, ply:EntIndex())
 
-	return self:Get(tmpPath, client)
+	return TTT2NET.Get(tmpPath, client)
 end
 
 ---
 -- Prints out all TTT2NET related tables, for debugging purposes.
-function TTT2NET:Debug()
+function TTT2NET.Debug()
 	print("[TTT2NET] Debug:")
 	print("Registered listeners:")
 	PrintTable(data_listeners)
@@ -114,10 +114,10 @@ local function CallCallbacksOnTree(oldData, curPath)
 		if nextNode.type then
 			-- The node is a leaf node -> is a node with meta data
 			local oldval = table.GetWithPath(oldData, nextPath)
-			local newval = TTT2NET:Get(nextPath)
+			local newval = TTT2NET.Get(nextPath)
 
 			-- Call the listeners for this change
-			TTT2NET:CallOnUpdate(nextPath, oldval, newval)
+			TTT2NET.CallOnUpdate(nextPath, oldval, newval)
 		else
 			-- Descend a level deeper
 			CallCallbacksOnTree(oldData, nextPath)
@@ -153,8 +153,8 @@ net.ReceiveStream(TTT2NET.NET_STREAM_FULL_STATE_UPDATE, ReceiveFullStateUpdate)
 --
 -- @internal
 local function ReceiveMetaDataUpdate()
-	local path = TTT2NET:NetReadPath()
-	local metadata = TTT2NET:NetReadMetaData()
+	local path = TTT2NET.NetReadPath()
+	local metadata = TTT2NET.NetReadMetaData()
 
 	-- Set the new metadata
 	table.SetWithPath(data_store_metadata, path, metadata)
@@ -166,7 +166,7 @@ local function ReceiveMetaDataUpdate()
 	table.SetWithPath(data_store, path, nil)
 
 	-- Call callbacks that registered on data updates
-	TTT2NET:CallOnUpdate(path, oldval, nil)
+	TTT2NET.CallOnUpdate(path, oldval, nil)
 end
 net.Receive(TTT2NET.NETMSG_META_UPDATE, ReceiveMetaDataUpdate)
 
@@ -177,22 +177,22 @@ net.Receive(TTT2NET.NETMSG_META_UPDATE, ReceiveMetaDataUpdate)
 --
 -- @internal
 local function ReceiveDataUpdate()
-	local path = TTT2NET:NetReadPath()
+	local path = TTT2NET.NetReadPath()
 
 	-- Get the metadata for the path, this will also error if there is no metadata entry for the path
 	local metadata = table.GetWithPath(data_store_metadata, path)
 
 	-- Read the new value based on the metadata entry
-	local newval = TTT2NET:NetReadData(metadata)
+	local newval = TTT2NET.NetReadData(metadata)
 
 	-- Save the old value as we need to tell the update listeners about it
-	local oldval = TTT2NET:Get(path)
+	local oldval = TTT2NET.Get(path)
 
 	-- Save the new data
 	table.SetWithPath(data_store, path, newval)
 
 	-- Call the update listeners
-	TTT2NET:CallOnUpdate(path, oldval, newval)
+	TTT2NET.CallOnUpdate(path, oldval, newval)
 end
 net.Receive(TTT2NET.NETMSG_DATA_UPDATE, ReceiveDataUpdate)
 
@@ -203,7 +203,7 @@ net.Receive(TTT2NET.NETMSG_DATA_UPDATE, ReceiveDataUpdate)
 -- @param any|table path The path that this update was executed on
 -- @param any oldval The old value, before the update
 -- @param any newval The new value, after the update
-function TTT2NET:CallOnUpdate(path, oldval, newval)
+function TTT2NET.CallOnUpdate(path, oldval, newval)
 	-- Skip if the value did not change
 	if oldval == newval then return end
 
@@ -244,7 +244,7 @@ end
 
 ---
 -- Request a full state update from the server.
-function TTT2NET:RequestFullStateUpdate()
+function TTT2NET.RequestFullStateUpdate()
 	net.Start(TTT2NET.NETMSG_REQUEST_FULL_STATE_UPDATE)
 	net.SendToServer()
 end
@@ -253,7 +253,7 @@ end
 -- Reads a path table from the current network message.
 --
 -- @return table The path table
-function TTT2NET:NetReadPath()
+function TTT2NET.NetReadPath()
 	local result = net.ReadString()
 
 	return pon.decode(result)
@@ -263,7 +263,7 @@ end
 -- Reads a meta data table from the current network message.
 --
 -- @return table The metadata table
-function TTT2NET:NetReadMetaData()
+function TTT2NET.NetReadMetaData()
 	-- If the null flag is set, then return null
 	if net.ReadBool() then return end
 
@@ -285,7 +285,7 @@ end
 --
 -- @param table metadata The meta data table for the data that is expected
 -- @return any The data that was read
-function TTT2NET:NetReadData(metadata)
+function TTT2NET.NetReadData(metadata)
 	-- If the null flag is set, then return null
 	if net.ReadBool() then return end
 
@@ -312,7 +312,7 @@ end
 --
 -- @param the path to watch for changes
 -- @param function func
-function TTT2NET:OnUpdate(path, func)
+function TTT2NET.OnUpdate(path, func)
 	assert(isfunction(func), "[TTT2NET] OnUpdate called with an invalid function.")
 
 	local tmpPath
@@ -345,7 +345,7 @@ end
 --
 -- @param any|table path The path to register the callback on
 -- @param function func The callback function that should be executed
-function TTT2NET:OnUpdateGlobal(path, func)
+function TTT2NET.OnUpdateGlobal(path, func)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -358,7 +358,7 @@ function TTT2NET:OnUpdateGlobal(path, func)
 	-- Add the prefix for the correct table
 	table.insert(tmpPath, 1, "global")
 
-	self:OnUpdate(tmpPath, func)
+	TTT2NET.OnUpdate(tmpPath, func)
 end
 
 ---
@@ -367,7 +367,7 @@ end
 -- @param any|table path The path to register the callback on
 -- @param Entity ply The player that this data entry is from
 -- @param function func The callback function that should be executed
-function TTT2NET:OnUpdateOnPlayer(path, ply, func)
+function TTT2NET.OnUpdateOnPlayer(path, ply, func)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -381,5 +381,5 @@ function TTT2NET:OnUpdateOnPlayer(path, ply, func)
 	table.insert(tmpPath, 1, "players")
 	table.insert(tmpPath, 2, ply:EntIndex())
 
-	self:OnUpdate(tmpPath, func)
+	TTT2NET.OnUpdate(tmpPath, func)
 end

--- a/gamemodes/terrortown/gamemode/client/vgui/cl_hudswitcher.lua
+++ b/gamemodes/terrortown/gamemode/client/vgui/cl_hudswitcher.lua
@@ -179,7 +179,7 @@ function PANEL:Init()
 
 	local sheets = {}
 	local hudLists = huds.GetList()
-	local restrictedHUDs = TTT2NET.GetGlobal({"hud_manager", "restrictedHUDs"})
+	local restrictedHUDs = ttt2net.GetGlobal({"hud_manager", "restrictedHUDs"})
 	local colorHUDBoxEnabled = Color(155, 155, 155, 255)
 	local colorHUDBoxDisabled = Color(255, 0, 0)
 

--- a/gamemodes/terrortown/gamemode/client/vgui/cl_hudswitcher.lua
+++ b/gamemodes/terrortown/gamemode/client/vgui/cl_hudswitcher.lua
@@ -179,7 +179,7 @@ function PANEL:Init()
 
 	local sheets = {}
 	local hudLists = huds.GetList()
-	local restrictedHUDs = TTT2NET:GetGlobal({"hud_manager", "restrictedHUDs"})
+	local restrictedHUDs = TTT2NET.GetGlobal({"hud_manager", "restrictedHUDs"})
 	local colorHUDBoxEnabled = Color(155, 155, 155, 255)
 	local colorHUDBoxDisabled = Color(255, 0, 0)
 

--- a/gamemodes/terrortown/gamemode/server/sv_hud_manager.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_hud_manager.lua
@@ -76,15 +76,15 @@ function HUDManager.StoreData()
 	MsgN("[TTT2][HUDManager] Storing data in database...")
 
 	if DB_EnsureTableExists(HUD_MANAGER_SQL_TABLE, "key TEXT PRIMARY KEY, value TEXT") then
-		sql.Query("INSERT OR REPLACE INTO " .. HUD_MANAGER_SQL_TABLE .. " VALUES('forcedHUD', " .. sql.SQLStr(TTT2NET.GetGlobal("forcedHUD")) .. ")")
-		sql.Query("INSERT OR REPLACE INTO " .. HUD_MANAGER_SQL_TABLE .. " VALUES('defaultHUD', " .. sql.SQLStr(TTT2NET.GetGlobal("defaultHUD")) .. ")")
+		sql.Query("INSERT OR REPLACE INTO " .. HUD_MANAGER_SQL_TABLE .. " VALUES('forcedHUD', " .. sql.SQLStr(ttt2net.GetGlobal("forcedHUD")) .. ")")
+		sql.Query("INSERT OR REPLACE INTO " .. HUD_MANAGER_SQL_TABLE .. " VALUES('defaultHUD', " .. sql.SQLStr(ttt2net.GetGlobal("defaultHUD")) .. ")")
 	end
 
 	-- delete the table to recreate it again, to remove all values that might have been removed from the table
 	sql.Query("DROP TABLE " .. HUD_MANAGER_SQL_RESTRICTEDHUDS_TABLE)
 
 	if DB_EnsureTableExists(HUD_MANAGER_SQL_RESTRICTEDHUDS_TABLE, "name TEXT PRIMARY KEY") then
-		local restrictedHuds = TTT2NET.GetGlobal({"hud_manager", "restrictedHUDs"})
+		local restrictedHuds = ttt2net.GetGlobal({"hud_manager", "restrictedHUDs"})
 
 		for i = 1, #restrictedHuds do
 			sql.Query("INSERT INTO " .. HUD_MANAGER_SQL_RESTRICTEDHUDS_TABLE .. " VALUES(" .. sql.SQLStr(restrictedHuds[i]) .. ")")
@@ -99,9 +99,9 @@ end
 function HUDManager.LoadData()
 	MsgN("[TTT2][HUDManager] Loading data from database...")
 
-	TTT2NET.SetGlobal({"hud_manager", "forcedHUD"}, {type = "string"}, DB_GetStringValue("forcedHUD"))
-	TTT2NET.SetGlobal({"hud_manager", "defaultHUD"}, {type = "string"}, DB_GetStringValue("defaultHUD") or "pure_skin")
-	TTT2NET.SetGlobal({"hud_manager", "restrictedHUDs"}, {type = "table"}, DB_GetStringTable(HUD_MANAGER_SQL_RESTRICTEDHUDS_TABLE) or {})
+	ttt2net.SetGlobal({"hud_manager", "forcedHUD"}, {type = "string"}, DB_GetStringValue("forcedHUD"))
+	ttt2net.SetGlobal({"hud_manager", "defaultHUD"}, {type = "string"}, DB_GetStringValue("defaultHUD") or "pure_skin")
+	ttt2net.SetGlobal({"hud_manager", "restrictedHUDs"}, {type = "table"}, DB_GetStringTable(HUD_MANAGER_SQL_RESTRICTEDHUDS_TABLE) or {})
 end
 
 -- load values from the database when this file is executed
@@ -115,10 +115,10 @@ HUDManager.LoadData()
 net.Receive("TTT2RequestHUD", function(_, ply)
 	local hudname = net.ReadString() -- new requested HUD
 	local oldHUD = net.ReadString() -- current HUD as fallback
-	local forced = TTT2NET.GetGlobal({"hud_manager", "forcedHUD"})
+	local forced = ttt2net.GetGlobal({"hud_manager", "forcedHUD"})
 
 	if not forced then
-		local restrictions = TTT2NET.GetGlobal({"hud_manager", "restrictedHUDs"}) or {}
+		local restrictions = ttt2net.GetGlobal({"hud_manager", "restrictedHUDs"}) or {}
 		local restricted = false
 
 		for i = 1, #restrictions do
@@ -145,7 +145,7 @@ net.Receive("TTT2RequestHUD", function(_, ply)
 
 		-- still restricted? Then take the default
 		if restricted then
-			hudname = TTT2NET.GetGlobal({"hud_manager", "defaultHUD"})
+			hudname = ttt2net.GetGlobal({"hud_manager", "defaultHUD"})
 		end
 	end
 
@@ -153,7 +153,7 @@ net.Receive("TTT2RequestHUD", function(_, ply)
 	local hudToSendTbl = huds.GetStored(hudToSend)
 
 	if not hudToSendTbl or hudToSendTbl.isAbstract then
-		hudToSend = TTT2NET.GetGlobal({"hud_manager", "defaultHUD"}) or "pure_skin"
+		hudToSend = ttt2net.GetGlobal({"hud_manager", "defaultHUD"}) or "pure_skin"
 	end
 
 	net.Start("TTT2ReceiveHUD")
@@ -168,13 +168,13 @@ net.Receive("TTT2DefaultHUDRequest", function(_, ply)
 
 	if ply:IsAdmin() then
 		if HUDToSet == "" then -- Reset the forcedHUD value, to allow users to have a different HUD
-			TTT2NET.SetGlobal({"hud_manager", "defaultHUD"}, {type = "string"}, "pure_skin")
+			ttt2net.SetGlobal({"hud_manager", "defaultHUD"}, {type = "string"}, "pure_skin")
 
 			acceptedRequest = true
 		else
 			local hudtbl = huds.GetStored(HUDToSet)
 			if hudtbl ~= nil then
-				TTT2NET.SetGlobal({"hud_manager", "defaultHUD"}, {type = "string"}, HUDToSet)
+				ttt2net.SetGlobal({"hud_manager", "defaultHUD"}, {type = "string"}, HUDToSet)
 
 				acceptedRequest = true
 			end
@@ -196,13 +196,13 @@ net.Receive("TTT2ForceHUDRequest", function(_, ply)
 
 	if ply:IsAdmin() then
 		if HUDToForce == "" then -- Reset the forcedHUD value, to allow users to have a different HUD
-			TTT2NET.SetGlobal({"hud_manager", "forcedHUD"}, {type = "string"}, nil)
+			ttt2net.SetGlobal({"hud_manager", "forcedHUD"}, {type = "string"}, nil)
 
 			acceptedRequest = true
 		else
 			local hudtbl = huds.GetStored(HUDToForce)
 			if hudtbl ~= nil then
-				TTT2NET.SetGlobal({"hud_manager", "forcedHUD"}, {type = "string"}, HUDToForce)
+				ttt2net.SetGlobal({"hud_manager", "forcedHUD"}, {type = "string"}, HUDToForce)
 
 				acceptedRequest = true
 			end
@@ -226,7 +226,7 @@ net.Receive("TTT2RestrictHUDRequest", function(_, ply)
 	if ply:IsAdmin() then
 		local hudtbl = huds.GetStored(HUDToRestrict)
 		if hudtbl ~= nil then
-			local restrictedHUDs = TTT2NET.GetGlobal({"hud_manager", "restrictedHUDs"}) or {}
+			local restrictedHUDs = ttt2net.GetGlobal({"hud_manager", "restrictedHUDs"}) or {}
 
 			if shouldBeRestricted and not table.HasValue(restrictedHUDs, HUDToRestrict) then
 				restrictedHUDs[#restrictedHUDs + 1] = HUDToRestrict
@@ -234,7 +234,7 @@ net.Receive("TTT2RestrictHUDRequest", function(_, ply)
 				table.RemoveByValue(restrictedHUDs, HUDToRestrict)
 			end
 
-			TTT2NET.SetGlobal({"hud_manager", "restrictedHUDs"}, {type = "table"}, table.Copy(restrictedHUDs))
+			ttt2net.SetGlobal({"hud_manager", "restrictedHUDs"}, {type = "table"}, table.Copy(restrictedHUDs))
 
 			HUDManager.StoreData()
 

--- a/gamemodes/terrortown/gamemode/server/sv_hud_manager.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_hud_manager.lua
@@ -76,15 +76,15 @@ function HUDManager.StoreData()
 	MsgN("[TTT2][HUDManager] Storing data in database...")
 
 	if DB_EnsureTableExists(HUD_MANAGER_SQL_TABLE, "key TEXT PRIMARY KEY, value TEXT") then
-		sql.Query("INSERT OR REPLACE INTO " .. HUD_MANAGER_SQL_TABLE .. " VALUES('forcedHUD', " .. sql.SQLStr(TTT2NET:GetGlobal("forcedHUD")) .. ")")
-		sql.Query("INSERT OR REPLACE INTO " .. HUD_MANAGER_SQL_TABLE .. " VALUES('defaultHUD', " .. sql.SQLStr(TTT2NET:GetGlobal("defaultHUD")) .. ")")
+		sql.Query("INSERT OR REPLACE INTO " .. HUD_MANAGER_SQL_TABLE .. " VALUES('forcedHUD', " .. sql.SQLStr(TTT2NET.GetGlobal("forcedHUD")) .. ")")
+		sql.Query("INSERT OR REPLACE INTO " .. HUD_MANAGER_SQL_TABLE .. " VALUES('defaultHUD', " .. sql.SQLStr(TTT2NET.GetGlobal("defaultHUD")) .. ")")
 	end
 
 	-- delete the table to recreate it again, to remove all values that might have been removed from the table
 	sql.Query("DROP TABLE " .. HUD_MANAGER_SQL_RESTRICTEDHUDS_TABLE)
 
 	if DB_EnsureTableExists(HUD_MANAGER_SQL_RESTRICTEDHUDS_TABLE, "name TEXT PRIMARY KEY") then
-		local restrictedHuds = TTT2NET:GetGlobal({"hud_manager", "restrictedHUDs"})
+		local restrictedHuds = TTT2NET.GetGlobal({"hud_manager", "restrictedHUDs"})
 
 		for i = 1, #restrictedHuds do
 			sql.Query("INSERT INTO " .. HUD_MANAGER_SQL_RESTRICTEDHUDS_TABLE .. " VALUES(" .. sql.SQLStr(restrictedHuds[i]) .. ")")
@@ -99,9 +99,9 @@ end
 function HUDManager.LoadData()
 	MsgN("[TTT2][HUDManager] Loading data from database...")
 
-	TTT2NET:SetGlobal({"hud_manager", "forcedHUD"}, {type = "string"}, DB_GetStringValue("forcedHUD"))
-	TTT2NET:SetGlobal({"hud_manager", "defaultHUD"}, {type = "string"}, DB_GetStringValue("defaultHUD") or "pure_skin")
-	TTT2NET:SetGlobal({"hud_manager", "restrictedHUDs"}, {type = "table"}, DB_GetStringTable(HUD_MANAGER_SQL_RESTRICTEDHUDS_TABLE) or {})
+	TTT2NET.SetGlobal({"hud_manager", "forcedHUD"}, {type = "string"}, DB_GetStringValue("forcedHUD"))
+	TTT2NET.SetGlobal({"hud_manager", "defaultHUD"}, {type = "string"}, DB_GetStringValue("defaultHUD") or "pure_skin")
+	TTT2NET.SetGlobal({"hud_manager", "restrictedHUDs"}, {type = "table"}, DB_GetStringTable(HUD_MANAGER_SQL_RESTRICTEDHUDS_TABLE) or {})
 end
 
 -- load values from the database when this file is executed
@@ -115,10 +115,10 @@ HUDManager.LoadData()
 net.Receive("TTT2RequestHUD", function(_, ply)
 	local hudname = net.ReadString() -- new requested HUD
 	local oldHUD = net.ReadString() -- current HUD as fallback
-	local forced = TTT2NET:GetGlobal({"hud_manager", "forcedHUD"})
+	local forced = TTT2NET.GetGlobal({"hud_manager", "forcedHUD"})
 
 	if not forced then
-		local restrictions = TTT2NET:GetGlobal({"hud_manager", "restrictedHUDs"}) or {}
+		local restrictions = TTT2NET.GetGlobal({"hud_manager", "restrictedHUDs"}) or {}
 		local restricted = false
 
 		for i = 1, #restrictions do
@@ -145,7 +145,7 @@ net.Receive("TTT2RequestHUD", function(_, ply)
 
 		-- still restricted? Then take the default
 		if restricted then
-			hudname = TTT2NET:GetGlobal({"hud_manager", "defaultHUD"})
+			hudname = TTT2NET.GetGlobal({"hud_manager", "defaultHUD"})
 		end
 	end
 
@@ -153,7 +153,7 @@ net.Receive("TTT2RequestHUD", function(_, ply)
 	local hudToSendTbl = huds.GetStored(hudToSend)
 
 	if not hudToSendTbl or hudToSendTbl.isAbstract then
-		hudToSend = TTT2NET:GetGlobal({"hud_manager", "defaultHUD"}) or "pure_skin"
+		hudToSend = TTT2NET.GetGlobal({"hud_manager", "defaultHUD"}) or "pure_skin"
 	end
 
 	net.Start("TTT2ReceiveHUD")
@@ -168,13 +168,13 @@ net.Receive("TTT2DefaultHUDRequest", function(_, ply)
 
 	if ply:IsAdmin() then
 		if HUDToSet == "" then -- Reset the forcedHUD value, to allow users to have a different HUD
-			TTT2NET:SetGlobal({"hud_manager", "defaultHUD"}, {type = "string"}, "pure_skin")
+			TTT2NET.SetGlobal({"hud_manager", "defaultHUD"}, {type = "string"}, "pure_skin")
 
 			acceptedRequest = true
 		else
 			local hudtbl = huds.GetStored(HUDToSet)
 			if hudtbl ~= nil then
-				TTT2NET:SetGlobal({"hud_manager", "defaultHUD"}, {type = "string"}, HUDToSet)
+				TTT2NET.SetGlobal({"hud_manager", "defaultHUD"}, {type = "string"}, HUDToSet)
 
 				acceptedRequest = true
 			end
@@ -196,13 +196,13 @@ net.Receive("TTT2ForceHUDRequest", function(_, ply)
 
 	if ply:IsAdmin() then
 		if HUDToForce == "" then -- Reset the forcedHUD value, to allow users to have a different HUD
-			TTT2NET:SetGlobal({"hud_manager", "forcedHUD"}, {type = "string"}, nil)
+			TTT2NET.SetGlobal({"hud_manager", "forcedHUD"}, {type = "string"}, nil)
 
 			acceptedRequest = true
 		else
 			local hudtbl = huds.GetStored(HUDToForce)
 			if hudtbl ~= nil then
-				TTT2NET:SetGlobal({"hud_manager", "forcedHUD"}, {type = "string"}, HUDToForce)
+				TTT2NET.SetGlobal({"hud_manager", "forcedHUD"}, {type = "string"}, HUDToForce)
 
 				acceptedRequest = true
 			end
@@ -226,7 +226,7 @@ net.Receive("TTT2RestrictHUDRequest", function(_, ply)
 	if ply:IsAdmin() then
 		local hudtbl = huds.GetStored(HUDToRestrict)
 		if hudtbl ~= nil then
-			local restrictedHUDs = TTT2NET:GetGlobal({"hud_manager", "restrictedHUDs"}) or {}
+			local restrictedHUDs = TTT2NET.GetGlobal({"hud_manager", "restrictedHUDs"}) or {}
 
 			if shouldBeRestricted and not table.HasValue(restrictedHUDs, HUDToRestrict) then
 				restrictedHUDs[#restrictedHUDs + 1] = HUDToRestrict
@@ -234,7 +234,7 @@ net.Receive("TTT2RestrictHUDRequest", function(_, ply)
 				table.RemoveByValue(restrictedHUDs, HUDToRestrict)
 			end
 
-			TTT2NET:SetGlobal({"hud_manager", "restrictedHUDs"}, {type = "table"}, table.Copy(restrictedHUDs))
+			TTT2NET.SetGlobal({"hud_manager", "restrictedHUDs"}, {type = "table"}, table.Copy(restrictedHUDs))
 
 			HUDManager.StoreData()
 

--- a/gamemodes/terrortown/gamemode/server/sv_network_sync.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_network_sync.lua
@@ -13,7 +13,7 @@
 -- for the same players to another client Y (eg. to let him know of his traitor team members). While doing that, the server still knows what each client
 -- currently knows and can adjust to that.
 --
--- @module TTT2NET
+-- @module ttt2net
 -- @author saibotk
 
 -- Only send to clients, that already requested a full state update,
@@ -31,9 +31,9 @@ local data_store = {}
 local data_synced_nwvars = {}
 
 -- Register network message names
-util.AddNetworkString(TTT2NET.NETMSG_META_UPDATE)
-util.AddNetworkString(TTT2NET.NETMSG_DATA_UPDATE)
-util.AddNetworkString(TTT2NET.NETMSG_REQUEST_FULL_STATE_UPDATE)
+util.AddNetworkString(ttt2net.NETMSG_META_UPDATE)
+util.AddNetworkString(ttt2net.NETMSG_DATA_UPDATE)
+util.AddNetworkString(ttt2net.NETMSG_REQUEST_FULL_STATE_UPDATE)
 
 ---
 -- Set the value of an NWVar to the value at the specified path.
@@ -56,7 +56,7 @@ local function SyncNWVarWithPath(path, meta, nwent, nwkey)
 	end
 
 	local metadata = meta or table.GetWithPath(data_store_metadata, tmpPath)
-	local value = TTT2NET.Get(tmpPath)
+	local value = ttt2net.Get(tmpPath)
 
 	if metadata.type == "int" then
 		assert(not metadata.unsigned, "[TTT2NET] Unsigned numbers are not supported by NWVars! Change the metadata information!")
@@ -77,7 +77,7 @@ end
 -- @param table meta1 first meta table
 -- @param table meta2 second meta table
 -- @return bool Returns true if they are equal false if not
-function TTT2NET.NetworkMetaDataTableEqual(meta1, meta2)
+function ttt2net.NetworkMetaDataTableEqual(meta1, meta2)
 	if meta1 == nil and meta2 == nil then
 		return true
 	end
@@ -99,7 +99,7 @@ end
 --
 -- @param any|table path The path that this meta data is associated with
 -- @param table|nil metadata The metadata table
-function TTT2NET.SetMetaData(path, metadata)
+function ttt2net.SetMetaData(path, metadata)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -113,7 +113,7 @@ function TTT2NET.SetMetaData(path, metadata)
 	local storedMetaData = table.GetWithPath(data_store_metadata, tmpPath)
 
 	-- If the metadata is already stored, do nothing
-	if TTT2NET.NetworkMetaDataTableEqual(storedMetaData, metadata) then return end
+	if ttt2net.NetworkMetaDataTableEqual(storedMetaData, metadata) then return end
 
 	-- Insert data to metadata table
 	table.SetWithPath(data_store_metadata, tmpPath, metadata)
@@ -122,16 +122,16 @@ function TTT2NET.SetMetaData(path, metadata)
 	table.SetWithPath(data_store, tmpPath, nil)
 
 	-- Sync new meta information to all clients that are already connected and received a full state!
-	TTT2NET.SendMetaDataUpdate(tmpPath)
+	ttt2net.SendMetaDataUpdate(tmpPath)
 end
 
 ---
 -- This will set the metadata for a specific path and prepend the path with the "global" keyword.
--- For more information look at {@TTT2NET.SetMetaData}.
+-- For more information look at {@ttt2net.SetMetaData}.
 --
 -- @param any|table path The path this meta data is associated with (already includes the "global" keyword)
 -- @param table|nil metadata The metadata table
-function TTT2NET.SetMetaDataGlobal(path, metadata)
+function ttt2net.SetMetaDataGlobal(path, metadata)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -144,16 +144,16 @@ function TTT2NET.SetMetaDataGlobal(path, metadata)
 	-- Add the prefix for the correct table
 	table.insert(tmpPath, 1, "global")
 
-	TTT2NET.SetMetaData(tmpPath, metadata)
+	ttt2net.SetMetaData(tmpPath, metadata)
 end
 
 ---
 -- This will set the metadata for a specific path on a player and prepend needed keywords.
--- For more information look at {@TTT2NET.SetMetaData}.
+-- For more information look at {@ttt2net.SetMetaData}.
 --
 -- @param any|table path The path this meta data is associated with (already includes the needed keywords)
 -- @param table|nil metadata The metadata table
-function TTT2NET.SetMetaDataOnPlayer(path, metadata, ply)
+function ttt2net.SetMetaDataOnPlayer(path, metadata, ply)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -167,7 +167,7 @@ function TTT2NET.SetMetaDataOnPlayer(path, metadata, ply)
 	table.insert(tmpPath, 1, "players")
 	table.insert(tmpPath, 2, ply:EntIndex())
 
-	TTT2NET.SetMetaData(tmpPath, metadata)
+	ttt2net.SetMetaData(tmpPath, metadata)
 end
 
 ---
@@ -185,7 +185,7 @@ end
 -- @param table|nil meta The metadata for the path (or empty to use an existing metadata entry)
 -- @param any value The value to save
 -- @param Entity|nil client The client/entity to set this value for (overrides the default value)
-function TTT2NET.Set(path, meta, value, client)
+function ttt2net.Set(path, meta, value, client)
 	local tmpPath
 	local clientId = client and client:EntIndex() or nil
 
@@ -201,7 +201,7 @@ function TTT2NET.Set(path, meta, value, client)
 	assert(metadata, "[TTT2NET] Set() called but no metadata entry or metadata parameter found!")
 
 	-- Set the meta data, this will only send / update if the meta data has changed
-	TTT2NET.SetMetaData(tmpPath, metadata)
+	ttt2net.SetMetaData(tmpPath, metadata)
 
 	-- Add the identifier for the default value for all clients or the clientId if specified
 	tmpPath[#tmpPath + 1] = clientId or "default"
@@ -216,7 +216,7 @@ function TTT2NET.Set(path, meta, value, client)
 	tmpPath[#tmpPath] = nil
 
 	-- Sync the new value
-	TTT2NET.SendDataUpdate(tmpPath, client)
+	ttt2net.SendDataUpdate(tmpPath, client)
 
 	-- Sync all registered nwvars to the new value
 	-- Only attempt to sync, if the path leads to a player, which NWVars can be synced to.
@@ -241,7 +241,7 @@ end
 -- This will also automatically sync the new value to the clients that previously had an override value.
 --
 -- @param table path The path to clear out all overrides on.
-function TTT2NET.RemoveOverrides(path)
+function ttt2net.RemoveOverrides(path)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -288,16 +288,16 @@ function TTT2NET.RemoveOverrides(path)
 	currentDataTable[lastKey] = { default = defaultValue }
 
 	-- Send update to all players that previously had an override
-	TTT2NET.SendDataUpdate(tmpPath, receivers)
+	ttt2net.SendDataUpdate(tmpPath, receivers)
 end
 
 ---
 -- This will be used to clear out all client specific overrides for a path, so that only the
 -- default value is set. This will also prepend the "global" keyword to the path, otherwise
--- it will do the same as {@TTT2NET.RemoveOverrides}.
+-- it will do the same as {@ttt2net.RemoveOverrides}.
 --
 -- @param table path The path to clear out all overrides on.
-function TTT2NET.RemoveOverridesGlobal(path)
+function ttt2net.RemoveOverridesGlobal(path)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -310,16 +310,16 @@ function TTT2NET.RemoveOverridesGlobal(path)
 	-- Add the prefix for the correct table
 	table.insert(tmpPath, 1, "global")
 
-	TTT2NET.RemoveOverrides(tmpPath)
+	ttt2net.RemoveOverrides(tmpPath)
 end
 
 ---
 -- This will be used to clear out all client specific overrides for a path on a player/entity object, so that only the
 -- default value is set. This will also prepend the needed keywords to the path, otherwise
--- it will do the same as {@TTT2NET.RemoveOverrides}.
+-- it will do the same as {@ttt2net.RemoveOverrides}.
 --
 -- @param table path The path to clear out all overrides on.
-function TTT2NET.RemoveOverridesOnPlayer(path, ply)
+function ttt2net.RemoveOverridesOnPlayer(path, ply)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -333,7 +333,7 @@ function TTT2NET.RemoveOverridesOnPlayer(path, ply)
 	table.insert(tmpPath, 1, "players")
 	table.insert(tmpPath, 2, ply:EntIndex())
 
-	TTT2NET.RemoveOverrides(tmpPath)
+	ttt2net.RemoveOverrides(tmpPath)
 end
 
 ---
@@ -344,7 +344,7 @@ end
 -- @param any|table path The path to get the value from
 -- @param Entity|nil client The client/entity to get the value for
 -- @return any|nil The value found at the given path
-function TTT2NET.Get(path, client)
+function ttt2net.Get(path, client)
 	local clientId = client and client:EntIndex() or nil
 	local tmpPath
 
@@ -369,7 +369,7 @@ end
 -- @param any|table path The path to get the value from
 -- @param Entity|nil client The client/entity to get the value for
 -- @return any|nil The value that a client knows
-function TTT2NET.GetWithOverride(path, client)
+function ttt2net.GetWithOverride(path, client)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -399,12 +399,12 @@ end
 
 ---
 -- Returns the currently saved value for a given path.
--- This will do the same as {@TTT2NET.Get} but will first prepend the "global" keyword to the path.
+-- This will do the same as {@ttt2net.Get} but will first prepend the "global" keyword to the path.
 --
 -- @param any|table path The path to get the value from
 -- @param Entity|nil client The client/entity to get the value for
 -- @return any|nil The value for the given path
-function TTT2NET.GetGlobal(path, client)
+function ttt2net.GetGlobal(path, client)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -417,18 +417,18 @@ function TTT2NET.GetGlobal(path, client)
 	-- Add the prefix for the correct table
 	table.insert(tmpPath, 1, "global")
 
-	return TTT2NET.Get(tmpPath, client)
+	return ttt2net.Get(tmpPath, client)
 end
 
 ---
--- This is used to set a value in the data table for a specific path and works the same as {@TTT2NET.Set},
+-- This is used to set a value in the data table for a specific path and works the same as {@ttt2net.Set},
 -- but it will prepend the "global" keyword to the path.
 --
 -- @param any|table path The path to set the data for
 -- @param table|nil meta The metadata for the path
 -- @param any value The value to save
 -- @param Entity|nil client The client/entity to set this value for (overrides the default value)
-function TTT2NET.SetGlobal(path, meta, value, client)
+function ttt2net.SetGlobal(path, meta, value, client)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -441,11 +441,11 @@ function TTT2NET.SetGlobal(path, meta, value, client)
 	-- Add the prefix for the correct table
 	table.insert(tmpPath, 1, "global")
 
-	TTT2NET.Set(tmpPath, meta, value, client)
+	ttt2net.Set(tmpPath, meta, value, client)
 end
 
 ---
--- This is used to set a value in the data table for a specific path on a specific player/entity and works the same as {@TTT2NET.Set},
+-- This is used to set a value in the data table for a specific path on a specific player/entity and works the same as {@ttt2net.Set},
 -- but it will prepend the needed keywords to the path.
 --
 -- @param any|table path The path to set the data for
@@ -453,7 +453,7 @@ end
 -- @param any value The value to save
 -- @param Entity ply The player/entity that this data is associated to
 -- @param Entity|nil client The client/entity to set this value for (as an override for the default value)
-function TTT2NET.SetOnPlayer(path, meta, value, ply, client)
+function ttt2net.SetOnPlayer(path, meta, value, ply, client)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -467,18 +467,18 @@ function TTT2NET.SetOnPlayer(path, meta, value, ply, client)
 	table.insert(tmpPath, 1, "players")
 	table.insert(tmpPath, 2, ply:EntIndex())
 
-	TTT2NET.Set(tmpPath, meta, value, client)
+	ttt2net.Set(tmpPath, meta, value, client)
 end
 
 ---
 -- Returns the currently saved value for a given path on a specific player.
--- This will do the same as {@TTT2NET.Get} but will first prepend the needed keywords to the path.
+-- This will do the same as {@ttt2net.Get} but will first prepend the needed keywords to the path.
 --
 -- @param any|table path The path to get the value from
 -- @param Entity ply The client/entity to save the value on
 -- @param Entity|nil client The client/entity to get the value for
 -- @return any|nil The value for the given path
-function TTT2NET.GetOnPlayer(path, ply, client)
+function ttt2net.GetOnPlayer(path, ply, client)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -492,12 +492,12 @@ function TTT2NET.GetOnPlayer(path, ply, client)
 	table.insert(tmpPath, 1, "players")
 	table.insert(tmpPath, 2, ply:EntIndex())
 
-	return TTT2NET.Get(tmpPath, client)
+	return ttt2net.Get(tmpPath, client)
 end
 
 ---
--- Prints out all TTT2NET related tables, for debugging purposes.
-function TTT2NET.Debug()
+-- Prints out all ttt2net related tables, for debugging purposes.
+function ttt2net.Debug()
 	print("[TTT2NET] Debug:")
 	print("Initialized clients:")
 	PrintTable(initialized_clients)
@@ -514,7 +514,7 @@ end
 -- initialized clients.
 --
 -- @param any|table path The path to send a metadata update for
-function TTT2NET.SendMetaDataUpdate(path)
+function ttt2net.SendMetaDataUpdate(path)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -528,10 +528,10 @@ function TTT2NET.SendMetaDataUpdate(path)
 	local metadata = table.GetWithPath(data_store_metadata, tmpPath)
 
 	-- Write meta data
-	net.Start(TTT2NET.NETMSG_META_UPDATE)
+	net.Start(ttt2net.NETMSG_META_UPDATE)
 
-	TTT2NET.NetWritePath(tmpPath)
-	TTT2NET.NetWriteMetaData(metadata)
+	ttt2net.NetWritePath(tmpPath)
+	ttt2net.NetWriteMetaData(metadata)
 
 	net.Send(initialized_clients)
 end
@@ -546,7 +546,7 @@ end
 -- @param Entity client The client/entity to clear all overrides for
 -- @param table curTable This is the current metadata table. This should start with the complete metadata table, otherwise the path has to be adjusted, see the description.
 -- @param table|nil path The current path to the curTable based on the root of the data table
-function TTT2NET.RemoveOverridesForClient(client, curTable, path)
+function ttt2net.RemoveOverridesForClient(client, curTable, path)
 	local tmpPath = not istable(path) and { path } or path and table.Copy(path) or {}
 
 	-- Visit all keys in the current tree
@@ -558,10 +558,10 @@ function TTT2NET.RemoveOverridesForClient(client, curTable, path)
 		-- Check if we reached a leaf node (a node with metadata)
 		if nextNode.type then
 			-- Remove the override from this key
-			TTT2NET.Set(nextPath, nil, nil, client)
+			ttt2net.Set(nextPath, nil, nil, client)
 		else
 			-- Descend a level deeper
-			TTT2NET.RemoveOverridesForClient(client, curTable[key], nextPath)
+			ttt2net.RemoveOverridesForClient(client, curTable[key], nextPath)
 		end
 	end
 end
@@ -570,16 +570,16 @@ end
 -- This will reset all known data for a client and remove all entries related to this client.
 --
 -- @param Entity client The client to remove
-function TTT2NET.ResetClient(client)
+function ttt2net.ResetClient(client)
 	assert(IsEntity(client), "[TTT2NET] ResetClient() client is not a valid Entity!")
 
 	table.RemoveByValue(initialized_clients, client)
 
 	-- Clear up the player specific data table
-	TTT2NET.SetMetaDataOnPlayer(nil, nil, client)
+	ttt2net.SetMetaDataOnPlayer(nil, nil, client)
 
 	-- Clear up all left over overrides
-	TTT2NET.RemoveOverridesForClient(client, data_store_metadata)
+	ttt2net.RemoveOverridesForClient(client, data_store_metadata)
 end
 
 ---
@@ -587,7 +587,7 @@ end
 --
 -- @param any|table path The path to send the update for
 -- @param Player|table|nil client The client/list of clients or nil to send this to all knwon clients
-function TTT2NET.SendDataUpdate(path, client)
+function ttt2net.SendDataUpdate(path, client)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -610,12 +610,12 @@ function TTT2NET.SendDataUpdate(path, client)
 	-- For each receiver send the data
 	for i = 1, #receivers do
 		local receiver = receivers[i]
-		local value = TTT2NET.GetWithOverride(tmpPath, receiver)
+		local value = ttt2net.GetWithOverride(tmpPath, receiver)
 
-		net.Start(TTT2NET.NETMSG_DATA_UPDATE)
+		net.Start(ttt2net.NETMSG_DATA_UPDATE)
 
-		TTT2NET.NetWritePath(tmpPath)
-		TTT2NET.NetWriteData(metadata, value)
+		ttt2net.NetWritePath(tmpPath)
+		ttt2net.NetWriteData(metadata, value)
 
 		net.Send(receiver)
 	end
@@ -631,7 +631,7 @@ end
 -- @param Entity client The client/entity to get the data for
 -- @param table curTable This is the current metadata table. This should start with the complete metadata table, otherwise the path has to be adjusted, see the description.
 -- @param table|nil path The current path to the curTable based on the root of the data table
-function TTT2NET.DataTableWithOverrides(client, curTable, path)
+function ttt2net.DataTableWithOverrides(client, curTable, path)
 	local tmpPath = not istable(path) and { path } or path and table.Copy(path) or {}
 	local newTable = table.Copy(curTable)
 
@@ -645,10 +645,10 @@ function TTT2NET.DataTableWithOverrides(client, curTable, path)
 		-- Check if we reached a leaf node (a node with metadata)
 		if nextNode.type then
 			-- Replace the metadata with the data
-			newTable[key] = TTT2NET.GetWithOverride(nextPath, client)
+			newTable[key] = ttt2net.GetWithOverride(nextPath, client)
 		else
 			-- Descend a level deeper
-			newTable[key] = TTT2NET.DataTableWithOverrides(client, curTable[key], nextPath)
+			newTable[key] = ttt2net.DataTableWithOverrides(client, curTable[key], nextPath)
 		end
 	end
 
@@ -661,7 +661,7 @@ end
 -- @note This will also set all reveivers as initialized.
 --
 -- @param Player|table|nil client The client/list of clients or nil for all known clients, to send the update to
-function TTT2NET.SendFullStateUpdate(client)
+function ttt2net.SendFullStateUpdate(client)
 	-- Wrap the given receivers to a table
 	local receivers = istable(client) and client or client and { client } or initialized_clients
 
@@ -670,10 +670,10 @@ function TTT2NET.SendFullStateUpdate(client)
 		local receiver = receivers[i]
 		local data = {
 			meta = data_store_metadata,
-			data = TTT2NET.DataTableWithOverrides(receiver, data_store_metadata)
+			data = ttt2net.DataTableWithOverrides(receiver, data_store_metadata)
 		}
 
-		net.SendStream(TTT2NET.NET_STREAM_FULL_STATE_UPDATE, data, receiver)
+		net.SendStream(ttt2net.NET_STREAM_FULL_STATE_UPDATE, data, receiver)
 
 		-- Set the client as initialized (so it will receive future data updates)
 		if not table.HasValue(initialized_clients, receiver) then
@@ -692,15 +692,15 @@ end
 local function ClientRequestFullStateUpdate(len, client)
 	print("[TTT2NET] Client " .. (client:Nick() or "unknown") .. " requested a full state update.")
 
-	TTT2NET.SendFullStateUpdate(client)
+	ttt2net.SendFullStateUpdate(client)
 end
-net.Receive(TTT2NET.NETMSG_REQUEST_FULL_STATE_UPDATE, ClientRequestFullStateUpdate)
+net.Receive(ttt2net.NETMSG_REQUEST_FULL_STATE_UPDATE, ClientRequestFullStateUpdate)
 
 ---
 -- This is used to write a path table to the current network message.
 --
 -- @param table path The path table to send
-function TTT2NET.NetWritePath(path)
+function ttt2net.NetWritePath(path)
 	net.WriteString(pon.encode(path))
 end
 
@@ -708,7 +708,7 @@ end
 -- This is used to write a metadata table to the current network message.
 --
 -- @param table metadata The metadata to send
-function TTT2NET.NetWriteMetaData(metadata)
+function ttt2net.NetWriteMetaData(metadata)
 	local isMetadataNil = metadata == nil
 
 	net.WriteBool(isMetadataNil)
@@ -731,7 +731,7 @@ end
 --
 -- @param table metadata The metadata for the given value
 -- @param any|nil val The value to send, can also be nil
-function TTT2NET.NetWriteData(metadata, val)
+function ttt2net.NetWriteData(metadata, val)
 	-- Check if the value is nil, to also allow setting a value to nil
 	local isValNil = val == nil
 
@@ -758,7 +758,7 @@ function TTT2NET.NetWriteData(metadata, val)
 end
 
 local function NWVarProxyCallback(ent, name, oldval, newval, path, meta)
-	TTT2NET.Set(path, meta, newval)
+	ttt2net.Set(path, meta, newval)
 end
 
 ---
@@ -775,7 +775,7 @@ end
 -- @param table|nil meta The metadata
 -- @param Entity nwent The entity that this NWVar is saved on
 -- @param string nwkey The key of the NWVar
-function TTT2NET.SyncWithNWVar(path, meta, nwent, nwkey)
+function ttt2net.SyncWithNWVar(path, meta, nwent, nwkey)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -794,7 +794,7 @@ function TTT2NET.SyncWithNWVar(path, meta, nwent, nwkey)
 	assert(metadata, "[TTT2NET] SyncWithNWVar() called but no metadata entry or metadata parameter found!")
 
 	-- Set the meta data, this will only send / update if the meta data has changed
-	TTT2NET.SetMetaData(tmpPath, metadata)
+	ttt2net.SetMetaData(tmpPath, metadata)
 
 	nwent:SetNWVarProxy(nwkey, function (ent, name, oldval, newval)
 		NWVarProxyCallback(ent, name, oldval, newval, tmpPath, metadata)
@@ -814,7 +814,7 @@ function TTT2NET.SyncWithNWVar(path, meta, nwent, nwkey)
 		curval = nwent:GetNWString(nwkey)
 	end
 
-	TTT2NET.Set(tmpPath, metadata, curval)
+	ttt2net.Set(tmpPath, metadata, curval)
 
 	-- Get all registered nwvars
 	local nwvars = table.GetWithPath(data_synced_nwvars, tmpPath) or {}
@@ -840,7 +840,7 @@ local plymeta = assert(FindMetaTable("Player"), "[TTT2NET] FAILED TO FIND PLAYER
 -- @param any|table path The path to set the value for
 -- @param bool|nil value The value to set
 function plymeta:TTT2NETSetBool(path, value)
-	TTT2NET.SetOnPlayer(path, { type = "bool" }, value, self)
+	ttt2net.SetOnPlayer(path, { type = "bool" }, value, self)
 end
 
 ---
@@ -850,7 +850,7 @@ end
 -- @param int|nil value The value to set
 -- @param int|nil bits The bits that this int needs to be stored (optional, otherwise a default of 32 is used)
 function plymeta:TTT2NETSetInt(path, value, bits)
-	TTT2NET.SetOnPlayer(path, {
+	ttt2net.SetOnPlayer(path, {
 		type = "int",
 		bits = bits
 	}, value, self)
@@ -863,7 +863,7 @@ end
 -- @param uint|nil value The value to set
 -- @param int|nil bits The bits that this int needs to be stored (optional, otherwise a default of 32 is used)
 function plymeta:TTT2NETSetUInt(path, value, bits)
-	TTT2NET.SetOnPlayer(path, {
+	ttt2net.SetOnPlayer(path, {
 		type = "int",
 		unsigned = true,
 		bits = bits
@@ -876,7 +876,7 @@ end
 -- @param any|table path The path to set the value for
 -- @param float|nil value The value to set
 function plymeta:TTT2NETSetFloat(path, value)
-	TTT2NET.SetOnPlayer(path, { type = "float" }, value, self)
+	ttt2net.SetOnPlayer(path, { type = "float" }, value, self)
 end
 
 ---
@@ -885,5 +885,5 @@ end
 -- @param any|table path The path to set the value for
 -- @param string|nil value The value to set
 function plymeta:TTT2NETSetString(path, value)
-	TTT2NET.SetOnPlayer(path, { type = "string" }, value, self)
+	ttt2net.SetOnPlayer(path, { type = "string" }, value, self)
 end

--- a/gamemodes/terrortown/gamemode/server/sv_network_sync.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_network_sync.lua
@@ -56,7 +56,7 @@ local function SyncNWVarWithPath(path, meta, nwent, nwkey)
 	end
 
 	local metadata = meta or table.GetWithPath(data_store_metadata, tmpPath)
-	local value = TTT2NET:Get(tmpPath)
+	local value = TTT2NET.Get(tmpPath)
 
 	if metadata.type == "int" then
 		assert(not metadata.unsigned, "[TTT2NET] Unsigned numbers are not supported by NWVars! Change the metadata information!")
@@ -77,7 +77,7 @@ end
 -- @param table meta1 first meta table
 -- @param table meta2 second meta table
 -- @return bool Returns true if they are equal false if not
-function TTT2NET:NetworkMetaDataTableEqual(meta1, meta2)
+function TTT2NET.NetworkMetaDataTableEqual(meta1, meta2)
 	if meta1 == nil and meta2 == nil then
 		return true
 	end
@@ -99,7 +99,7 @@ end
 --
 -- @param any|table path The path that this meta data is associated with
 -- @param table|nil metadata The metadata table
-function TTT2NET:SetMetaData(path, metadata)
+function TTT2NET.SetMetaData(path, metadata)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -113,7 +113,7 @@ function TTT2NET:SetMetaData(path, metadata)
 	local storedMetaData = table.GetWithPath(data_store_metadata, tmpPath)
 
 	-- If the metadata is already stored, do nothing
-	if self:NetworkMetaDataTableEqual(storedMetaData, metadata) then return end
+	if TTT2NET.NetworkMetaDataTableEqual(storedMetaData, metadata) then return end
 
 	-- Insert data to metadata table
 	table.SetWithPath(data_store_metadata, tmpPath, metadata)
@@ -122,16 +122,16 @@ function TTT2NET:SetMetaData(path, metadata)
 	table.SetWithPath(data_store, tmpPath, nil)
 
 	-- Sync new meta information to all clients that are already connected and received a full state!
-	self:SendMetaDataUpdate(tmpPath)
+	TTT2NET.SendMetaDataUpdate(tmpPath)
 end
 
 ---
 -- This will set the metadata for a specific path and prepend the path with the "global" keyword.
--- For more information look at {@TTT2NET:SetMetaData}.
+-- For more information look at {@TTT2NET.SetMetaData}.
 --
 -- @param any|table path The path this meta data is associated with (already includes the "global" keyword)
 -- @param table|nil metadata The metadata table
-function TTT2NET:SetMetaDataGlobal(path, metadata)
+function TTT2NET.SetMetaDataGlobal(path, metadata)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -144,16 +144,16 @@ function TTT2NET:SetMetaDataGlobal(path, metadata)
 	-- Add the prefix for the correct table
 	table.insert(tmpPath, 1, "global")
 
-	self:SetMetaData(tmpPath, metadata)
+	TTT2NET.SetMetaData(tmpPath, metadata)
 end
 
 ---
 -- This will set the metadata for a specific path on a player and prepend needed keywords.
--- For more information look at {@TTT2NET:SetMetaData}.
+-- For more information look at {@TTT2NET.SetMetaData}.
 --
 -- @param any|table path The path this meta data is associated with (already includes the needed keywords)
 -- @param table|nil metadata The metadata table
-function TTT2NET:SetMetaDataOnPlayer(path, metadata, ply)
+function TTT2NET.SetMetaDataOnPlayer(path, metadata, ply)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -167,7 +167,7 @@ function TTT2NET:SetMetaDataOnPlayer(path, metadata, ply)
 	table.insert(tmpPath, 1, "players")
 	table.insert(tmpPath, 2, ply:EntIndex())
 
-	self:SetMetaData(tmpPath, metadata)
+	TTT2NET.SetMetaData(tmpPath, metadata)
 end
 
 ---
@@ -185,7 +185,7 @@ end
 -- @param table|nil meta The metadata for the path (or empty to use an existing metadata entry)
 -- @param any value The value to save
 -- @param Entity|nil client The client/entity to set this value for (overrides the default value)
-function TTT2NET:Set(path, meta, value, client)
+function TTT2NET.Set(path, meta, value, client)
 	local tmpPath
 	local clientId = client and client:EntIndex() or nil
 
@@ -201,7 +201,7 @@ function TTT2NET:Set(path, meta, value, client)
 	assert(metadata, "[TTT2NET] Set() called but no metadata entry or metadata parameter found!")
 
 	-- Set the meta data, this will only send / update if the meta data has changed
-	self:SetMetaData(tmpPath, metadata)
+	TTT2NET.SetMetaData(tmpPath, metadata)
 
 	-- Add the identifier for the default value for all clients or the clientId if specified
 	tmpPath[#tmpPath + 1] = clientId or "default"
@@ -216,7 +216,7 @@ function TTT2NET:Set(path, meta, value, client)
 	tmpPath[#tmpPath] = nil
 
 	-- Sync the new value
-	self:SendDataUpdate(tmpPath, client)
+	TTT2NET.SendDataUpdate(tmpPath, client)
 
 	-- Sync all registered nwvars to the new value
 	-- Only attempt to sync, if the path leads to a player, which NWVars can be synced to.
@@ -241,7 +241,7 @@ end
 -- This will also automatically sync the new value to the clients that previously had an override value.
 --
 -- @param table path The path to clear out all overrides on.
-function TTT2NET:RemoveOverrides(path)
+function TTT2NET.RemoveOverrides(path)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -288,16 +288,16 @@ function TTT2NET:RemoveOverrides(path)
 	currentDataTable[lastKey] = { default = defaultValue }
 
 	-- Send update to all players that previously had an override
-	self:SendDataUpdate(tmpPath, receivers)
+	TTT2NET.SendDataUpdate(tmpPath, receivers)
 end
 
 ---
 -- This will be used to clear out all client specific overrides for a path, so that only the
 -- default value is set. This will also prepend the "global" keyword to the path, otherwise
--- it will do the same as {@TTT2NET:RemoveOverrides}.
+-- it will do the same as {@TTT2NET.RemoveOverrides}.
 --
 -- @param table path The path to clear out all overrides on.
-function TTT2NET:RemoveOverridesGlobal(path)
+function TTT2NET.RemoveOverridesGlobal(path)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -310,16 +310,16 @@ function TTT2NET:RemoveOverridesGlobal(path)
 	-- Add the prefix for the correct table
 	table.insert(tmpPath, 1, "global")
 
-	self:RemoveOverrides(tmpPath)
+	TTT2NET.RemoveOverrides(tmpPath)
 end
 
 ---
 -- This will be used to clear out all client specific overrides for a path on a player/entity object, so that only the
 -- default value is set. This will also prepend the needed keywords to the path, otherwise
--- it will do the same as {@TTT2NET:RemoveOverrides}.
+-- it will do the same as {@TTT2NET.RemoveOverrides}.
 --
 -- @param table path The path to clear out all overrides on.
-function TTT2NET:RemoveOverridesOnPlayer(path, ply)
+function TTT2NET.RemoveOverridesOnPlayer(path, ply)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -333,7 +333,7 @@ function TTT2NET:RemoveOverridesOnPlayer(path, ply)
 	table.insert(tmpPath, 1, "players")
 	table.insert(tmpPath, 2, ply:EntIndex())
 
-	self:RemoveOverrides(tmpPath)
+	TTT2NET.RemoveOverrides(tmpPath)
 end
 
 ---
@@ -344,7 +344,7 @@ end
 -- @param any|table path The path to get the value from
 -- @param Entity|nil client The client/entity to get the value for
 -- @return any|nil The value found at the given path
-function TTT2NET:Get(path, client)
+function TTT2NET.Get(path, client)
 	local clientId = client and client:EntIndex() or nil
 	local tmpPath
 
@@ -369,7 +369,7 @@ end
 -- @param any|table path The path to get the value from
 -- @param Entity|nil client The client/entity to get the value for
 -- @return any|nil The value that a client knows
-function TTT2NET:GetWithOverride(path, client)
+function TTT2NET.GetWithOverride(path, client)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -399,12 +399,12 @@ end
 
 ---
 -- Returns the currently saved value for a given path.
--- This will do the same as {@TTT2NET:Get} but will first prepend the "global" keyword to the path.
+-- This will do the same as {@TTT2NET.Get} but will first prepend the "global" keyword to the path.
 --
 -- @param any|table path The path to get the value from
 -- @param Entity|nil client The client/entity to get the value for
 -- @return any|nil The value for the given path
-function TTT2NET:GetGlobal(path, client)
+function TTT2NET.GetGlobal(path, client)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -417,18 +417,18 @@ function TTT2NET:GetGlobal(path, client)
 	-- Add the prefix for the correct table
 	table.insert(tmpPath, 1, "global")
 
-	return self:Get(tmpPath, client)
+	return TTT2NET.Get(tmpPath, client)
 end
 
 ---
--- This is used to set a value in the data table for a specific path and works the same as {@TTT2NET:Set},
+-- This is used to set a value in the data table for a specific path and works the same as {@TTT2NET.Set},
 -- but it will prepend the "global" keyword to the path.
 --
 -- @param any|table path The path to set the data for
 -- @param table|nil meta The metadata for the path
 -- @param any value The value to save
 -- @param Entity|nil client The client/entity to set this value for (overrides the default value)
-function TTT2NET:SetGlobal(path, meta, value, client)
+function TTT2NET.SetGlobal(path, meta, value, client)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -441,11 +441,11 @@ function TTT2NET:SetGlobal(path, meta, value, client)
 	-- Add the prefix for the correct table
 	table.insert(tmpPath, 1, "global")
 
-	self:Set(tmpPath, meta, value, client)
+	TTT2NET.Set(tmpPath, meta, value, client)
 end
 
 ---
--- This is used to set a value in the data table for a specific path on a specific player/entity and works the same as {@TTT2NET:Set},
+-- This is used to set a value in the data table for a specific path on a specific player/entity and works the same as {@TTT2NET.Set},
 -- but it will prepend the needed keywords to the path.
 --
 -- @param any|table path The path to set the data for
@@ -453,7 +453,7 @@ end
 -- @param any value The value to save
 -- @param Entity ply The player/entity that this data is associated to
 -- @param Entity|nil client The client/entity to set this value for (as an override for the default value)
-function TTT2NET:SetOnPlayer(path, meta, value, ply, client)
+function TTT2NET.SetOnPlayer(path, meta, value, ply, client)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -467,18 +467,18 @@ function TTT2NET:SetOnPlayer(path, meta, value, ply, client)
 	table.insert(tmpPath, 1, "players")
 	table.insert(tmpPath, 2, ply:EntIndex())
 
-	self:Set(tmpPath, meta, value, client)
+	TTT2NET.Set(tmpPath, meta, value, client)
 end
 
 ---
 -- Returns the currently saved value for a given path on a specific player.
--- This will do the same as {@TTT2NET:Get} but will first prepend the needed keywords to the path.
+-- This will do the same as {@TTT2NET.Get} but will first prepend the needed keywords to the path.
 --
 -- @param any|table path The path to get the value from
 -- @param Entity ply The client/entity to save the value on
 -- @param Entity|nil client The client/entity to get the value for
 -- @return any|nil The value for the given path
-function TTT2NET:GetOnPlayer(path, ply, client)
+function TTT2NET.GetOnPlayer(path, ply, client)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -492,12 +492,12 @@ function TTT2NET:GetOnPlayer(path, ply, client)
 	table.insert(tmpPath, 1, "players")
 	table.insert(tmpPath, 2, ply:EntIndex())
 
-	return self:Get(tmpPath, client)
+	return TTT2NET.Get(tmpPath, client)
 end
 
 ---
 -- Prints out all TTT2NET related tables, for debugging purposes.
-function TTT2NET:Debug()
+function TTT2NET.Debug()
 	print("[TTT2NET] Debug:")
 	print("Initialized clients:")
 	PrintTable(initialized_clients)
@@ -514,7 +514,7 @@ end
 -- initialized clients.
 --
 -- @param any|table path The path to send a metadata update for
-function TTT2NET:SendMetaDataUpdate(path)
+function TTT2NET.SendMetaDataUpdate(path)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -530,8 +530,8 @@ function TTT2NET:SendMetaDataUpdate(path)
 	-- Write meta data
 	net.Start(TTT2NET.NETMSG_META_UPDATE)
 
-	self:NetWritePath(tmpPath)
-	self:NetWriteMetaData(metadata)
+	TTT2NET.NetWritePath(tmpPath)
+	TTT2NET.NetWriteMetaData(metadata)
 
 	net.Send(initialized_clients)
 end
@@ -546,7 +546,7 @@ end
 -- @param Entity client The client/entity to clear all overrides for
 -- @param table curTable This is the current metadata table. This should start with the complete metadata table, otherwise the path has to be adjusted, see the description.
 -- @param table|nil path The current path to the curTable based on the root of the data table
-function TTT2NET:RemoveOverridesForClient(client, curTable, path)
+function TTT2NET.RemoveOverridesForClient(client, curTable, path)
 	local tmpPath = not istable(path) and { path } or path and table.Copy(path) or {}
 
 	-- Visit all keys in the current tree
@@ -558,10 +558,10 @@ function TTT2NET:RemoveOverridesForClient(client, curTable, path)
 		-- Check if we reached a leaf node (a node with metadata)
 		if nextNode.type then
 			-- Remove the override from this key
-			self:Set(nextPath, nil, nil, client)
+			TTT2NET.Set(nextPath, nil, nil, client)
 		else
 			-- Descend a level deeper
-			self:RemoveOverridesForClient(client, curTable[key], nextPath)
+			TTT2NET.RemoveOverridesForClient(client, curTable[key], nextPath)
 		end
 	end
 end
@@ -570,16 +570,16 @@ end
 -- This will reset all known data for a client and remove all entries related to this client.
 --
 -- @param Entity client The client to remove
-function TTT2NET:ResetClient(client)
+function TTT2NET.ResetClient(client)
 	assert(IsEntity(client), "[TTT2NET] ResetClient() client is not a valid Entity!")
 
 	table.RemoveByValue(initialized_clients, client)
 
 	-- Clear up the player specific data table
-	self:SetMetaDataOnPlayer(nil, nil, client)
+	TTT2NET.SetMetaDataOnPlayer(nil, nil, client)
 
 	-- Clear up all left over overrides
-	self:RemoveOverridesForClient(client, data_store_metadata)
+	TTT2NET.RemoveOverridesForClient(client, data_store_metadata)
 end
 
 ---
@@ -587,7 +587,7 @@ end
 --
 -- @param any|table path The path to send the update for
 -- @param Player|table|nil client The client/list of clients or nil to send this to all knwon clients
-function TTT2NET:SendDataUpdate(path, client)
+function TTT2NET.SendDataUpdate(path, client)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -610,12 +610,12 @@ function TTT2NET:SendDataUpdate(path, client)
 	-- For each receiver send the data
 	for i = 1, #receivers do
 		local receiver = receivers[i]
-		local value = self:GetWithOverride(tmpPath, receiver)
+		local value = TTT2NET.GetWithOverride(tmpPath, receiver)
 
 		net.Start(TTT2NET.NETMSG_DATA_UPDATE)
 
-		self:NetWritePath(tmpPath)
-		self:NetWriteData(metadata, value)
+		TTT2NET.NetWritePath(tmpPath)
+		TTT2NET.NetWriteData(metadata, value)
 
 		net.Send(receiver)
 	end
@@ -631,7 +631,7 @@ end
 -- @param Entity client The client/entity to get the data for
 -- @param table curTable This is the current metadata table. This should start with the complete metadata table, otherwise the path has to be adjusted, see the description.
 -- @param table|nil path The current path to the curTable based on the root of the data table
-function TTT2NET:DataTableWithOverrides(client, curTable, path)
+function TTT2NET.DataTableWithOverrides(client, curTable, path)
 	local tmpPath = not istable(path) and { path } or path and table.Copy(path) or {}
 	local newTable = table.Copy(curTable)
 
@@ -645,10 +645,10 @@ function TTT2NET:DataTableWithOverrides(client, curTable, path)
 		-- Check if we reached a leaf node (a node with metadata)
 		if nextNode.type then
 			-- Replace the metadata with the data
-			newTable[key] = self:GetWithOverride(nextPath, client)
+			newTable[key] = TTT2NET.GetWithOverride(nextPath, client)
 		else
 			-- Descend a level deeper
-			newTable[key] = self:DataTableWithOverrides(client, curTable[key], nextPath)
+			newTable[key] = TTT2NET.DataTableWithOverrides(client, curTable[key], nextPath)
 		end
 	end
 
@@ -661,7 +661,7 @@ end
 -- @note This will also set all reveivers as initialized.
 --
 -- @param Player|table|nil client The client/list of clients or nil for all known clients, to send the update to
-function TTT2NET:SendFullStateUpdate(client)
+function TTT2NET.SendFullStateUpdate(client)
 	-- Wrap the given receivers to a table
 	local receivers = istable(client) and client or client and { client } or initialized_clients
 
@@ -670,7 +670,7 @@ function TTT2NET:SendFullStateUpdate(client)
 		local receiver = receivers[i]
 		local data = {
 			meta = data_store_metadata,
-			data = self:DataTableWithOverrides(receiver, data_store_metadata)
+			data = TTT2NET.DataTableWithOverrides(receiver, data_store_metadata)
 		}
 
 		net.SendStream(TTT2NET.NET_STREAM_FULL_STATE_UPDATE, data, receiver)
@@ -692,7 +692,7 @@ end
 local function ClientRequestFullStateUpdate(len, client)
 	print("[TTT2NET] Client " .. (client:Nick() or "unknown") .. " requested a full state update.")
 
-	TTT2NET:SendFullStateUpdate(client)
+	TTT2NET.SendFullStateUpdate(client)
 end
 net.Receive(TTT2NET.NETMSG_REQUEST_FULL_STATE_UPDATE, ClientRequestFullStateUpdate)
 
@@ -700,7 +700,7 @@ net.Receive(TTT2NET.NETMSG_REQUEST_FULL_STATE_UPDATE, ClientRequestFullStateUpda
 -- This is used to write a path table to the current network message.
 --
 -- @param table path The path table to send
-function TTT2NET:NetWritePath(path)
+function TTT2NET.NetWritePath(path)
 	net.WriteString(pon.encode(path))
 end
 
@@ -708,7 +708,7 @@ end
 -- This is used to write a metadata table to the current network message.
 --
 -- @param table metadata The metadata to send
-function TTT2NET:NetWriteMetaData(metadata)
+function TTT2NET.NetWriteMetaData(metadata)
 	local isMetadataNil = metadata == nil
 
 	net.WriteBool(isMetadataNil)
@@ -731,7 +731,7 @@ end
 --
 -- @param table metadata The metadata for the given value
 -- @param any|nil val The value to send, can also be nil
-function TTT2NET:NetWriteData(metadata, val)
+function TTT2NET.NetWriteData(metadata, val)
 	-- Check if the value is nil, to also allow setting a value to nil
 	local isValNil = val == nil
 
@@ -758,7 +758,7 @@ function TTT2NET:NetWriteData(metadata, val)
 end
 
 local function NWVarProxyCallback(ent, name, oldval, newval, path, meta)
-	TTT2NET:Set(path, meta, newval)
+	TTT2NET.Set(path, meta, newval)
 end
 
 ---
@@ -775,7 +775,7 @@ end
 -- @param table|nil meta The metadata
 -- @param Entity nwent The entity that this NWVar is saved on
 -- @param string nwkey The key of the NWVar
-function TTT2NET:SyncWithNWVar(path, meta, nwent, nwkey)
+function TTT2NET.SyncWithNWVar(path, meta, nwent, nwkey)
 	local tmpPath
 
 	-- Convert path with single key to table
@@ -794,7 +794,7 @@ function TTT2NET:SyncWithNWVar(path, meta, nwent, nwkey)
 	assert(metadata, "[TTT2NET] SyncWithNWVar() called but no metadata entry or metadata parameter found!")
 
 	-- Set the meta data, this will only send / update if the meta data has changed
-	self:SetMetaData(tmpPath, metadata)
+	TTT2NET.SetMetaData(tmpPath, metadata)
 
 	nwent:SetNWVarProxy(nwkey, function (ent, name, oldval, newval)
 		NWVarProxyCallback(ent, name, oldval, newval, tmpPath, metadata)
@@ -814,7 +814,7 @@ function TTT2NET:SyncWithNWVar(path, meta, nwent, nwkey)
 		curval = nwent:GetNWString(nwkey)
 	end
 
-	TTT2NET:Set(tmpPath, metadata, curval)
+	TTT2NET.Set(tmpPath, metadata, curval)
 
 	-- Get all registered nwvars
 	local nwvars = table.GetWithPath(data_synced_nwvars, tmpPath) or {}
@@ -840,7 +840,7 @@ local plymeta = assert(FindMetaTable("Player"), "[TTT2NET] FAILED TO FIND PLAYER
 -- @param any|table path The path to set the value for
 -- @param bool|nil value The value to set
 function plymeta:TTT2NETSetBool(path, value)
-	TTT2NET:SetOnPlayer(path, { type = "bool" }, value, self)
+	TTT2NET.SetOnPlayer(path, { type = "bool" }, value, self)
 end
 
 ---
@@ -850,7 +850,7 @@ end
 -- @param int|nil value The value to set
 -- @param int|nil bits The bits that this int needs to be stored (optional, otherwise a default of 32 is used)
 function plymeta:TTT2NETSetInt(path, value, bits)
-	TTT2NET:SetOnPlayer(path, {
+	TTT2NET.SetOnPlayer(path, {
 		type = "int",
 		bits = bits
 	}, value, self)
@@ -863,7 +863,7 @@ end
 -- @param uint|nil value The value to set
 -- @param int|nil bits The bits that this int needs to be stored (optional, otherwise a default of 32 is used)
 function plymeta:TTT2NETSetUInt(path, value, bits)
-	TTT2NET:SetOnPlayer(path, {
+	TTT2NET.SetOnPlayer(path, {
 		type = "int",
 		unsigned = true,
 		bits = bits
@@ -876,7 +876,7 @@ end
 -- @param any|table path The path to set the value for
 -- @param float|nil value The value to set
 function plymeta:TTT2NETSetFloat(path, value)
-	TTT2NET:SetOnPlayer(path, { type = "float" }, value, self)
+	TTT2NET.SetOnPlayer(path, { type = "float" }, value, self)
 end
 
 ---
@@ -885,5 +885,5 @@ end
 -- @param any|table path The path to set the value for
 -- @param string|nil value The value to set
 function plymeta:TTT2NETSetString(path, value)
-	TTT2NET:SetOnPlayer(path, { type = "string" }, value, self)
+	TTT2NET.SetOnPlayer(path, { type = "string" }, value, self)
 end

--- a/gamemodes/terrortown/gamemode/server/sv_player.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player.lua
@@ -55,7 +55,7 @@ function GM:PlayerInitialSpawn(ply)
 
 	-- Sync NWVars
 	-- Needs to be done here, to include bots (also this wont send any net messages to the initialized player)
-	TTT2NET.SyncWithNWVar("body_found", { type = "bool" }, ply, "body_found")
+	ttt2net.SyncWithNWVar("body_found", { type = "bool" }, ply, "body_found")
 
 	-- maybe show credits
 	net.Start("TTT2DevChanges")
@@ -654,7 +654,7 @@ function GM:PlayerDisconnected(ply)
 		KARMA.Remember(ply)
 	end
 
-	TTT2NET.ResetClient(ply)
+	ttt2net.ResetClient(ply)
 end
 
 ---

--- a/gamemodes/terrortown/gamemode/server/sv_player.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player.lua
@@ -55,7 +55,7 @@ function GM:PlayerInitialSpawn(ply)
 
 	-- Sync NWVars
 	-- Needs to be done here, to include bots (also this wont send any net messages to the initialized player)
-	TTT2NET:SyncWithNWVar("body_found", { type = "bool" }, ply, "body_found")
+	TTT2NET.SyncWithNWVar("body_found", { type = "bool" }, ply, "body_found")
 
 	-- maybe show credits
 	net.Start("TTT2DevChanges")
@@ -654,7 +654,7 @@ function GM:PlayerDisconnected(ply)
 		KARMA.Remember(ply)
 	end
 
-	TTT2NET:ResetClient(ply)
+	TTT2NET.ResetClient(ply)
 end
 
 ---

--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -1317,7 +1317,7 @@ local function SetPlayerReady(_, ply)
 	ply.isReady = true
 
 	-- Send full state update to client
-	TTT2NET:SendFullStateUpdate(ply)
+	TTT2NET.SendFullStateUpdate(ply)
 
 	hook.Run("TTT2PlayerReady", ply)
 end

--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -1317,7 +1317,7 @@ local function SetPlayerReady(_, ply)
 	ply.isReady = true
 
 	-- Send full state update to client
-	TTT2NET.SendFullStateUpdate(ply)
+	ttt2net.SendFullStateUpdate(ply)
 
 	hook.Run("TTT2PlayerReady", ply)
 end

--- a/gamemodes/terrortown/gamemode/shared/hud_elements/tttminiscoreboard/pure_skin_miniscoreboard.lua
+++ b/gamemodes/terrortown/gamemode/shared/hud_elements/tttminiscoreboard/pure_skin_miniscoreboard.lua
@@ -46,7 +46,7 @@ if CLIENT then
 		hudelements.RegisterChildRelation(self.id, "pure_skin_roundinfo", false)
 
 		-- resort miniscoreboard if body_found is changed
-		TTT2NET:OnUpdate("players", function(oldval, newval, reversePath)
+		TTT2NET.OnUpdate("players", function(oldval, newval, reversePath)
 			-- check if path of changed value is one of our releavant paths
 			if not refreshPaths[reversePath[2]] then return end
 

--- a/gamemodes/terrortown/gamemode/shared/hud_elements/tttminiscoreboard/pure_skin_miniscoreboard.lua
+++ b/gamemodes/terrortown/gamemode/shared/hud_elements/tttminiscoreboard/pure_skin_miniscoreboard.lua
@@ -46,7 +46,7 @@ if CLIENT then
 		hudelements.RegisterChildRelation(self.id, "pure_skin_roundinfo", false)
 
 		-- resort miniscoreboard if body_found is changed
-		TTT2NET.OnUpdate("players", function(oldval, newval, reversePath)
+		ttt2net.OnUpdate("players", function(oldval, newval, reversePath)
 			-- check if path of changed value is one of our releavant paths
 			if not refreshPaths[reversePath[2]] then return end
 

--- a/gamemodes/terrortown/gamemode/shared/sh_network_sync.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_network_sync.lua
@@ -2,15 +2,15 @@
 -- This file contains all shared networking functions, to sync and manage the information between server and clients
 -- @author saibotk
 
-TTT2NET = {}
+ttt2net = {}
 
 -- Network message name constants
-TTT2NET.NETMSG_META_UPDATE = "TTT2_NET_META_UPDATE"
-TTT2NET.NETMSG_DATA_UPDATE = "TTT2_NET_DATA_UPDATE"
-TTT2NET.NETMSG_REQUEST_FULL_STATE_UPDATE = "TTT2_NET_REQUEST_FULL_STATE_UPDATE"
+ttt2net.NETMSG_META_UPDATE = "TTT2_NET_META_UPDATE"
+ttt2net.NETMSG_DATA_UPDATE = "TTT2_NET_DATA_UPDATE"
+ttt2net.NETMSG_REQUEST_FULL_STATE_UPDATE = "TTT2_NET_REQUEST_FULL_STATE_UPDATE"
 
 -- Network stream message name constants
-TTT2NET.NET_STREAM_FULL_STATE_UPDATE = "TTT2_NET_STREAM_FULL_STATE_UPDATE"
+ttt2net.NET_STREAM_FULL_STATE_UPDATE = "TTT2_NET_STREAM_FULL_STATE_UPDATE"
 
 ---
 -- Player extensions
@@ -24,7 +24,7 @@ local plymeta = assert(FindMetaTable("Player"), "[TTT2NET] FAILED TO FIND PLAYER
 -- @param any|nil fallback The fallback value to return instead of nil
 -- @return bool|any|nil The value at the path or fallback if the value is nil
 function plymeta:TTT2NETGetBool(path, fallback)
-	return TTT2NET.GetOnPlayer(path, self) == true or fallback
+	return ttt2net.GetOnPlayer(path, self) == true or fallback
 end
 
 ---
@@ -34,7 +34,7 @@ end
 -- @param number fallback The fallback value to return instead of nil
 -- @return number The value at the path or fallback if the value is nil
 function plymeta:TTT2NETGetInt(path, fallback)
-	return tonumber(TTT2NET.GetOnPlayer(path, self) or fallback)
+	return tonumber(ttt2net.GetOnPlayer(path, self) or fallback)
 end
 
 ---
@@ -44,7 +44,7 @@ end
 -- @param number fallback The fallback value to return instead of nil
 -- @return number The value at the path or fallback if the value is nil
 function plymeta:TTT2NETGetUInt(path, fallback)
-	return tonumber(TTT2NET.GetOnPlayer(path, self) or fallback)
+	return tonumber(ttt2net.GetOnPlayer(path, self) or fallback)
 end
 
 ---
@@ -54,7 +54,7 @@ end
 -- @param number fallback The fallback value to return instead of nil
 -- @return number The value at the path or fallback if the value is nil
 function plymeta:TTT2NETGetFloat(path, fallback)
-	return tonumber(TTT2NET.GetOnPlayer(path, self) or fallback)
+	return tonumber(ttt2net.GetOnPlayer(path, self) or fallback)
 end
 
 ---
@@ -64,5 +64,5 @@ end
 -- @param string fallback The fallback value to return instead of nil
 -- @return string The value at the path or fallback if the value is nil
 function plymeta:TTT2NETGetString(path, fallback)
-	return tostring(TTT2NET.GetOnPlayer(path, self) or fallback)
+	return tostring(ttt2net.GetOnPlayer(path, self) or fallback)
 end

--- a/gamemodes/terrortown/gamemode/shared/sh_network_sync.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_network_sync.lua
@@ -24,7 +24,7 @@ local plymeta = assert(FindMetaTable("Player"), "[TTT2NET] FAILED TO FIND PLAYER
 -- @param any|nil fallback The fallback value to return instead of nil
 -- @return bool|any|nil The value at the path or fallback if the value is nil
 function plymeta:TTT2NETGetBool(path, fallback)
-	return TTT2NET:GetOnPlayer(path, self) == true or fallback
+	return TTT2NET.GetOnPlayer(path, self) == true or fallback
 end
 
 ---
@@ -34,7 +34,7 @@ end
 -- @param number fallback The fallback value to return instead of nil
 -- @return number The value at the path or fallback if the value is nil
 function plymeta:TTT2NETGetInt(path, fallback)
-	return tonumber(TTT2NET:GetOnPlayer(path, self) or fallback)
+	return tonumber(TTT2NET.GetOnPlayer(path, self) or fallback)
 end
 
 ---
@@ -44,7 +44,7 @@ end
 -- @param number fallback The fallback value to return instead of nil
 -- @return number The value at the path or fallback if the value is nil
 function plymeta:TTT2NETGetUInt(path, fallback)
-	return tonumber(TTT2NET:GetOnPlayer(path, self) or fallback)
+	return tonumber(TTT2NET.GetOnPlayer(path, self) or fallback)
 end
 
 ---
@@ -54,7 +54,7 @@ end
 -- @param number fallback The fallback value to return instead of nil
 -- @return number The value at the path or fallback if the value is nil
 function plymeta:TTT2NETGetFloat(path, fallback)
-	return tonumber(TTT2NET:GetOnPlayer(path, self) or fallback)
+	return tonumber(TTT2NET.GetOnPlayer(path, self) or fallback)
 end
 
 ---
@@ -64,5 +64,5 @@ end
 -- @param string fallback The fallback value to return instead of nil
 -- @return string The value at the path or fallback if the value is nil
 function plymeta:TTT2NETGetString(path, fallback)
-	return tostring(TTT2NET:GetOnPlayer(path, self) or fallback)
+	return tostring(TTT2NET.GetOnPlayer(path, self) or fallback)
 end


### PR DESCRIPTION
This removes the unnecessary self reference caused by `TTT2NET:FUNCTIONNAME`.

Another thing we may discuss, is to whether or not rename the module to its lowercase name `ttt2net` but I'm unsure, as this really looks weird. So please let me know what you think!