### PR TITLE
Adjust CLSCORE to fix clipping title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
   - there's now a popup queue
   - popups are now also shown to dead players as well
 - Refactored the role selection code to reside in its own module and cleaned up the code
+- Refactored some internal functions in CLSCORE to prevent errors (thanks @Kefta)
 
 ### Fixed
 
@@ -56,6 +57,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed map lock/unlock trigger of doors not updating targetID
 - Fixed roles having sometimes the wrong radar color
 - Fixed miniscoreboard update issue and players not getting shown when entering force-spec mode
+- Fixed the CLSCORE window being too small for large winning team titles (will now adjust on demand)
 
 ## [v0.6.4b](https://github.com/TTT-2/TTT2/tree/v0.6.4b) (2020-04-03)
 

--- a/gamemodes/terrortown/gamemode/client/cl_scoring.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_scoring.lua
@@ -45,6 +45,8 @@ surface.CreateFont("WinHuge", {
 	extended = true
 })
 
+local titleBackgroundColor = Color(50, 50, 50, 255)
+
 -- so much text here I'm using shorter names than usual
 local T = LANG.GetTranslation
 local PT = LANG.GetParamTranslation
@@ -509,6 +511,7 @@ end
 function CLSCORE:BuildTitle(wintype)
 	-- wintype can be both a WIN_ var or the team name directly, so we need to convert it to a teamname
 	local winnerTeam = TEAM_INNOCENT
+
 	if wintype == WIN_TIMELIMIT or wintype == WIN_INNOCENT then
 		winnerTeam = TEAM_INNOCENT
 	elseif wintype == WIN_TRAITOR then
@@ -520,7 +523,7 @@ function CLSCORE:BuildTitle(wintype)
 			Text = "hilite_win_bees",
 			BoxColor = TEAMS[TEAM_INNOCENT].color,
 			TextColor = COLOR_WHITE,
-			BackgroundColor = Color(50, 50, 50, 255)
+			BackgroundColor = titleBackgroundColor
 		}
 	elseif isstring(wintype) then
 		winnerTeam = wintype
@@ -530,7 +533,7 @@ function CLSCORE:BuildTitle(wintype)
 		Text = "hilite_win_" .. winnerTeam,
 		BoxColor = TEAMS[winnerTeam].color,
 		TextColor = COLOR_WHITE,
-		BackgroundColor = Color(50, 50, 50, 255)
+		BackgroundColor = titleBackgroundColor
 	}
 end
 
@@ -563,8 +566,6 @@ function CLSCORE:ShowPanel()
 	-- size the panel based on the win text w/ 88px horizontal padding and 44px veritcal padding
 	surface.SetFont("WinHuge")
 	local w, h = surface.GetTextSize(T(title.Text))
-
-	MsgN("Calculated width of text = " .. w)
 
 	-- w + padding (100) + DPropertySheet padding (8) + winlbl padding (30) + offset margin (margin * 2) + size margin (margin)
 	w, h = math.max(700, w + 138 + margin * 3), 500
@@ -729,8 +730,8 @@ function CLSCORE:Init(events)
 	local tms = nil
 	local scores = {}
 	local nicks = {}
-
 	local game, selected, spawn = false, false, false
+
 	for i = 1, #events do
 		local e = events[i]
 


### PR DESCRIPTION
This implements the changes made by Kefta in https://github.com/Facepunch/garrysmod/pull/1677

The code is adjusted at some points to work with TTT2 and is not exactly the same.

Thank you @Kefta for letting us use this code and your contribution!

As a reference, this is the original commit message from Keftas commit:
- The CLSCORE panel now adjusts its width to the win text, fixing clipping with some languages (https://github.com/Facepunch/garrysmod/pull/1672). This required moving the win calculations to ``CLSCORE:ShowPanel`` from ``CLSCORE:BuildHilitePanel``
- ``CLSCORE:BuildHilitePanel(Panel base)`` -> ``CLSCORE:BuildHilitePanel(Panel base, WinTitle /*See definition at the bottom*/ title, Number starttime, Number endtime)``
- Changed Error calls to error as Error is no longer halting (https://github.com/Facepunch/garrysmod-issues/issues/2113)
- pairs loops of ``CLSCORE.Events`` are now numeric-for loops to make sure no stray string keys are considered
- Changed a usage of ``type`` to ``TypeID`` - using type is not safe for checking userdata types since the ``MetaName`` key of its metatable affects the output
- ``ValidAward`` now checks the types of its members instead of verifying they are simply non-nil
- ``CLSCORE:ShowPanel`` now deletes the last panel instead of creating a duplicate
- ``CLSCORE:ClearPanel`` now properly checks panel validity before trying to remove it
- Merged two loops over the event table in ``CLSCORE:Init``. Events with no traitor or detective tables no longer error from there
- Some hardcoded tables and colors are now members of CLSCORE so addons can modify them without overriding the whole system. These new members include:
-- Array<values = String> ``CLSCORE.ScorePanelNames``
-- Color ``CLSCORE.ScorePanelColor``
-- Table<keys = Number, values = WinTitle> ``CLSCORE.WinTypes``. This must have a string key ``Default`` pointing to a default WinTitle with all keys provided. WinTitle is defined as a Table<keys = String> {[String] ``Text`` /* Will be translated */, [Color] ``BoxColor``, [Color] ``TextColor``, [Color] ``BackgroundColor``}. All keys are optional and will fall back to the ``Default`` WinTitle table if not specified.