### PR TITLE
fixed door grouping

### DIFF
--- a/lua/ttt2/libraries/door.lua
+++ b/lua/ttt2/libraries/door.lua
@@ -54,7 +54,7 @@ local valid_doors = {
 local function GetClosedAngle(ent)
 	local data = ent:GetInternalVariable("m_angRotationClosed")
 
-	if not data then return end
+	if not data or #data < 3 then return end
 
 	return Angle(data[1], data[2], data[3])
 end
@@ -72,11 +72,11 @@ local function FindPair(ent)
 		local ang1 = GetClosedAngle(ent)
 		local ang2 = GetClosedAngle(foundEnt)
 
-		if not isangle(ang1) or not isangle(ang2) then continue end
+		if not ang1 or not ang2 then continue end
 
 		ang1:Normalize()
 
-		ang2:Add(Angle(0, 180, 0))
+		ang2.y = ang2.y + 180
 		ang2:Normalize()
 
 		if ang1 ~= ang2 then continue end

--- a/lua/ttt2/libraries/door.lua
+++ b/lua/ttt2/libraries/door.lua
@@ -51,6 +51,14 @@ local valid_doors = {
 	}
 }
 
+local function GetClosedAngle(ent)
+	local data = ent:GetInternalVariable("m_angRotationClosed")
+
+	if not data then return end
+
+	return Angle(data[1], data[2], data[3])
+end
+
 local function FindPair(ent)
 	local entsTable = ents.FindInSphere(ent:GetPos(), 94)
 
@@ -60,8 +68,18 @@ local function FindPair(ent)
 		-- a door can't be a pair with itself
 		if foundEnt == ent or foundEnt:GetClass() ~= ent:GetClass() then continue end
 
-		-- both doors are probably no pair if they have the same rotation
-		if ent:GetInternalVariable("m_angRotationClosed") == foundEnt:GetInternalVariable("m_angRotationClosed") then continue end
+		-- both doors are only a pair if they have mirrored angles
+		local ang1 = GetClosedAngle(ent)
+		local ang2 = GetClosedAngle(foundEnt)
+
+		if not isangle(ang1) or not isangle(ang2) then continue end
+
+		ang1:Normalize()
+
+		ang2:Add(Angle(0, 180, 0))
+		ang2:Normalize()
+
+		if ang1 ~= ang2 then continue end
 
 		return foundEnt
 	end


### PR DESCRIPTION
fixed double door grouping (#542). Previously I falsely simplified it to only group doors that don't have the same default rotation. Now only doors with inverted default rotation are grouped.