### PR TITLE
Adjust CLSCORE to use the new stream net functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
   - popups are now also shown to dead players as well
 - Refactored the role selection code to reside in its own module and cleaned up the code
 - Refactored some internal functions in CLSCORE to prevent errors (thanks @Kefta)
+- Moved CLSCORE event report syncing to the new net.SendStream / net.ReceiveStream functions
 
 ### Fixed
 

--- a/gamemodes/terrortown/gamemode/client/cl_scoring.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_scoring.lua
@@ -788,38 +788,15 @@ function CLSCORE:Toggle()
 	end
 end
 
-local buff = ""
-
-local function ReceiveReportStream(len)
-	local cont = net.ReadBit() == 1
-
-	buff = buff .. net.ReadString()
-
-	if cont then
-		return
+local function ReceiveReportStream(events)
+	if istable(events) then
+		table.SortByMember(events, "t", true)
+		CLSCORE:ReportEvents(events)
 	else
-		-- do stuff with buffer contents
-
-		local json_events = buff -- util.Decompress(buff)
-
-		if not json_events then
-			ErrorNoHalt("Round report decompression failed!\n")
-		else
-			-- convert the json string back to a table
-			local events = util.JSONToTable(json_events)
-
-			if istable(events) then
-				CLSCORE:ReportEvents(events)
-			else
-				ErrorNoHalt("Round report event decoding failed!\n")
-			end
-		end
-
-		-- flush
-		buff = ""
+		ErrorNoHalt("Round report event decoding failed!\n")
 	end
 end
-net.Receive("TTT_ReportStream", ReceiveReportStream)
+net.ReceiveStream("TTT2_EventReport", ReceiveReportStream)
 
 local function SaveLog(ply, cmd, args)
 	if not CLSCORE then return end

--- a/gamemodes/terrortown/gamemode/server/sv_scoring.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_scoring.lua
@@ -277,6 +277,7 @@ function SCORE:ApplyEventLogScores(wintype)
 
 	-- count deaths
 	local events = self.Events
+
 	for i = 1, #events do
 		local e = events[i]
 		if e.id == EVENT_KILL then

--- a/gamemodes/terrortown/gamemode/server/sv_scoring.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_scoring.lua
@@ -320,7 +320,7 @@ function SCORE:Reset()
 end
 
 ---
--- Steams the events list to all available @{Player}s
+-- Streams the events list to all available @{Player}s
 -- @realm server
 function SCORE:StreamToClients()
 	net.SendStream("TTT2_EventReport", self.Events)

--- a/gamemodes/terrortown/gamemode/server/sv_scoring.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_scoring.lua
@@ -280,6 +280,7 @@ function SCORE:ApplyEventLogScores(wintype)
 
 	for i = 1, #events do
 		local e = events[i]
+
 		if e.id == EVENT_KILL then
 			local victim = player.GetBySteamID64(e.vic.sid64)
 


### PR DESCRIPTION
This PR roughly adopts https://github.com/Facepunch/garrysmod/pull/1678
but uses the stream functions of TTT2 instead.

It moves the old custom implemented event stream to our new net.SendStream and net.ReceiveStream methods and removes now unused code / comments.
This also adjusts the events to store their exact date and other values, according to the PR linked above, as they can also now be sent without any problems (even though we are not relying on the Json function and are using pON instead).