### PR TITLE
Doors: Move destruction to next frame to avoid "area portals"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ## Unreleased
 
+### Added
+
+### Changed
+
+### Fixed
+
+- Fixed area portals on servers for destroyed doors
+
 ## [v0.7.1b](https://github.com/TTT-2/TTT2/tree/v0.7.1b) (2020-06-02)
 
 ### Fixed

--- a/gamemodes/terrortown/gamemode/shared/sh_door.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_door.lua
@@ -329,6 +329,8 @@ if SERVER then
 		end
 
 		timer.Simple(0, function()
+			if not IsValid(self) or not IsValid(doorProp) then return end
+
 			-- we have to kill the entity here instead of removing it because this way we
 			-- have no problems with area portals (invisible rooms after door is destroyed)
 			self:Fire("Kill", "", 0)

--- a/gamemodes/terrortown/gamemode/shared/sh_door.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_door.lua
@@ -319,27 +319,29 @@ if SERVER then
 		-- before the entity is killed, we have to trigger a door opening
 		self:OpenDoor()
 
-		-- we have to kill the entity here instead of removing it because this way we
-		-- have no problems with area portals (invisible rooms after door is destroyed)
-		self:Fire("Kill", "", 0)
-
 		-- set flag that this door is destroyed to prevent multiple prop spawns in case
 		-- this function is called multiple times for the same door in the same tick
 		self.isDestroyed = true
-
-		DamageLog("TTT2Doors: The door with the index " .. self:EntIndex() .. " has been destroyed.")
-
-		doorProp:Spawn()
-		doorProp:SetHealth(cvDoorPropHealth:GetInt())
-
-		doorProp.isDoorProp = true
-
-		doorProp:GetPhysicsObject():ApplyForceCenter(pushForce or Vector(0, 0, 0))
 
 		-- if the door is grouped as a pair, call the other one as well
 		if not surpressPair and IsValid(self.otherPairDoor) then
 			self.otherPairDoor:SafeDestroyDoor(pushForce, true)
 		end
+
+		timer.Simple(0, function()
+			-- we have to kill the entity here instead of removing it because this way we
+			-- have no problems with area portals (invisible rooms after door is destroyed)
+			self:Fire("Kill", "", 0)
+
+			DamageLog("TTT2Doors: The door with the index " .. self:EntIndex() .. " has been destroyed.")
+
+			doorProp:Spawn()
+			doorProp:SetHealth(cvDoorPropHealth:GetInt())
+
+			doorProp.isDoorProp = true
+
+			doorProp:GetPhysicsObject():ApplyForceCenter(pushForce or Vector(0, 0, 0))
+		end)
 
 		return doorProp
 	end


### PR DESCRIPTION
fixed problems with area portals on dedicated servers by adding a zero seconds timer.