### PR TITLE
TargetID: Added hooks for modification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 - Added Hooks to the targetID system to modify the displayed data
   - `GM:TTTModifyTargetedEntity(ent, distance)`: Modify the entity that is targeted. This is useful for addons like an "Identity Disguiser".
-  - `GM:TTTModifyTargetTracestart(startpos, endpos)`: Modify the start and enpos for a trace. This is useful for addons like the "Supersheep".
 - Added Hooks to interact with door destruction
   - `GM:TTT2BlockDoorDestruction(doorEntity, activator)`: Hook to block the door destruction.
   - `GM:TTT2DoorDestroyed(doorPropEntity, activator)`: Hook that is called after the door is destroyed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ## Unreleased
 
+### Added
+
+- Added Hooks to the targetID system to modify the displayed data
+  - `GM:TTTModifyTargetedEntity(ent, distance)`: Modify the entity that is targeted. This is useful for addons like an "Identity Disguiser".
+  - `GM:TTTModifyTargetTracestart(startpos, endpos)`: Modify the start and enpos for a trace. This is useful for addons like the "Supersheep".
+
+### Changed
+
+### Fixed
+
 ## [v0.7.1b](https://github.com/TTT-2/TTT2/tree/v0.7.1b) (2020-06-02)
 
 ### Fixed

--- a/gamemodes/terrortown/gamemode/client/cl_target_data.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_target_data.lua
@@ -28,6 +28,14 @@ function TARGET_DATA:GetEntity()
 end
 
 ---
+-- Returns the entity before it was modified by @{GM:TTTModifyTargetedEntity}.
+-- @return nil|Entity The focused entity, nil if it wasn't modified
+-- @realm client
+function TARGET_DATA:GetUnchangedEntity()
+	return self.data.unchangedEnt
+end
+
+---
 -- Returns the distance to the focused entity
 -- @return number The distance to the focused entity
 -- @realm client

--- a/gamemodes/terrortown/gamemode/client/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_targetid.lua
@@ -243,14 +243,7 @@ function GM:HUDDrawTargetID()
 	endpos:Mul(MAX_TRACE_LENGTH)
 	endpos:Add(startpos)
 
-	local changedStartpos, changedEndpos = hook.Run("TTTModifyTargetTracedata", startpos, endpos)
-
-	if isvector(changedStartpos) and isvector(changedEndpos) then
-		startpos = changedStartpos
-		endpos = changedEndpos
-	end
-
-	local ent, distance
+	local ent, unchangedEnt, distance
 
 	-- if the user is looking at a traitor button, it should always be handled with priority
 	if TBHUD.focus_but and IsValid(TBHUD.focus_but.ent) and (TBHUD.focus_but.access or TBHUD.focus_but.admin) and TBHUD.focus_stick >= CurTime() then
@@ -279,7 +272,12 @@ function GM:HUDDrawTargetID()
 	-- only add onscreen infos when the entity isn't the local player
 	if ent == client then return end
 
-	ent = hook.Run("TTTModifyTargetedEntity", ent, distance) or ent
+	local changedEnt = hook.Run("TTTModifyTargetedEntity", ent, distance)
+
+	if IsValid(changedEnt) then
+		unchangedEnt = ent
+		ent = changedEnt
+	end
 
 	-- make sure it is a valid entity
 	if not IsValid(ent) or ent.NoTarget then return end
@@ -287,6 +285,7 @@ function GM:HUDDrawTargetID()
 	-- combine data into a table to read them inside a hook
 	local data = {
 		ent = ent,
+		unchangedEnt = unchangedEnt,
 		distance = distance
 	}
 

--- a/gamemodes/terrortown/gamemode/client/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_targetid.lua
@@ -274,7 +274,7 @@ function GM:HUDDrawTargetID()
 
 	local changedEnt = hook.Run("TTTModifyTargetedEntity", ent, distance)
 
-	if IsValid(changedEnt) then
+	if changedEnt then
 		unchangedEnt = ent
 		ent = changedEnt
 	end

--- a/gamemodes/terrortown/gamemode/client/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_targetid.lua
@@ -239,6 +239,12 @@ function GM:HUDDrawTargetID()
 
 	local startpos = client:EyePos()
 
+	local changedStartpos = hook.Run("TTTModifyTargetTracestart", startpos)
+
+	if isvector(changedStartpos) then
+		startpos = changedStartpos
+	end
+
 	local endpos = client:GetAimVector()
 	endpos:Mul(MAX_TRACE_LENGTH)
 	endpos:Add(startpos)
@@ -274,6 +280,12 @@ function GM:HUDDrawTargetID()
 
 	-- only add onscreen infos when the entity isn't the local player
 	if ent == client then return end
+
+	local changedEnt = hook.Run("TTTModifyTargetedEntity", ent, distance)
+
+	if IsValid(changedEnt) then
+		ent = changedEnt
+	end
 
 	-- combine data into a table to read them inside a hook
 	local data = {
@@ -445,11 +457,32 @@ function GM:HUDDrawTargetID()
 end
 
 ---
--- Add targetID info to a focused entity
+-- Add targetID info to a focused entity.
 -- @param @{TARGET_DATA} tData The @{TARGET_DATA} data object which contains all information
 -- @hook
 -- @realm client
 function GM:TTTRenderEntityInfo(tData)
+
+end
+
+---
+-- Change the focused entity used for targetID.
+-- @param Entity ent The focuces entity that should be changed
+-- @param number distance The distance to the focused entity
+-- @return Entity The new entity to replace the real one
+-- @hook
+-- @realm client
+function GM:TTTModifyTargetedEntity(ent, distance)
+
+end
+
+---
+-- Change the starting position for the trace that looks for entites.
+-- @param Vector startpos The current startpos of the trace to find an entity
+-- @return Vector The new startpos for the trace
+-- @hook
+-- @realm client
+function GM:TTTModifyTargetTracestart(startpos)
 
 end
 

--- a/gamemodes/terrortown/gamemode/client/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_targetid.lua
@@ -271,18 +271,18 @@ function GM:HUDDrawTargetID()
 		distance = trace.StartPos:Distance(trace.HitPos)
 	end
 
-	ent = hook.Run("TTTModifyTargetedEntity", ent, distance) or ent
-
-	-- make sure it is a valid entity
-	if not IsValid(ent) or ent.NoTarget then return end
-
 	-- if a vehicle, we identify the driver instead
-	if IsValid(ent:GetNWEntity("ttt_driver", nil)) then
+	if IsValid(ent) and IsValid(ent:GetNWEntity("ttt_driver", nil)) then
 		ent = ent:GetNWEntity("ttt_driver", nil)
 	end
 
 	-- only add onscreen infos when the entity isn't the local player
 	if ent == client then return end
+
+	ent = hook.Run("TTTModifyTargetedEntity", ent, distance) or ent
+
+	-- make sure it is a valid entity
+	if not IsValid(ent) or ent.NoTarget then return end
 
 	-- combine data into a table to read them inside a hook
 	local data = {

--- a/gamemodes/terrortown/gamemode/client/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_targetid.lua
@@ -238,16 +238,17 @@ function GM:HUDDrawTargetID()
 	end
 
 	local startpos = client:EyePos()
-
-	local changedStartpos = hook.Run("TTTModifyTargetTracestart", startpos)
-
-	if isvector(changedStartpos) then
-		startpos = changedStartpos
-	end
-
 	local endpos = client:GetAimVector()
+
 	endpos:Mul(MAX_TRACE_LENGTH)
 	endpos:Add(startpos)
+
+	local changedStartpos, changedEndpos = hook.Run("TTTModifyTargetTracedata", startpos, endpos)
+
+	if isvector(changedStartpos) and isvector(changedEndpos) then
+		startpos = changedStartpos
+		endpos = changedEndpos
+	end
 
 	local ent, distance
 
@@ -479,10 +480,11 @@ end
 ---
 -- Change the starting position for the trace that looks for entites.
 -- @param Vector startpos The current startpos of the trace to find an entity
--- @return Vector The new startpos for the trace
+-- @param Vector endpos The current endpos of the trace to find an entity
+-- @return Vector, Vector The new startpos for the trace, the new endpos for the trace
 -- @hook
 -- @realm client
-function GM:TTTModifyTargetTracestart(startpos)
+function GM:TTTModifyTargetTracedata(startpos, endpos)
 
 end
 

--- a/gamemodes/terrortown/gamemode/client/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_targetid.lua
@@ -271,6 +271,8 @@ function GM:HUDDrawTargetID()
 		distance = trace.StartPos:Distance(trace.HitPos)
 	end
 
+	ent = hook.Run("TTTModifyTargetedEntity", ent, distance) or ent
+
 	-- make sure it is a valid entity
 	if not IsValid(ent) or ent.NoTarget then return end
 
@@ -281,12 +283,6 @@ function GM:HUDDrawTargetID()
 
 	-- only add onscreen infos when the entity isn't the local player
 	if ent == client then return end
-
-	local changedEnt = hook.Run("TTTModifyTargetedEntity", ent, distance)
-
-	if IsValid(changedEnt) then
-		ent = changedEnt
-	end
 
 	-- combine data into a table to read them inside a hook
 	local data = {


### PR DESCRIPTION
Added two hooks to modify the targetID base data.

`GM:TTTModifyTargetedEntity(ent, distance)`: Modify the entity that is targeted. This is useful for addons like an "Identity Disguiser".