### PR TITLE
added door hooks

### DIFF
--- a/gamemodes/terrortown/gamemode/shared/sh_door.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_door.lua
@@ -294,12 +294,15 @@ if SERVER then
 	-- prop. Furthermore it makes sure that the door will not leave a unrendered room behind
 	-- (problems with area portals). If it is a double door, both doors will be destroyed by
 	-- default.
+	-- @param Player ply The player that wants to destroy the door
 	-- @param[default=Vector(0, 0, 0)] Vector pushForce The push force for the door
 	-- @param[default=false] boolean surpressPair Should the call of the other door (if in a pair) be omitted?
 	-- @return Entity Returns the entity of the created prop
 	-- @realm server
-	function entmeta:SafeDestroyDoor(pushForce, surpressPair)
+	function entmeta:SafeDestroyDoor(ply, pushForce, surpressPair)
 		if self.isDestroyed or not self:PlayerCanOpenDoor() or not door.IsValidNormal(self:GetClass()) then return end
+
+		if hook.Run("TTT2BlockDoorDestruction", self, ply) then return end
 
 		-- if door is destroyed, spawn a prop in the world
 		local doorProp = ents.Create("prop_physics")
@@ -327,7 +330,11 @@ if SERVER then
 		-- this function is called multiple times for the same door in the same tick
 		self.isDestroyed = true
 
-		DamageLog("TTT2Doors: The door with the index " .. self:EntIndex() .. " has been destroyed.")
+		if IsValid(ply) and ply:IsPlayer() then
+			DamageLog("TTT2Doors: The door with the index " .. self:EntIndex() .. " has been destroyed by " .. ply:Nick() .. ".")
+		else
+			DamageLog("TTT2Doors: The door with the index " .. self:EntIndex() .. " has been destroyed.")
+		end
 
 		doorProp:Spawn()
 		doorProp:SetHealth(cvDoorPropHealth:GetInt())
@@ -338,8 +345,10 @@ if SERVER then
 
 		-- if the door is grouped as a pair, call the other one as well
 		if not surpressPair and IsValid(self.otherPairDoor) then
-			self.otherPairDoor:SafeDestroyDoor(pushForce, true)
+			self.otherPairDoor:SafeDestroyDoor(ply, pushForce, true)
 		end
+
+		hook.Run("TTT2DoorDestroyed", doorProp, ply)
 
 		return doorProp
 	end

--- a/lua/ttt2/libraries/door.lua
+++ b/lua/ttt2/libraries/door.lua
@@ -411,22 +411,23 @@ if SERVER then
 		if not ent:DoorIsDestructible() then return end
 
 		local damage = math.max(0, dmginfo:GetDamage())
-
-		ent:SetHealth(ent:Health() - damage)
-		ent:SetNWInt("fast_sync_health", ent:Health())
+		local health = ent:Health() - damage
 
 		-- if the door is grouped as a pair, call the other one as well
 		if not surpressPair and IsValid(ent.otherPairDoor) then
 			door.HandleDamage(ent.otherPairDoor, dmginfo, true)
 		end
 
-		if ent:Health() > 0 then return end
+		if health <= 0 then
+			-- capping the force factor is sufficient because
+			-- the forward vector is normalized
+			local forceFactor = math.min(50000, 500 * damage)
 
-		-- capping the force factor is sufficient because
-		-- the forward vector is normalized
-		local forceFactor = math.min(50000, 500 * damage)
+			if not ent:SafeDestroyDoor(dmginfo:GetAttacker(), forceFactor * dmginfo:GetAttacker():GetForward(), true) then return end
+		end
 
-		ent:SafeDestroyDoor(forceFactor * dmginfo:GetAttacker():GetForward(), true)
+		ent:SetHealth(health)
+		ent:SetNWInt("fast_sync_health", health)
 	end
 
 	---
@@ -632,6 +633,16 @@ if SERVER then
 	end
 
 	---
+	-- This hook is called after the door is destroyed and the door prop is spawned.
+	-- @param Entity doorPropEntity The door prop entity that is created
+	-- @param Entity activator The activator entity
+	-- @hook
+	-- @realm server
+	function GM:TTT2DoorDestroyed(doorPropEntity, activator)
+
+	end
+
+	---
 	-- This hook is called when the door is about to be locked. You can cancel the event.
 	-- @param Entity doorEntity The door entity
 	-- @param Entity activator The activator entity
@@ -676,6 +687,17 @@ if SERVER then
 	-- @hook
 	-- @realm server
 	function GM:TTT2BlockDoorClose(doorEntity, activator, caller)
+
+	end
+
+	---
+	-- This hook is called when the door is about to be destroyed. You can cancel the event.
+	-- @param Entity doorEntity The door entity
+	-- @param Entity activator The activator entity
+	-- @return boolean Return true to cancel the door destruction
+	-- @hook
+	-- @realm server
+	function GM:TTT2BlockDoorDestruction(doorEntity, activator)
 
 	end
 end


### PR DESCRIPTION
Added two door hooks as requested by @TheNickSkater.

`GM:TTT2BlockDoorDestruction(doorEntity, activator)`: Hook to block the door destruction.

`GM:TTT2DoorDestroyed(doorPropEntity, activator)`: Hook that is called after the door is destroyed.