### PR TITLE
Disguiser: Rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ### Changed
 
+- Moved the disguiser icon to the status system to be only displayed when the player is actually disguised
+
 ### Fixed
 
 - Fixed inno subrole upgrading if many roles are installed

--- a/gamemodes/terrortown/gamemode/client/cl_keys.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_keys.lua
@@ -172,16 +172,3 @@ function GM:KeyRelease(ply, key)
 		UpdateInputSprint(ply, key, false)
 	end
 end
-
----
--- Called when a player releases a button.
--- @param Player ply @{Player} who released the button
--- @param number btn The button, see
--- <a href="https://wiki.garrysmod.com/page/Enums/BUTTON_CODE">BUTTON_CODE_Enums</a>
--- @hook
--- @realm client
--- @ref https://wiki.facepunch.com/gmod/GM:PlayerButtonUp
--- @local
-function GM:PlayerButtonUp(ply, btn)
-
-end

--- a/gamemodes/terrortown/gamemode/client/cl_keys.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_keys.lua
@@ -183,11 +183,5 @@ end
 -- @ref https://wiki.facepunch.com/gmod/GM:PlayerButtonUp
 -- @local
 function GM:PlayerButtonUp(ply, btn)
-	if not IsFirstTimePredicted() then return end
 
-	-- Would be nice to clean up this whole "all key handling in massive
-	-- functions" thing. oh well
-	if btn == KEY_PAD_ENTER then
-		WEPS.DisguiseToggle(ply)
-	end
 end

--- a/gamemodes/terrortown/gamemode/client/cl_lang.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_lang.lua
@@ -474,11 +474,6 @@ local styledmessages = {
 		"tele_marked"
 	},
 
-	chat_plain = { -- TODO move to disguiser
-		"disg_turned_on",
-		"disg_turned_off"
-	},
-
 	chat_warn = { -- TODO move to teleporter
 		"tele_no_ground",
 		"tele_no_crouch",

--- a/gamemodes/terrortown/gamemode/client/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_targetid.lua
@@ -49,6 +49,7 @@ local icon_tid_auto_close = Material("vgui/ttt/tid/tid_auto_close")
 local materialDoor = Material("vgui/ttt/tid/tid_big_door")
 local materialDestructible = Material("vgui/ttt/tid/tid_destructible")
 local icon_tid_dna = Material("vgui/ttt/dnascanner/dna_hud")
+local materialDisguised = Material("vgui/ttt/perks/hud_disguiser.png")
 
 ---
 -- Returns the localized ClassHint table
@@ -767,8 +768,9 @@ function HUDDrawTargetIDPlayers(tData)
 	local h_string, h_color = util.HealthToString(ent:Health(), ent:GetMaxHealth())
 
 	tData:SetTitle(
-		ent:Nick() .. " " .. (disguised and string.upper(TryT("target_disg")) or ""),
-		disguised and COLOR_RED or nil
+		ent:Nick() .. " " .. (disguised and TryT("target_disg") or ""),
+		disguised and COLOR_ORANGE or nil,
+		disguised and {materialDisguised}
 	)
 
 	tData:SetSubtitle(

--- a/gamemodes/terrortown/gamemode/shared/lang/english.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/english.lua
@@ -611,7 +611,7 @@ L.corpse_too_far_away = "The corpse is too far away."
 L.corpse_binoculars = "Press [{key}] to search corpse with binoculars."
 L.corpse_searched_by_detective = "This corpse was searched by a detective"
 
-L.target_disg = "disguised"
+L.target_disg = "(disguised)"
 L.target_unid = "Unidentified body"
 
 L.target_credits = "Search to receive unspent credits"
@@ -648,10 +648,6 @@ L.tbut_admin_mode_only = "Only visible to you because you're an admin and '{cv}'
 L.tbut_allow = "Allow"
 L.tbut_prohib = "Prohibit"
 L.tbut_default = "Default"
-
--- Equipment info lines (on the left above the health/ammo panel)
-L.disg_hud = "Disguised. Your name is hidden."
-L.radar_hud = "Radar ready for next scan in: {time}"
 
 -- Spectator muting of living/dead
 L.mute_living = "Living players muted"
@@ -1296,9 +1292,12 @@ L.hud_revival_time = "{time}s"
 -- 2020-05-03
 L.door_destructible = "Door is destructible ({health}HP)"
 
---2020-05-28
+-- 2020-05-28
 L.confirm_detective_only = "Only detectives can confirm bodies"
 L.inspect_detective_only = "Only detectives can inspect bodies"
 L.corpse_hint_no_inspect = "Only detectives can search this body."
 L.corpse_hint_inspect_only = "Press [{usekey}] to search. Only detectives can confirm the body."
 L.corpse_hint_inspect_only_credits = "Press [{usekey}] to receive credits. Only detectives can search this body."
+
+-- 2020-06-04
+L.label_bind_disguiser = "Toggle disguiser"

--- a/gamemodes/terrortown/gamemode/shared/lang/german.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/german.lua
@@ -1291,4 +1291,4 @@ L.corpse_hint_inspect_only = "Drücke [{usekey}] zum Durchsuchen. Nur Detektive 
 L.corpse_hint_inspect_only_credits = "Drücke [{usekey}] zum Erhalten der Credits. Nur ein Detektiv kann diesen Körper untersuchen."
 
 -- 2020-06-04
-L.label_bind_disguiser = "Schalte Tarnung"
+L.label_bind_disguiser = "Tarnung umschalten"

--- a/gamemodes/terrortown/gamemode/shared/lang/german.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/german.lua
@@ -603,7 +603,7 @@ L.corpse_too_far_away = "Leiche zu weit weg zum Untersuchen."
 L.corpse_binoculars = "Drücke [{key}] um Leiche mit Fernglas zu untersuchen."
 L.corpse_searched_by_detective = "Diese Leiche wurde von einem Detektiv untersucht"
 
-L.target_disg = "Getarnt"
+L.target_disg = "(Getarnt)"
 L.target_unid = "Unidentifizierter Körper"
 
 L.target_credits = "Durchsuche, um ungenutzte Credits zu erhalten."
@@ -640,10 +640,6 @@ L.tbut_admin_mode_only = "Nur sichtbar für dich, da du ein Admin bist und '{cv}
 L.tbut_allow = "Erlaubt"
 L.tbut_prohib = "Verboten"
 L.tbut_default = "Standard"
-
--- Equipment info lines (on the left above the health/ammo panel)
-L.disg_hud = "Getarnt. Dein Name ist ausgeblendet."
-L.radar_hud = "Radar bereit für nächsten Scan in: {time}"
 
 -- Spectator muting of living/dead
 L.mute_living = "Lebende stumm gestellt"
@@ -1287,9 +1283,12 @@ L.hud_revival_time = "{time}s"
 -- 2020-05-03
 L.door_destructible = "Tür ist zerstörbar ({health}HP)"
 
---2020-05-28
+-- 2020-05-28
 L.confirm_detective_only = "Nur Detektive können Leichen bestätigen"
 L.inspect_detective_only = "Nur Detektive können Leichen untersuchen"
 L.corpse_hint_no_inspect = "Nur ein Detektiv kann diesen Körper untersuchen."
 L.corpse_hint_inspect_only = "Drücke [{usekey}] zum Durchsuchen. Nur Detektive können diesen Körper bestätigen."
 L.corpse_hint_inspect_only_credits = "Drücke [{usekey}] zum Erhalten der Credits. Nur ein Detektiv kann diesen Körper untersuchen."
+
+-- 2020-06-04
+L.label_bind_disguiser = "Schalte Tarnung"

--- a/gamemodes/terrortown/gamemode/shared/lang/italian.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/italian.lua
@@ -639,7 +639,7 @@ L.karma_min = "Irresponsabile"
 L.corpse = "Cadavere"
 L.corpse_hint = "Premi {usekey} per identificare. {walkkey} + {usekey} per identificare segretamente."
 
-L.target_disg = "(TRAVESTITO)"
+L.target_disg = "(travestito)"
 L.target_unid = "Corpo non identificato"
 
 L.target_traitor = "TRADITORE"
@@ -653,11 +653,6 @@ L.tbut_single = "Uso singolo"
 L.tbut_reuse = "Riutilizzabile"
 L.tbut_retime = "Riutilizzabile dopo {num} secondi"
 L.tbut_help = "Premi {key} per attivare"
-
--- Stringhe di informazione sull'equipaggiamento (sulla sinistra sopra il pannello di vita/munizioni)
--- Equipment info lines (on the left above the health/ammo panel)
-L.disg_hud = "Travestito. Il tuo nome è nascosto."
-L.radar_hud = "Radar pronto per il prossima scansione tra: {time}"
 
 -- Spettatori che mutano vivi/morti
 -- Spectator muting of living/dead
@@ -1301,9 +1296,12 @@ L.item_no_drown_damage_desc = [[Ti rende immune al danno da affogamento.]]
 -- 2020-05-03
 L.door_destructible = "La porta è distruttibile ({health}HP)"
 
---2020-05-28
+-- 2020-05-28
 --L.confirm_detective_only = "Only detectives can confirm bodies"
 --L.inspect_detective_only = "Only detectives can inspect bodies"
 --L.corpse_hint_no_inspect = "Only detectives can search this body."
 --L.corpse_hint_inspect_only = "Press [{usekey}] to serch. Only detectives can confirm the body."
 --L.corpse_hint_inspect_only_credits = "Press [{usekey}] to receive credits. Only detectives can search this body."
+
+-- 2020-06-04
+--L.label_bind_disguiser = "Toggle disguiser"

--- a/gamemodes/terrortown/gamemode/shared/lang/polish.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/polish.lua
@@ -619,7 +619,7 @@ L.corpse_too_far_away = "Ciało jest za daleko."
 L.corpse_binoculars = "Press [{key}] to search corpse with binoculars."
 L.corpse_searched_by_detective = "Te ciało przeszukał detektyw"
 
-L.target_disg  = " (PRZEBRANY)"
+L.target_disg  = "(przebrany)"
 L.target_unid  = "Niezidentyfikowane ciało"
 
 L.target_credits = "Przeszukaj, aby otrzymywać niewykorzystane kredyty"
@@ -656,10 +656,6 @@ L.tbut_admin_mode_only = "Only visible to you because you're an admin and '{cv}'
 L.tbut_allow = "Pozwól"
 L.tbut_prohib = "Zabroń"
 L.tbut_default = "Domyślne"
-
--- Equipment info lines (on the left above the health/ammo panel)
-L.disg_hud     = "Przebrałeś się. Twoje imię jest ukryte."
-L.radar_hud    = "Radar będzie gotowy do nowego skanu: {time}"
 
 -- Spectator muting of living/dead
 L.mute_living = "Living players muted"
@@ -1250,9 +1246,12 @@ L.hud_health = "Zdrowie"
 -- 2020-05-03
 --L.door_destructible = "Door is destructible ({health}HP)"
 
---2020-05-28
+-- 2020-05-28
 --L.confirm_detective_only = "Only detectives can confirm bodies"
 --L.inspect_detective_only = "Only detectives can inspect bodies"
 --L.corpse_hint_no_inspect = "Only detectives can search this body."
 --L.corpse_hint_inspect_only = "Press [{usekey}] to serch. Only detectives can confirm the body."
 --L.corpse_hint_inspect_only_credits = "Press [{usekey}] to receive credits. Only detectives can search this body."
+
+-- 2020-06-04
+--L.label_bind_disguiser = "Toggle disguiser"

--- a/gamemodes/terrortown/gamemode/shared/lang/russian.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/russian.lua
@@ -609,7 +609,7 @@ L.corpse_too_far_away = "Тело слишком далеко."
 L.corpse_binoculars = "[{key}]: осмотреть тело через Бинокль."
 L.corpse_searched_by_detective = "Это тело осмотрено детективом."
 
-L.target_disg = "под маскировкой"
+L.target_disg = "(под маскировкой)"
 L.target_unid = "Неопознанное тело"
 
 L.target_traitor = "ПРЕДАТЕЛЬ"
@@ -638,10 +638,6 @@ L.tbut_single = "Одноразовое использование."
 L.tbut_reuse = "Многоразовое использование."
 L.tbut_retime = "Можно использовать повторно через {num} сек."
 L.tbut_help = "Нажмите [{usekey}], чтобы активировать."
-
--- Equipment info lines (on the left above the health/ammo panel)
-L.disg_hud = "Вы замаскированы. Информация о вас скрыта."
-L.radar_hud = "Радар перезарядиться через {time}"
 
 -- Spectator muting of living/dead
 L.mute_living = "Заглушены: живые"
@@ -1242,9 +1238,12 @@ L.disable_overheadicons_tip = "Выключает иконки ролей над
 -- 2020-05-03
 --L.door_destructible = "Door is destructible ({health}HP)"
 
---2020-05-28
+-- 2020-05-28
 --L.confirm_detective_only = "Only detectives can confirm bodies"
 --L.inspect_detective_only = "Only detectives can inspect bodies"
 --L.corpse_hint_no_inspect = "Only detectives can search this body."
 --L.corpse_hint_inspect_only = "Press [{usekey}] to serch. Only detectives can confirm the body."
 --L.corpse_hint_inspect_only_credits = "Press [{usekey}] to receive credits. Only detectives can search this body."
+
+-- 2020-06-04
+L.label_bind_disguiser = "Toggle disguiser"

--- a/gamemodes/terrortown/gamemode/shared/lang/russian.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/russian.lua
@@ -1246,4 +1246,4 @@ L.disable_overheadicons_tip = "Выключает иконки ролей над
 --L.corpse_hint_inspect_only_credits = "Press [{usekey}] to receive credits. Only detectives can search this body."
 
 -- 2020-06-04
-L.label_bind_disguiser = "Toggle disguiser"
+--L.label_bind_disguiser = "Toggle disguiser"

--- a/gamemodes/terrortown/gamemode/shared/sh_weaponry.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_weaponry.lua
@@ -51,3 +51,10 @@ function WEPS.DisguiseToggle(ply)
 	end
 end
 concommand.Add("ttt_toggle_disguise", WEPS.DisguiseToggle)
+
+if CLIENT then
+	bind.Register("ttt2_disguiser_toggle", function()
+		WEPS.DisguiseToggle(LocalPlayer())
+	end,
+	nil, "TTT2 Bindings", "label_bind_disguiser", KEY_PAD_ENTER)
+end

--- a/lua/terrortown/entities/items/item_ttt_disguiser.lua
+++ b/lua/terrortown/entities/items/item_ttt_disguiser.lua
@@ -9,7 +9,6 @@ if SERVER then
 	AddCSLuaFile()
 end
 
-ITEM.hud = Material("vgui/ttt/perks/hud_disguiser.png")
 ITEM.EquipMenuData = {
 	type = "item_active",
 	name = "item_disg",
@@ -60,33 +59,6 @@ if CLIENT then
 		return dform
 	end
 
-	---
-	-- Draws the disguise info on screen for the disguised @{Player}
-	-- @param Player client the client
-	-- @realm client
-	function DISGUISE.Draw(client)
-		if not client or not client:IsActive() or not client:GetNWBool("disguised", false) then return end
-
-		trans = trans or LANG.GetTranslation
-
-		surface.SetFont("TabLarge")
-		surface.SetTextColor(255, 0, 0, 230)
-
-		local text = trans("disg_hud")
-		local _, h = surface.GetTextSize(text)
-
-		surface.SetTextPos(36, ScrH() - 160 - h)
-		surface.DrawText(text)
-	end
-
-	hook.Add("HUDPaint", "TTTItemDisguiser", function()
-		local client = LocalPlayer()
-
-		if client:Alive() and client:Team() ~= TEAM_SPEC and hook.Call("HUDShouldDraw", GAMEMODE, "TTTDisguise") then
-			DISGUISE.Draw(client)
-		end
-	end)
-
 	hook.Add("TTTEquipmentTabs", "TTTItemDisguiser", function(dsheet)
 		trans = trans or LANG.GetTranslation
 
@@ -96,7 +68,16 @@ if CLIENT then
 
 		dsheet:AddSheet(trans("disg_name"), ddisguise, "icon16/user.png", false, false, trans("equip_tooltip_disguise"))
 	end)
-else
+
+	hook.Add("Initialize", "TTTItemDisguiserInitStatus", function()
+		STATUS:RegisterStatus("item_disguiser_status", {
+			hud = Material("vgui/ttt/perks/hud_disguiser.png"),
+			type = "good"
+		})
+	end)
+end
+
+if SERVER then
 	local function SetDisguise(ply, cmd, args)
 		if not IsValid(ply) or not ply:IsActive() and ply:HasTeam(TEAM_TRAITOR) then return end
 
@@ -108,7 +89,19 @@ else
 
 		ply:SetNWBool("disguised", state)
 
-		LANG.Msg(ply, state and "disg_turned_on" or "disg_turned_off")
+		LANG.Msg(ply, state and "disg_turned_on" or "disg_turned_off", nil, MSG_MSTACK_ROLE)
 	end
 	concommand.Add("ttt_set_disguise", SetDisguise)
+
+	hook.Add("TTT2PlayerReady", "TTTItemDisguiserPlayerReady", function(ply)
+		ply:SetNWVarProxy("disguised", function(ent, name, old, new)
+			if not IsValid(ent) or not ent:IsPlayer() or name ~= "disguised" then return end
+
+			if new then
+				STATUS:AddStatus(ent, "item_disguiser_status")
+			else
+				STATUS:RemoveStatus(ent, "item_disguiser_status")
+			end
+		end)
+	end)
 end


### PR DESCRIPTION
Cleaned up the disguiser code and moved the icon to the status system. This way it is only displayed while the player is disguised to remove the redudancy with the text displayed ob top of the HUD.