### PR TITLE
DNA Scanner HUDElement Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed and improved the radar role/team modification hook
 - Fixed area portals on servers for destroyed doors
 - Fixed revive fail function reference reset
+- Removed the DNA Scanner hudelement for spectators
 
 ## [v0.7.1b](https://github.com/TTT-2/TTT2/tree/v0.7.1b) (2020-06-02)
 

--- a/gamemodes/terrortown/gamemode/shared/hud_elements/tttdnascanner/pure_skin_dnascanner.lua
+++ b/gamemodes/terrortown/gamemode/shared/hud_elements/tttdnascanner/pure_skin_dnascanner.lua
@@ -40,8 +40,9 @@ if CLIENT then
 
 	function HUDELEMENT:ShouldDraw()
 		local client = LocalPlayer()
+		local scanner = client:GetWeapon("weapon_ttt_wtester")
 
-		return HUDEditor.IsEditing or IsValid(client:GetActiveWeapon()) and client:GetActiveWeapon():GetClass() == "weapon_ttt_wtester" and client:Alive()
+		return HUDEditor.IsEditing or IsValid(scanner) and client:GetActiveWeapon() == scanner and client:Alive()
 	end
 
 	function HUDELEMENT:PerformLayout()


### PR DESCRIPTION
The hudelement isn't visible for spectators anymore, which removes inconsistencies with the network syncing when spectating a player, who holds a DNA scanner

Addresses possibly the bug mentioned in #569