### PR TITLE
ITEMS: Moved legacy item initialization to items module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Moved the disguiser icon to the status system to be only displayed when the player is actually disguised
 - Reworked the addonchecker and added a command to execute the checker at a later point
 - Updated Italian translation (Thanks @ThePlatinumGhost)
+- Moved legacy item initialization to the `items` module (`items.MigrateLegacyItems()`)
 
 ### Fixed
 

--- a/gamemodes/terrortown/gamemode/client/cl_main.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_main.lua
@@ -153,6 +153,9 @@ function GM:InitPostEntity()
 
 	hook.Run("TTTInitPostEntity")
 
+	items.MigrateLegacyItems()
+	items.OnLoaded()
+
 	HUDManager.LoadAllHUDS()
 	HUDManager.SetHUD()
 

--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -298,6 +298,9 @@ function GM:InitPostEntity()
 
 	hook.Run("TTTInitPostEntity")
 
+	items.MigrateLegacyItems()
+	items.OnLoaded()
+
 	InitDefaultEquipment()
 
 	local itms = items.GetList()

--- a/gamemodes/terrortown/gamemode/shared/sh_item_module.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_item_module.lua
@@ -51,67 +51,9 @@ for i = 1, #itemsFolders do
 		end
 	end
 
-
 	items.Register(ITEM, folder)
 
 	ITEM = nil
 end
 
 ITEM = oldITEM
-
--- Initialize old items and convert them to the new item system
-hook.Add("TTTInitPostEntity", "InitTTT2OldItems", function()
-	for subrole, tbl in pairs(EquipmentItems or {}) do
-		for i = 1, #tbl do
-			local v = tbl[i]
-
-			if v.avoidTTT2 then continue end
-
-			local name = v.ClassName or v.name or WEPS.GetClass(v)
-			if not name then continue end
-
-			local item = items.GetStored(GetEquipmentFileName(name))
-			if not item then
-				local ITEMDATA = table.Copy(v)
-				ITEMDATA.oldId = v.id
-				ITEMDATA.id = name
-				ITEMDATA.EquipMenuData = v.EquipMenuData or {
-					type = v.type,
-					name = v.name,
-					desc = v.desc
-				}
-				ITEMDATA.type = nil
-				ITEMDATA.desc = nil
-				ITEMDATA.name = name
-				ITEMDATA.material = v.material
-				ITEMDATA.CanBuy = { [subrole] = subrole }
-				ITEMDATA.limited = v.limited or v.LimitedStock or true
-
-				-- reset this old hud bool
-				if ITEMDATA.hud == true then
-					ITEMDATA.oldHud = true
-					ITEMDATA.hud = nil
-				end
-
-				-- set the converted indicator
-				ITEMDATA.converted = true
-
-				-- don't add icon and desc to the search panel if it's not intended
-				ITEMDATA.noCorpseSearch = ITEMDATA.noCorpseSearch or true
-
-				items.Register(ITEMDATA, GetEquipmentFileName(name))
-
-				timer.Simple(0, function()
-					if not ITEMDATA then return end
-
-					print("[TTT2][INFO] Automatically converted not adjusted ITEM", name, ITEMDATA.oldId)
-				end)
-			else
-				item.CanBuy = item.CanBuy or {}
-				item.CanBuy[subrole] = subrole
-			end
-		end
-	end
-
-	items.OnLoaded() -- init baseclasses
-end)


### PR DESCRIPTION
In this change, the function to initialize legacy items is now properly contained inside the items module and is called directly in the respective InitPostEntity functions on the client / server, instead of using the hook. 

This also removes the timer delay for migration messages, as there should not be any difference. 
Closes #547