### PR TITLE
Roleselection: Do not reseed the RNG just before role selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Removed the DNA Scanner hudelement for spectators
 - Fixed a rare clientside error that happens if a player connects in the moment the preparing time just started
 - Fixed the image in the confirmation notification whenever a bot's corpse gets identified
+- Fixed bad role selection due to RNG reseeding
 
 ## [v0.7.1b](https://github.com/TTT-2/TTT2/tree/v0.7.1b) (2020-06-02)
 

--- a/gamemodes/terrortown/gamemode/server/sv_roleselection.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_roleselection.lua
@@ -440,9 +440,6 @@ end
 -- @param ?number maxPlys amount of maximum @{Player}s. `nil` to calculate automatically
 -- @realm server
 function roleselection.SelectRoles(plys, maxPlys)
-	-- ensure a decent amount of randomness
-	math.randomseed(os.time())
-
 	roleselection.selectableRoles = nil -- reset to enable recalculation
 
 	GAMEMODE.LastRole = GAMEMODE.LastRole or {}


### PR DESCRIPTION
This leads to extremely bad RNG as the first numbers generated from
seed values that are close together are not random enough. This leads to
similar or identical role selection, especially for low player counts.

More details in this write up:
https://gist.github.com/JustHev/42c5fc970bb75ddb17e8128a5c29ef98