### PR TITLE
Cleanup: Move round state hooks & remove hook add

### DIFF
--- a/gamemodes/terrortown/gamemode/client/cl_main.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_main.lua
@@ -342,29 +342,6 @@ local function ttt_print_playercount()
 end
 concommand.Add("ttt_print_playercount", ttt_print_playercount)
 
----
--- A hook that is called when the preparation phase starts.
--- @hook
--- @realm client
-function GM:TTTPrepareRound()
-
-end
-
----
--- A hook that is called when the round begins.
--- @hook
--- @realm client
-function GM:TTTBeginRound()
-
-end
-
--- A hook that is called when the round ends.
--- @hook
--- @realm client
-function GM:TTTEndRound()
-
-end
-
 -- usermessages
 
 local function ReceiveRole()

--- a/gamemodes/terrortown/gamemode/shared/sh_init.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_init.lua
@@ -634,14 +634,6 @@ DefaultEquipment = {
 BUYTABLE = BUYTABLE or {}
 TEAMBUYTABLE = TEAMBUYTABLE or {}
 
-hook.Add("TTTPrepareRound", "TTT2SharedPrepareRound", function()
-	BUYTABLE = {}
-	TEAMBUYTABLE = {}
-
-	math.randomseed(os.time())
-	math.random(); math.random(); math.random() -- warming up
-end)
-
 ---
 -- Checks whether an equipment is buyable
 -- @param table tbl equipment table

--- a/gamemodes/terrortown/gamemode/shared/sh_main.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_main.lua
@@ -227,6 +227,30 @@ function GM:Tick()
 end
 
 ---
+-- A hook that is called when the preparation phase starts.
+-- @hook
+-- @realm shared
+function GM:TTTPrepareRound()
+	BUYTABLE = {}
+	TEAMBUYTABLE = {}
+end
+
+---
+-- A hook that is called when the round begins.
+-- @hook
+-- @realm shared
+function GM:TTTBeginRound()
+
+end
+
+-- A hook that is called when the round ends.
+-- @hook
+-- @realm shared
+function GM:TTTEndRound()
+
+end
+
+---
 -- Called right after the map has been cleaned up (usually because game.CleanUpMap was called).
 -- This hook is called after the @{outputs} library is set up and map entity outputs can be
 -- registered.


### PR DESCRIPTION
This removes the random reseeding every round and also moves the buytable resets to their appropriate functions.

Also this moves the hooks with their documentation to the correct sh_main file, as they are shared.