### PR TITLE
Sprint: airborne players can no longer replenish stamina

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ### Changed
 - Roles are now only getting synced to clients if the role is known, not just the body being confirmed
+- Airborne players can no longer replenish stamina
 
 ## [v0.7.2b](https://github.com/TTT-2/TTT2/tree/v0.7.2b) (2020-06-26)
 

--- a/gamemodes/terrortown/gamemode/shared/sh_sprint.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_sprint.lua
@@ -119,6 +119,7 @@ function UpdateSprint()
 
 	for i = 1, #plys do
 		local ply = plys[i]
+
 		if not ply:OnGround() then continue end
 
 		local wantsToMove = ply:KeyDown(IN_FORWARD) or ply:KeyDown(IN_BACK) or ply:KeyDown(IN_MOVERIGHT) or ply:KeyDown(IN_MOVELEFT)

--- a/gamemodes/terrortown/gamemode/shared/sh_sprint.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_sprint.lua
@@ -119,6 +119,8 @@ function UpdateSprint()
 
 	for i = 1, #plys do
 		local ply = plys[i]
+		if not ply:OnGround() then continue end
+
 		local wantsToMove = ply:KeyDown(IN_FORWARD) or ply:KeyDown(IN_BACK) or ply:KeyDown(IN_MOVERIGHT) or ply:KeyDown(IN_MOVELEFT)
 
 		if ply.sprintProgress == 1 and (not ply.isSprinting or not wantsToMove) then continue end


### PR DESCRIPTION
The current sprint system allows players to sprint continuously by jumping to regain stamina.
This PR aims to fix this "issue"

Players have to be on ground to be able to sprint and players can't replenish their stamina when they're airborne.