### PR TITLE
Overhead Icons: Changed detective overhead icon to show to innocents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ### Changed
 - Roles are now only getting synced to clients if the role is known, not just the body being confirmed
 - Airborne players can no longer replenish stamina
+- Detective overhead icon is now shown to innocents
 
 ## [v0.7.2b](https://github.com/TTT-2/TTT2/tree/v0.7.2b) (2020-06-26)
 

--- a/gamemodes/terrortown/gamemode/client/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_targetid.lua
@@ -165,7 +165,7 @@ function GM:PostDrawTranslucentRenderables(bDrawingDepth, bDrawingSkybox)
 	end
 
 	-- OVERHEAD ICONS
-	if disable_overheadicons:GetBool() or not client:IsSpecial() then return end
+	if disable_overheadicons:GetBool() then return end
 
 	for i = 1, #plys do
 		local ply = plys[i]


### PR DESCRIPTION
Innocents are not considered special, so no role icons were shown to
innocents, although Detective Icons should be shown to them.