### PR TITLE
Radar: Make bomb.team optional to fix compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Roles are now only getting synced to clients if the role is known, not just the body being confirmed
 - Airborne players can no longer replenish stamina
 
+### Fixed
+- Radar now shows bombs again, that do not have the team property set
+
 ## [v0.7.2b](https://github.com/TTT-2/TTT2/tree/v0.7.2b) (2020-06-26)
 
 ### Added

--- a/lua/terrortown/entities/items/item_ttt_radar/cl_init.lua
+++ b/lua/terrortown/entities/items/item_ttt_radar/cl_init.lua
@@ -152,7 +152,7 @@ function RADAR:Draw(client)
 		surface.SetDrawColor(255, 255, 255, 200)
 
 		for _, bomb in pairs(self.bombs) do
-			if bomb.team == client:GetTeam() then
+			if bomb.team ~= nil and bomb.team == client:GetTeam() then
 				DrawTarget(bomb, 24, 0, true)
 			end
 		end


### PR DESCRIPTION
This will ensure that TTT items, which do not know about the new team property, will still be displayed.