### PR TITLE
HUDManager: Fix saving forcedHUD and defaultHUD values to DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Roles are now only getting synced to clients if the role is known, not just the body being confirmed
 - Airborne players can no longer replenish stamina
 
+### Fixed
+- Fix HUDManager not saving forcedHUD and defaultHUD values
+
 ## [v0.7.2b](https://github.com/TTT-2/TTT2/tree/v0.7.2b) (2020-06-26)
 
 ### Added

--- a/gamemodes/terrortown/gamemode/server/sv_hud_manager.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_hud_manager.lua
@@ -76,8 +76,8 @@ function HUDManager.StoreData()
 	MsgN("[TTT2][HUDManager] Storing data in database...")
 
 	if DB_EnsureTableExists(HUD_MANAGER_SQL_TABLE, "key TEXT PRIMARY KEY, value TEXT") then
-		sql.Query("INSERT OR REPLACE INTO " .. HUD_MANAGER_SQL_TABLE .. " VALUES('forcedHUD', " .. sql.SQLStr(ttt2net.GetGlobal("forcedHUD")) .. ")")
-		sql.Query("INSERT OR REPLACE INTO " .. HUD_MANAGER_SQL_TABLE .. " VALUES('defaultHUD', " .. sql.SQLStr(ttt2net.GetGlobal("defaultHUD")) .. ")")
+		sql.Query("INSERT OR REPLACE INTO " .. HUD_MANAGER_SQL_TABLE .. " VALUES('forcedHUD', " .. sql.SQLStr(ttt2net.GetGlobal({"hud_manager", "forcedHUD"})) .. ")")
+		sql.Query("INSERT OR REPLACE INTO " .. HUD_MANAGER_SQL_TABLE .. " VALUES('defaultHUD', " .. sql.SQLStr(ttt2net.GetGlobal({"hud_manager", "defaultHUD"})) .. ")")
 	end
 
 	-- delete the table to recreate it again, to remove all values that might have been removed from the table
@@ -181,6 +181,7 @@ net.Receive("TTT2DefaultHUDRequest", function(_, ply)
 		end
 
 		HUDManager.StoreData()
+		HUDManager.LoadData()
 	end
 
 	net.Start("TTT2DefaultHUDResponse")


### PR DESCRIPTION
This fixes saving the values to the database, where the path was just wrong.

This fixes #610 and was tested by me.