### PR TITLE
Corpses: Fix multiple corpses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Roles are now only getting synced to clients if the role is known, not just the body being confirmed
 - Airborne players can no longer replenish stamina
 
+### Fixed
+- Fixed death handling spawning multiple corpses when killed multiple times in the same frame
+
 ## [v0.7.2b](https://github.com/TTT-2/TTT2/tree/v0.7.2b) (2020-06-26)
 
 ### Added

--- a/gamemodes/terrortown/gamemode/server/sv_player.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player.lua
@@ -803,39 +803,35 @@ function GM:PlayerDeath(victim, infl, attacker)
 	-- abort the weapon pickup when a player dies
 	ResetWeapon(victim.wpickup_weapon)
 
-	timer.Simple(0, function()
-		if not IsValid(victim) then return end
+	-- a function to handle the rolespecific stuff that should be done on
+	-- rolechange and respawn (while a round is active)
+	if victim:IsActive() then
+		victim:GetSubRoleData():RemoveRoleLoadout(victim, false)
+	end
 
-		-- a function to handle the rolespecific stuff that should be done on
-		-- rolechange and respawn (while a round is active)
-		if victim:IsActive() then
-			victim:GetSubRoleData():RemoveRoleLoadout(victim, false)
-		end
+	victim:SetTeam(TEAM_SPEC)
+	victim:Freeze(false)
+	victim:SetRagdollSpec(true)
+	victim:Spectate(OBS_MODE_IN_EYE)
 
-		victim:SetTeam(TEAM_SPEC)
-		victim:Freeze(false)
-		victim:SetRagdollSpec(true)
-		victim:Spectate(OBS_MODE_IN_EYE)
+	local rag_ent = victim.server_ragdoll or victim:GetRagdollEntity()
 
-		local rag_ent = victim.server_ragdoll or victim:GetRagdollEntity()
+	victim:SpectateEntity(rag_ent)
+	victim:Flashlight(false)
+	victim:Extinguish()
 
-		victim:SpectateEntity(rag_ent)
-		victim:Flashlight(false)
-		victim:Extinguish()
+	net.Start("TTT_PlayerDied")
+	net.Send(victim)
 
-		net.Start("TTT_PlayerDied")
-		net.Send(victim)
+	if HasteMode() and GetRoundState() == ROUND_ACTIVE and not hook.Run("TTT2ShouldSkipHaste", victim, attacker) then
+		IncRoundEnd(GetConVar("ttt_haste_minutes_per_death"):GetFloat() * 60)
+	end
 
-		if HasteMode() and GetRoundState() == ROUND_ACTIVE and not hook.Run("TTT2ShouldSkipHaste", victim, attacker) then
-			IncRoundEnd(GetConVar("ttt_haste_minutes_per_death"):GetFloat() * 60)
-		end
+	if IsValid(attacker) and attacker:IsPlayer() and attacker ~= victim and attacker:IsActive() then
+		victim.killerSpec = attacker
+	end
 
-		if IsValid(attacker) and attacker:IsPlayer() and attacker ~= victim and attacker:IsActive() then
-			victim.killerSpec = attacker
-		end
-
-		hook.Run("TTT2PostPlayerDeath", victim, infl, attacker)
-	end)
+	hook.Run("TTT2PostPlayerDeath", victim, infl, attacker)
 end
 
 ---


### PR DESCRIPTION
This removes the timer in sv_player, that would delay handling the death to the next frame, as this leads to multiple corpses etc, when a player dies from damage and a `ply:Kill` command in the same frame.

Don't know why this timer even was introduced, maybe @Alf21 knows something about this?

Fixes #611 