### PR TITLE
Update sv_addonchecker.lua: Removed updated and now compatible Addons

### DIFF
--- a/gamemodes/terrortown/gamemode/server/sv_addonchecker.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_addonchecker.lua
@@ -167,10 +167,12 @@ addonChecker.curatedList = {
 		type = ADDON_INCOMPATIBLE
 	},
 	["606792331"] = { -- Advanced disguiser by Gamefreak
+		alternative = "2144375749",
 		reason = "Does not work with TTT2 targetID.",
 		type = ADDON_INCOMPATIBLE
 	},
 	["610632051"] = { -- Advanced disguiser by Killberty
+		alternative = "2144375749",
 		reason = "Does not work with TTT2 targetID.",
 		type = ADDON_INCOMPATIBLE
 	},
@@ -261,6 +263,21 @@ addonChecker.curatedList = {
 	},
 	["899206223"] = { -- Martyrdom by Koksgesicht
 		alternative = "1630269736",
+		reason = "Does not use the TTT2 sidebar system.",
+		type = ADDON_OUTDATED
+	},
+	["652046425"] = { -- Juggernaut Suit by Zaratusa
+		alternative = "2157829981",
+		reason = "Does not use the TTT2 sidebar system.",
+		type = ADDON_OUTDATED
+	},
+	["650523807"] = { -- Lucky Horseshoe by Zaratusa
+		alternative = "2157888469",
+		reason = "Does not use the TTT2 sidebar system.",
+		type = ADDON_OUTDATED
+	},
+	["650523765"] = { -- Hermes Boots by Zaratusa
+		alternative = "2157850255",
 		reason = "Does not use the TTT2 sidebar system.",
 		type = ADDON_OUTDATED
 	},

--- a/gamemodes/terrortown/gamemode/server/sv_addonchecker.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_addonchecker.lua
@@ -76,16 +76,6 @@ addonChecker.curatedList = {
 		reason = "Breaks the TTT2 gamemode.",
 		type = ADDON_INCOMPATIBLE
 	},
-	["253737047"] = { -- Golden Deagle by Zaratusa
-		alternative = "1398388611",
-		reason = "Does not work with our role system.",
-		type = ADDON_INCOMPATIBLE
-	},
-	["637848943"] = { -- Golden Deagle by Zaratusa
-		alternative = "1398388611",
-		reason = "Does not work with our role system.",
-		type = ADDON_INCOMPATIBLE
-	},
 	["1376434172"] = { -- Golden Deagle by DaniX_Chile
 		alternative = "1398388611",
 		reason = "Does not work with our role system.",
@@ -271,11 +261,6 @@ addonChecker.curatedList = {
 	},
 	["899206223"] = { -- Martyrdom by Koksgesicht
 		alternative = "1630269736",
-		reason = "Does not use the TTT2 sidebar system.",
-		type = ADDON_OUTDATED
-	},
-	["652046425"] = { -- Juggernaut Suit by Zaratusa
-		alternative = "1640512667",
 		reason = "Does not use the TTT2 sidebar system.",
 		type = ADDON_OUTDATED
 	},


### PR DESCRIPTION
The Golden Deagle V1, V2 and the Juggernaut Suit were updated by Zaratusa. They are now compatible with TTT2 and can be removed from the Addonchecker.