### PR TITLE
Fileloader: Introduced a new file loader to TTT2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 - Added a new custom file loader that loads lua files from `lua/terrortown/autorun/`
   - it basically works the same as the native file loader
-  - there are three subfolder: `client`, `server` and `shared`
+  - there are three subfolders: `client`, `server` and `shared`
   - the files inside this folder are loaded after all TTT2 gamemode files and library extensions are loaded
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,22 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ## Unreleased
 
+### Added
+
+- Added a new custom file loader that loads lua files from `lua/terrortown/autorun/`
+  - it basically works the same as the native file loader
+  - there are three subfolder: `client`, `server` and `shared`
+  - the files inside this folder are loaded after all TTT2 gamemode files and library extensions are loaded
+
 ### Changed
+
 - Roles are now only getting synced to clients if the role is known, not just the body being confirmed
 - Airborne players can no longer replenish stamina
 - Detective overhead icon is now shown to innocents
+- moved language files from `lua/lang/` to `lua/terrortown/lang`
 
 ### Fixed
+
 - Fixed death handling spawning multiple corpses when killed multiple times in the same frame
 - Radar now shows bombs again, that do not have the team property set
 - Fix HUDManager not saving forcedHUD and defaultHUD values

--- a/gamemodes/terrortown/gamemode/client/cl_main.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_main.lua
@@ -122,7 +122,7 @@ function GM:Initialize()
 
 	-- load addon language files
 	fileloader.LoadFolder("lang/", true, CLIENT, function(path)
-		ErrorNoHalt("[DEPRECATION WARNING]: Loaded language file from 'lang/', this folder is deprecated. Please switch to `terrortown/lang/`\n")
+		MsgN("[DEPRECATION WARNING]: Loaded language file from 'lang/', this folder is deprecated. Please switch to 'terrortown/lang/'")
 		MsgN("Added TTT2 language file: ", path)
 	end)
 

--- a/gamemodes/terrortown/gamemode/client/cl_main.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_main.lua
@@ -81,11 +81,11 @@ ttt_include("cl_damage_indicator")
 ttt_include("sh_armor")
 ttt_include("cl_weapon_pickup")
 
-fileloader.LoadFolder("terrortown/autorun/client/", false, CLIENT, function(path)
+fileloader.LoadFolder("terrortown/autorun/client/", false, CLIENT_FILE, function(path)
 	MsgN("Added TTT2 client autorun file: ", path)
 end)
 
-fileloader.LoadFolder("terrortown/autorun/shared/", false, SHARED, function(path)
+fileloader.LoadFolder("terrortown/autorun/shared/", false, SHARED_FILE, function(path)
 	MsgN("Added TTT2 shared autorun file: ", path)
 end)
 
@@ -121,12 +121,12 @@ function GM:Initialize()
 	self.roundCount = 0
 
 	-- load addon language files
-	fileloader.LoadFolder("lang/", true, CLIENT, function(path)
+	fileloader.LoadFolder("lang/", true, CLIENT_FILE, function(path)
 		MsgN("[DEPRECATION WARNING]: Loaded language file from 'lang/', this folder is deprecated. Please switch to 'terrortown/lang/'")
 		MsgN("Added TTT2 language file: ", path)
 	end)
 
-	fileloader.LoadFolder("terrortown/lang/", true, CLIENT, function(path)
+	fileloader.LoadFolder("terrortown/lang/", true, CLIENT_FILE, function(path)
 		MsgN("Added TTT2 language file: ", path)
 	end)
 

--- a/gamemodes/terrortown/gamemode/client/cl_main.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_main.lua
@@ -113,7 +113,14 @@ function GM:Initialize()
 	self.roundCount = 0
 
 	-- load addon language files
-	LANG.SetupFiles("lang/", true)
+	fileloader.LoadFolder("lang/", true, CLIENT, function(path)
+		ErrorNoHalt("[DEPRECATION WARNING]: Loaded language file from 'lang/', this folder is deprecated. Please switch to `terrortown/lang/`")
+		MsgN("Added TTT2 language file: ", path)
+	end)
+
+	fileloader.LoadFolder("terrortown/lang/", true, CLIENT, function(path)
+		MsgN("Added TTT2 language file: ", path)
+	end)
 
 	LANG.Init()
 

--- a/gamemodes/terrortown/gamemode/client/cl_main.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_main.lua
@@ -81,6 +81,14 @@ ttt_include("cl_damage_indicator")
 ttt_include("sh_armor")
 ttt_include("cl_weapon_pickup")
 
+fileloader.LoadFolder("terrortown/autorun/client/", false, CLIENT, function(path)
+	MsgN("Added TTT2 client autorun file: ", path)
+end)
+
+fileloader.LoadFolder("terrortown/autorun/shared/", false, SHARED, function(path)
+	MsgN("Added TTT2 shared autorun file: ", path)
+end)
+
 -- all files are loaded
 local TryT = LANG.TryTranslation
 
@@ -114,7 +122,7 @@ function GM:Initialize()
 
 	-- load addon language files
 	fileloader.LoadFolder("lang/", true, CLIENT, function(path)
-		ErrorNoHalt("[DEPRECATION WARNING]: Loaded language file from 'lang/', this folder is deprecated. Please switch to `terrortown/lang/`")
+		ErrorNoHalt("[DEPRECATION WARNING]: Loaded language file from 'lang/', this folder is deprecated. Please switch to `terrortown/lang/`\n")
 		MsgN("Added TTT2 language file: ", path)
 	end)
 

--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -205,7 +205,7 @@ function GM:Initialize()
 
 	-- check for language files to mark them as downloadable for clients
 	fileloader.LoadFolder("lang/", true, CLIENT, function(path)
-		ErrorNoHalt("[DEPRECATION WARNING]: Loaded language file from 'lang/', this folder is deprecated. Please switch to `terrortown/lang/`\n")
+		MsgN("[DEPRECATION WARNING]: Loaded language file from 'lang/', this folder is deprecated. Please switch to 'terrortown/lang/'")
 		MsgN("Added TTT2 language file: ", path)
 	end)
 

--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -175,15 +175,15 @@ util.AddNetworkString("TTT2RoleGlobalVoice")
 util.AddNetworkString("TTT2MuteTeam")
 util.AddNetworkString("TTT2UpdateHoldAimConvar")
 
-fileloader.LoadFolder("terrortown/autorun/client/", false, CLIENT, function(path)
+fileloader.LoadFolder("terrortown/autorun/client/", false, CLIENT_FILE, function(path)
 	MsgN("Marked TTT2 client autorun file for distribution: ", path)
 end)
 
-fileloader.LoadFolder("terrortown/autorun/shared/", false, SHARED, function(path)
-	MsgN("Marked TTT2 shared autorun file for distribution: ", path)
+fileloader.LoadFolder("terrortown/autorun/shared/", false, SHARED_FILE, function(path)
+	MsgN("Marked and added TTT2 shared autorun file for distribution: ", path)
 end)
 
-fileloader.LoadFolder("terrortown/autorun/server/", false, SERVER, function(path)
+fileloader.LoadFolder("terrortown/autorun/server/", false, SERVER_FILE, function(path)
 	MsgN("Added TTT2 server autorun file: ", path)
 end)
 
@@ -204,12 +204,12 @@ function GM:Initialize()
 	hook.Run("TTT2FinishedLoading")
 
 	-- check for language files to mark them as downloadable for clients
-	fileloader.LoadFolder("lang/", true, CLIENT, function(path)
+	fileloader.LoadFolder("lang/", true, CLIENT_FILE, function(path)
 		MsgN("[DEPRECATION WARNING]: Loaded language file from 'lang/', this folder is deprecated. Please switch to 'terrortown/lang/'")
 		MsgN("Added TTT2 language file: ", path)
 	end)
 
-	fileloader.LoadFolder("terrortown/lang/", true, CLIENT, function(path)
+	fileloader.LoadFolder("terrortown/lang/", true, CLIENT_FILE, function(path)
 		MsgN("Added TTT2 language file: ", path)
 	end)
 

--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -175,6 +175,18 @@ util.AddNetworkString("TTT2RoleGlobalVoice")
 util.AddNetworkString("TTT2MuteTeam")
 util.AddNetworkString("TTT2UpdateHoldAimConvar")
 
+fileloader.LoadFolder("terrortown/autorun/client/", false, CLIENT, function(path)
+	MsgN("Marked TTT2 client autorun file for distribution: ", path)
+end)
+
+fileloader.LoadFolder("terrortown/autorun/shared/", false, SHARED, function(path)
+	MsgN("Marked TTT2 shared autorun file for distribution: ", path)
+end)
+
+fileloader.LoadFolder("terrortown/autorun/server/", false, SERVER, function(path)
+	MsgN("Added TTT2 server autorun file: ", path)
+end)
+
 CHANGED_EQUIPMENT = {}
 
 ---
@@ -193,7 +205,7 @@ function GM:Initialize()
 
 	-- check for language files to mark them as downloadable for clients
 	fileloader.LoadFolder("lang/", true, CLIENT, function(path)
-		ErrorNoHalt("[DEPRECATION WARNING]: Loaded language file from 'lang/', this folder is deprecated. Please switch to `terrortown/lang/`")
+		ErrorNoHalt("[DEPRECATION WARNING]: Loaded language file from 'lang/', this folder is deprecated. Please switch to `terrortown/lang/`\n")
 		MsgN("Added TTT2 language file: ", path)
 	end)
 

--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -192,7 +192,14 @@ function GM:Initialize()
 	hook.Run("TTT2FinishedLoading")
 
 	-- check for language files to mark them as downloadable for clients
-	LANG.SetupFiles("lang/", true)
+	fileloader.LoadFolder("lang/", true, CLIENT, function(path)
+		ErrorNoHalt("[DEPRECATION WARNING]: Loaded language file from 'lang/', this folder is deprecated. Please switch to `terrortown/lang/`")
+		MsgN("Added TTT2 language file: ", path)
+	end)
+
+	fileloader.LoadFolder("terrortown/lang/", true, CLIENT, function(path)
+		MsgN("Added TTT2 language file: ", path)
+	end)
 
 	ShopEditor.SetupShopEditorCVars()
 	ShopEditor.CreateShopDBs()

--- a/gamemodes/terrortown/gamemode/shared/sh_init.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_init.lua
@@ -10,6 +10,9 @@ GM.Customized = true
 
 TTT2 = true -- identifier for TTT2. Just use "if TTT2 then ... end"
 
+-- extend CLIENT and SERVER flags
+SHARED = 2
+
 -- Round status consts
 ROUND_WAIT = 1
 ROUND_PREP = 2
@@ -526,6 +529,7 @@ include("includes/modules/pon.lua")
 include("ttt2/extensions/net.lua")
 include("ttt2/extensions/string.lua")
 include("ttt2/extensions/table.lua")
+include("ttt2/libraries/fileloader.lua")
 include("ttt2/libraries/door.lua")
 include("ttt2/libraries/thermalvision.lua")
 

--- a/gamemodes/terrortown/gamemode/shared/sh_init.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_init.lua
@@ -10,9 +10,6 @@ GM.Customized = true
 
 TTT2 = true -- identifier for TTT2. Just use "if TTT2 then ... end"
 
--- extend CLIENT and SERVER flags
-SHARED = 2
-
 -- Round status consts
 ROUND_WAIT = 1
 ROUND_PREP = 2

--- a/gamemodes/terrortown/gamemode/shared/sh_lang.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_lang.lua
@@ -26,58 +26,12 @@ util.IncludeClientFile("terrortown/gamemode/client/cl_lang.lua")
 local net = net
 local table = table
 local pairs = pairs
-local file = file
 local string = string
 
----
--- Sets up the language by scanning through the given directory; has to be run on both
--- server and client!
--- @param string lang_path The path to search in
--- @param boolean deepsearch If true, subfolders are scanned
--- @internal
--- @realm shared
-function LANG.SetupFiles(lang_path, deepsearch)
-	local file_paths = {}
-
-	if deepsearch then
-		local _, sub_folders = file.Find(lang_path .. "*", "LUA")
-
-		if not sub_folders then return end
-
-		for k = 1, #sub_folders do
-			local subname = sub_folders[k]
-			local files = file.Find(lang_path .. subname .. "/*.lua", "LUA")
-
-			if not files then continue end
-
-			for i = 1, #files do
-				file_paths[#file_paths + 1] = lang_path .. subname .. "/" .. files[i]
-			end
-		end
-	else
-		local files = file.Find(lang_path .. "*.lua", "LUA")
-
-		if not files then return end
-
-		for i = 1, #files do
-			file_paths[#file_paths + 1] = lang_path .. files[i]
-		end
-	end
-
-	for i = 1, #file_paths do
-		local path = file_paths[i]
-
-		-- filter out directories and temp files (like .lua~)
-		if string.Right(path, 3) == "lua" then
-			util.IncludeClientFile(path)
-
-			MsgN("Included TTT language file: " .. path)
-		end
-	end
-end
-
 -- load default TTT2 language files or mark them as downloadable on the server
-LANG.SetupFiles((GM.FolderName or "terrortown") .. "/gamemode/shared/lang/", false)
+fileloader.LoadFolder((GM.FolderName or "terrortown") .. "/gamemode/shared/lang/", false, CLIENT, function(path)
+	MsgN("Added TTT2 gamemode language file: ", path)
+end)
 
 if SERVER then
 	local count = table.Count

--- a/gamemodes/terrortown/gamemode/shared/sh_lang.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_lang.lua
@@ -29,7 +29,7 @@ local pairs = pairs
 local string = string
 
 -- load default TTT2 language files or mark them as downloadable on the server
-fileloader.LoadFolder((GM.FolderName or "terrortown") .. "/gamemode/shared/lang/", false, CLIENT, function(path)
+fileloader.LoadFolder((GM.FolderName or "terrortown") .. "/gamemode/shared/lang/", false, CLIENT_FILE, function(path)
 	MsgN("Added TTT2 gamemode language file: ", path)
 end)
 

--- a/lua/ttt2/libraries/fileloader.lua
+++ b/lua/ttt2/libraries/fileloader.lua
@@ -17,7 +17,7 @@ fileloader = fileloader or {}
 -- @param string path The path to search in
 -- @param[default=false] boolean deepsearch If true, subfolders are scanned
 -- @param[default=SHARED] number realm The realm where the file should be included
--- @param[opt] funcion callback A function that is called after the file is included
+-- @param[opt] function callback A function that is called after the file is included
 -- @realm shared
 function fileloader.LoadFolder(path, deepsearch, realm, callback)
 	deepsearch = deepsearch or false

--- a/lua/ttt2/libraries/fileloader.lua
+++ b/lua/ttt2/libraries/fileloader.lua
@@ -6,6 +6,10 @@ if SERVER then
 	AddCSLuaFile()
 end
 
+CLIENT_FILE = 0
+SERVER_FILE = 1
+SHARED_FILE = 2
+
 local fileFind = file.Find
 local stringRight = string.Right
 
@@ -16,12 +20,12 @@ fileloader = fileloader or {}
 -- @note Has to be run on both server and client for client and shared files.
 -- @param string path The absolute path to search in, has to end with `/`
 -- @param[default=false] boolean deepsearch If true, files are searched one level down inside all available subfolders
--- @param[default=SHARED] number realm The realm where the file should be included
+-- @param[default=SHARED_FILE] number realm The realm where the file should be included
 -- @param[opt] function callback A function that is called after the file is included
 -- @realm shared
 function fileloader.LoadFolder(path, deepsearch, realm, callback)
 	deepsearch = deepsearch or false
-	realm = realm or SHARED
+	realm = realm or SHARED_FILE
 
 	local file_paths = {}
 
@@ -56,14 +60,14 @@ function fileloader.LoadFolder(path, deepsearch, realm, callback)
 		-- filter out directories and temp files (like .lua~)
 		if stringRight(file_path, 3) ~= "lua" then continue end
 
-		if SERVER and realm == CLIENT then
+		if SERVER and realm == CLIENT_FILE then
 			AddCSLuaFile(file_path)
-		elseif SERVER and realm == SHARED then
+		elseif SERVER and realm == SHARED_FILE then
 			AddCSLuaFile(file_path)
 			include(file_path)
-		elseif SERVER and realm ~= CLIENT then
+		elseif SERVER and realm ~= CLIENT_FILE then
 			include(file_path)
-		elseif CLIENT and realm ~= SERVER then
+		elseif CLIENT and realm ~= SERVER_FILE then
 			include(file_path)
 		else
 			continue

--- a/lua/ttt2/libraries/fileloader.lua
+++ b/lua/ttt2/libraries/fileloader.lua
@@ -1,0 +1,78 @@
+---
+-- A file loading library for a custom ttt2 file loader
+-- @author Mineotopia
+
+if SERVER then
+	AddCSLuaFile()
+end
+
+local fileFind = file.Find
+local stringRight = string.Right
+
+fileloader = fileloader or {}
+
+---
+-- Sets up the language by scanning through the given directory; has to be run on both
+-- server and client!
+-- @param string path The path to search in
+-- @param[default=false] boolean deepsearch If true, subfolders are scanned
+-- @param[default=SHARED] number realm The realm where the file should be included
+-- @param[opt] funcion callback A function that is called after the file is included
+-- @realm shared
+function fileloader.LoadFolder(path, deepsearch, realm, callback)
+	deepsearch = deepsearch or false
+	realm = realm or SHARED
+
+	print("test")
+
+	local file_paths = {}
+
+	if deepsearch then
+		local _, sub_folders = fileFind(path .. "*", "LUA")
+
+		if not sub_folders then return end
+
+		for k = 1, #sub_folders do
+			local subname = sub_folders[k]
+			local files = fileFind(path .. subname .. "/*.lua", "LUA")
+
+			if not files then continue end
+
+			for i = 1, #files do
+				file_paths[#file_paths + 1] = path .. subname .. "/" .. files[i]
+			end
+		end
+	else
+		local files = fileFind(path .. "*.lua", "LUA")
+
+		if not files then return end
+
+		for i = 1, #files do
+			file_paths[#file_paths + 1] = path .. files[i]
+		end
+	end
+
+	print("file paths:")
+	PrintTable(file_paths)
+
+	for i = 1, #file_paths do
+		local file_path = file_paths[i]
+
+		-- filter out directories and temp files (like .lua~)
+		if stringRight(file_path, 3) ~= "lua" then continue end
+
+		if SERVER and realm ~= SERVER then
+			AddCSLuaFile(file_path)	
+		elseif SERVER and realm ~= CLIENT then
+			include(file_path)
+		elseif CLIENT and realm ~= SERVER then
+			include(file_path)
+		else
+			continue
+		end
+
+		if isfunction(callback) then
+			callback(file_path, path, deepsearch, realm)
+		end
+	end
+end

--- a/lua/ttt2/libraries/fileloader.lua
+++ b/lua/ttt2/libraries/fileloader.lua
@@ -56,8 +56,11 @@ function fileloader.LoadFolder(path, deepsearch, realm, callback)
 		-- filter out directories and temp files (like .lua~)
 		if stringRight(file_path, 3) ~= "lua" then continue end
 
-		if SERVER and realm ~= SERVER then
+		if SERVER and realm == CLIENT then
 			AddCSLuaFile(file_path)
+		elseif SERVER and realm == SHARED then
+			AddCSLuaFile(file_path)
+			include(file_path)
 		elseif SERVER and realm ~= CLIENT then
 			include(file_path)
 		elseif CLIENT and realm ~= SERVER then

--- a/lua/ttt2/libraries/fileloader.lua
+++ b/lua/ttt2/libraries/fileloader.lua
@@ -15,7 +15,7 @@ fileloader = fileloader or {}
 -- Sets up files by scanning through directories and including them into the runtime.
 -- @note Has to be run on both server and client for client and shared files.
 -- @param string path The absolute path to search in, has to end with `/`
--- @param[default=false] boolean deepsearch If true, subfolders are scanned
+-- @param[default=false] boolean deepsearch If true, files are searched one level down inside all available subfolders
 -- @param[default=SHARED] number realm The realm where the file should be included
 -- @param[opt] function callback A function that is called after the file is included
 -- @realm shared

--- a/lua/ttt2/libraries/fileloader.lua
+++ b/lua/ttt2/libraries/fileloader.lua
@@ -14,7 +14,7 @@ fileloader = fileloader or {}
 ---
 -- Sets up files by scanning through directories and including them into the runtime.
 -- @note Has to be run on both server and client for client and shared files.
--- @param string path The path to search in
+-- @param string path The absolute path to search in, has to end with `/`
 -- @param[default=false] boolean deepsearch If true, subfolders are scanned
 -- @param[default=SHARED] number realm The realm where the file should be included
 -- @param[opt] function callback A function that is called after the file is included

--- a/lua/ttt2/libraries/fileloader.lua
+++ b/lua/ttt2/libraries/fileloader.lua
@@ -23,8 +23,6 @@ function fileloader.LoadFolder(path, deepsearch, realm, callback)
 	deepsearch = deepsearch or false
 	realm = realm or SHARED
 
-	print("test")
-
 	local file_paths = {}
 
 	if deepsearch then
@@ -52,9 +50,6 @@ function fileloader.LoadFolder(path, deepsearch, realm, callback)
 		end
 	end
 
-	print("file paths:")
-	PrintTable(file_paths)
-
 	for i = 1, #file_paths do
 		local file_path = file_paths[i]
 
@@ -62,7 +57,7 @@ function fileloader.LoadFolder(path, deepsearch, realm, callback)
 		if stringRight(file_path, 3) ~= "lua" then continue end
 
 		if SERVER and realm ~= SERVER then
-			AddCSLuaFile(file_path)	
+			AddCSLuaFile(file_path)
 		elseif SERVER and realm ~= CLIENT then
 			include(file_path)
 		elseif CLIENT and realm ~= SERVER then

--- a/lua/ttt2/libraries/fileloader.lua
+++ b/lua/ttt2/libraries/fileloader.lua
@@ -12,8 +12,8 @@ local stringRight = string.Right
 fileloader = fileloader or {}
 
 ---
--- Sets up the language by scanning through the given directory; has to be run on both
--- server and client!
+-- Sets up files by scanning through directories and including them into the runtime.
+-- @note Has to be run on both server and client for client and shared files.
 -- @param string path The path to search in
 -- @param[default=false] boolean deepsearch If true, subfolders are scanned
 -- @param[default=SHARED] number realm The realm where the file should be included


### PR DESCRIPTION
This new file loader is heavily based on the old language file loader but is now more widely used.

CHANGED:
Language files are moved from `lua/lang/` to `lua/terrortown/lang/`. However the old path is loaded as well for now with a deprecation warning.

ADDED:
Added a new fileloader for addon files that were previously placed inside of `lua/autorun/` and were loaded in all gamemodes. This caused problems for players that switched between gamemodes. Additionally files inside those new folders are loaded directly after all TTT2 gamemode files are loaded. This has the added benefit that right from the time the files are loaded, all gamemode functions and library extensions are available.
The new path for files is `lua/terrortown/autorun` with three seperate subfolders for `client`, `server` and `shared`.

With this change, all TTT2 specifix files are now located in `lua/terrortown` (`/lang`, `/autorun`, `/entities`)