### PR TITLE
Spectators: Stop teleporting players to players they're not spectating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Roles are now only getting synced to clients if the role is known, not just the body being confirmed
 - Airborne players can no longer replenish stamina
 - Detective overhead icon is now shown to innocents
+- Stopped teleporting players to players they're not spectating if they press the "duck"-Key while roaming
 
 ### Fixed
 - Fixed death handling spawning multiple corpses when killed multiple times in the same frame

--- a/gamemodes/terrortown/gamemode/server/sv_player.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player.lua
@@ -379,7 +379,7 @@ function GM:KeyPress(ply, key)
 
 		local target = ply:GetObserverTarget()
 
-		if IsValid(target) and target:IsPlayer() then
+		if IsValid(target) and target:IsPlayer() and ply:GetObserverMode() ~= OBS_MODE_ROAMING then -- Only set the spectator's position to the player they are spectating if they are in chase or eye mode. They can use the reload key if they want to return to the person they're spectating
 			pos = target:EyePos()
 			ang = target:EyeAngles()
 		end

--- a/gamemodes/terrortown/gamemode/server/sv_player.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player.lua
@@ -379,7 +379,9 @@ function GM:KeyPress(ply, key)
 
 		local target = ply:GetObserverTarget()
 
-		if IsValid(target) and target:IsPlayer() and ply:GetObserverMode() ~= OBS_MODE_ROAMING then -- Only set the spectator's position to the player they are spectating if they are in chase or eye mode. They can use the reload key if they want to return to the person they're spectating
+		-- Only set the spectator's position to the player they are spectating if they are in chase or eye mode.
+		-- They can use the reload key if they want to return to the person they're spectating
+		if IsValid(target) and target:IsPlayer() and ply:GetObserverMode() ~= OBS_MODE_ROAMING then
 			pos = target:EyePos()
 			ang = target:EyeAngles()
 		end


### PR DESCRIPTION
If you crouch to stop spectating a player and want to slowly move while free-roaming and hold duck, you are teleported back to the person you were previously spectating. There is no need for this since if you want to return to the person you were spectating, you can just use your reload bind.

Change regarding https://github.com/Facepunch/garrysmod/pull/1696