### PR TITLE
CI: Move glualint workflow to github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Download & extract glualint
       run: |
         wget -c https://github.com/FPtje/GLuaFixer/releases/download/${GLUALINT_VERSION}/glualint-${GLUALINT_VERSION}-linux.zip -O glualint.zip
-        unzip -u glaulint.zip
+        unzip -u glualint.zip
 
     - name: Check code with glualint
       run: ./glualint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+env:
+  GLUALINT_VERSION: 1.16.2
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Download & extract glualint
+      run: |
+        wget -c https://github.com/FPtje/GLuaFixer/releases/download/${GLUALINT_VERSION}/glualint-${GLUALINT_VERSION}-linux.zip -O glualint.zip
+        unzip -u glaulint.zip
+
+    - name: Check code with glualint
+      run: ./glualint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       run: |
         wget -c https://github.com/FPtje/GLuaFixer/releases/download/${GLUALINT_VERSION}/glualint-${GLUALINT_VERSION}-linux.zip -O glualint.zip
         unzip -u glualint.zip
+        ls -la
 
     - name: Check code with glualint
-      run: ./glualint
+      run: ./glualint 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,7 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
+  lint:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         wget -c https://github.com/FPtje/GLuaFixer/releases/download/${GLUALINT_VERSION}/glualint-${GLUALINT_VERSION}-linux.zip -O glualint.zip
         unzip -u glualint.zip
-        ls -la
+        rm glualint.zip
 
     - name: Check code with glualint
-      run: ./glualint 
+      run: ./glualint .

--- a/gamemodes/terrortown/gamemode/client/vgui/cl_sb_row.lua
+++ b/gamemodes/terrortown/gamemode/client/vgui/cl_sb_row.lua
@@ -20,6 +20,7 @@ local ipairs = ipairs
 local IsValid = IsValid
 local surface = surface
 local vgui = vgui
+
 local color_trans = Color(0, 0, 0, 0)
 
 local ttt2_indicator_dev = "vgui/ttt/ttt2_indicator_dev"

--- a/gamemodes/terrortown/gamemode/client/vgui/cl_sb_row.lua
+++ b/gamemodes/terrortown/gamemode/client/vgui/cl_sb_row.lua
@@ -20,7 +20,6 @@ local ipairs = ipairs
 local IsValid = IsValid
 local surface = surface
 local vgui = vgui
-local bad_variable_hehe = "useless"
 local color_trans = Color(0, 0, 0, 0)
 
 local ttt2_indicator_dev = "vgui/ttt/ttt2_indicator_dev"

--- a/gamemodes/terrortown/gamemode/client/vgui/cl_sb_row.lua
+++ b/gamemodes/terrortown/gamemode/client/vgui/cl_sb_row.lua
@@ -20,7 +20,7 @@ local ipairs = ipairs
 local IsValid = IsValid
 local surface = surface
 local vgui = vgui
-
+local bad_variable_hehe = "useless"
 local color_trans = Color(0, 0, 0, 0)
 
 local ttt2_indicator_dev = "vgui/ttt/ttt2_indicator_dev"


### PR DESCRIPTION
This adds a CI workflow using Github Actions for the glualint tool.
The Jenkins build will then no longer be needed and all checks / output is available right here on Github, while also reducing the needed maintenance.