### PR TITLE
HUD: Fix saving keys table to be unique for each HUD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ### Fixed
 
 - Fixed foregoing fetch fix
+- Fixed HUD savingKeys variable not being unique across all HUDs
 
 ## [v0.7.3b](https://github.com/TTT-2/TTT2/tree/v0.7.3b) (2020-08-09)
 

--- a/gamemodes/terrortown/gamemode/shared/huds/base_huds/hud_base/cl_init.lua
+++ b/gamemodes/terrortown/gamemode/shared/huds/base_huds/hud_base/cl_init.lua
@@ -13,7 +13,7 @@ HUD.disabledTypes = {}
 -- Has to be a GMOD Material!
 HUD.previewImage = Material("vgui/ttt/score_logo_2")
 
-local savingKeys = {}
+HUD.savingKeys = {}
 
 ---
 -- This function will return a table containing all keys that will be stored by
@@ -21,7 +21,7 @@ local savingKeys = {}
 -- @return table
 -- @realm client
 function HUD:GetSavingKeys()
-	return savingKeys
+	return self.savingKeys
 end
 
 ---


### PR DESCRIPTION
This patch fixes the `savingKeys` table to be unique and not accidentally shared across all HUD's so that for example the old HUD does not falsely receive a base color attribute.