### PR TITLE
TargetID: Fix weapon key info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed HUD savingKeys variable not being unique across all HUDs
 - Fixed drawing web images, seamless web images and avatar images
 - Fixed correctly saving setting a bind to NONE, while a default is defined
+- Fixed a weapon pickup targetID bug where the +use key was displayed even though pickup has its own keybind
 
 ## [v0.7.3b](https://github.com/TTT-2/TTT2/tree/v0.7.3b) (2020-08-09)
 

--- a/gamemodes/terrortown/gamemode/client/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_targetid.lua
@@ -709,11 +709,16 @@ function HUDDrawTargetIDWeapons(tData)
 
 	tData:SetTitle(TryT(weapon_name) .. " [" .. ParT("target_slot_info", {slot = kind_pickup_wep}) .. "]")
 
+	local key_params_wep = {
+		usekey = string.upper(input.GetKeyName(bind.Find("ttt2_weaponswitch"))),
+		walkkey = Key("+walk", "WALK")
+	}
+
 	-- set subtitle depending on the switchmode
 	if switchMode == SWITCHMODE_PICKUP then
-		tData:SetSubtitle(ParT("target_pickup_weapon", key_params) .. (not isActiveWeapon and ParT("target_pickup_weapon_hidden", key_params) or ""))
+		tData:SetSubtitle(ParT("target_pickup_weapon", key_params_wep) .. (not isActiveWeapon and ParT("target_pickup_weapon_hidden", key_params_wep) or ""))
 	elseif switchMode == SWITCHMODE_SWITCH then
-		tData:SetSubtitle(ParT("target_switch_weapon", key_params) .. (not isActiveWeapon and ParT("target_switch_weapon_hidden", key_params) or ""))
+		tData:SetSubtitle(ParT("target_switch_weapon", key_params_wep) .. (not isActiveWeapon and ParT("target_switch_weapon_hidden", key_params_wep) or ""))
 	elseif switchMode == SWITCHMODE_FULLINV then
 		tData:SetSubtitle(TryT("target_switch_weapon_nospace"))
 	end


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13639408/91904745-b9409d80-eca5-11ea-8841-bc2ff2dc4a86.png)

fixes the shown bug where the `+use` key was displayed even though pickup has its own keybind