### PR TITLE
[WIP] ShopEditor: Changed how .minPlayers considers active players

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 - Added ConVar to toggle double-click buying
 - Added Japanese translation (by @Westoon)
+- Added new Global Integer "ttt2_active_players"
 
 ### Changed
 
 - The weapon pickup system has been improved to increase stability and remove edge cases in temporary weapon teleportation
 - Updated Spanish translation (by @DennisWolfgang)
+- Changed so .minPlayers now only considers the active count of players a round had at start
 
 ### Fixed
 

--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -1215,14 +1215,22 @@ function BeginRound()
 
 	local plys = player.GetAll()
 
+	local activeCount = 0
+
 	for i = 1, #plys do
 		local ply = plys[i]
 
 		ply:ResetRoundDeathCounter()
 
+		local isActive = ply:Alive() and ply:IsTerror()
+
 		-- a player should be considered "was active in round" if they received a role
-		ply:SetActiveInRound(ply:Alive() and ply:IsTerror())
+		ply:SetActiveInRound(isActive)
+
+		activeCount = isActive and activeCount+1 or activeCount
 	end
+
+	SetGlobalInt("ttt2_active_players", activeCount)
 
 	hook.Call("TTTBeginRound", GAMEMODE)
 

--- a/gamemodes/terrortown/gamemode/shared/sh_init.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_init.lua
@@ -663,20 +663,9 @@ function EquipmentIsBuyable(tbl, ply)
 	end
 
 	if tbl.minPlayers and tbl.minPlayers > 1 then
-		local choices = {}
-		local plys = player.GetAll()
-
-		for i = 1, #plys do
-			local v = plys[i]
-
-			-- everyone on the forcespec team is in specmode
-			if not IsValid(v) or v:GetForceSpec() then continue end
-
-			choices[#choices + 1] = v
-		end
-
-		if #choices < tbl.minPlayers then
-			return false, " " .. #choices .. " / " .. tbl.minPlayers, "Minimum amount of active players needed."
+		local activePlayers = GetGlobalInt("ttt2_active_players", 0)
+		if activePlayers < tbl.minPlayers then
+			return false, " " .. activePlayers .. " / " .. tbl.minPlayers, "Minimum amount of active players needed."
 		end
 	end
 


### PR DESCRIPTION
.minPlayers will now only consider players that were active in a round. For this I added the global int "ttt2_active_players". I did not use a reset for this, as it is set on every round begin, and I dont think you need to access a "0" in prepare/post.