### PR TITLE
Call Detective Hook: added serverside hook on "call detective"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Added ConVar to toggle double-click buying
 - Added Japanese translation (by @Westoon)
 - Added a team indicator in front of every name in the scoreboard (just known teams will be displayed)
+- Added a hook (`TTT2ModifyCorpseCallRadarReceipients`) that is called once "call detective" is pressed
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Added ConVar to toggle double-click buying
 - Added Japanese translation (by @Westoon)
 - Added a team indicator in front of every name in the scoreboard (just known teams will be displayed)
-- Added a hook (`TTT2ModifyCorpseCallRadarReceipients`) that is called once "call detective" is pressed
+- Added a hook `TTT2ModifyCorpseCallRadarRecipients` that is called once "call detective" is pressed
 
 ### Changed
 

--- a/gamemodes/terrortown/gamemode/server/sv_corpse.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_corpse.lua
@@ -237,7 +237,7 @@ local function ttt_call_detective(ply, cmd, args)
 		if CORPSE.GetFound(rag, false) then
 			local plyTable = GetRoleChatFilter(ROLE_DETECTIVE, true)
 
-			hook.Run("TTT2ModifyCorpseCallRadarReceipients", plyTable, rag, ply)
+			hook.Run("TTT2ModifyCorpseCallRadarRecipients", plyTable, rag, ply)
 
 			-- show indicator in radar to detectives
 			net.Start("TTT_CorpseCall")
@@ -261,7 +261,7 @@ concommand.Add("ttt_call_detective", ttt_call_detective)
 -- @param Player ply The player that pressed the "call detective" button
 -- @hook
 -- @realm server
-function GM:TTT2ModifyCorpseCallRadarReceipients(notifiedPlayers, ragdoll, ply)
+function GM:TTT2ModifyCorpseCallRadarRecipients(notifiedPlayers, ragdoll, ply)
 
 end
 

--- a/gamemodes/terrortown/gamemode/server/sv_corpse.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_corpse.lua
@@ -235,18 +235,35 @@ local function ttt_call_detective(ply, cmd, args)
 
 	if IsValid(rag) and rag:GetPos():Distance(ply:GetPos()) < 128 then
 		if CORPSE.GetFound(rag, false) then
+			local plyTable = GetRoleChatFilter(ROLE_DETECTIVE, true)
+
+			hook.Run("TTT2ModifyCorpseCallRadarReceipients", plyTable, rag, ply)
+
 			-- show indicator in radar to detectives
 			net.Start("TTT_CorpseCall")
 			net.WriteVector(rag:GetPos())
-			net.Send(GetRoleChatFilter(ROLE_DETECTIVE, true))
+			net.Send(plyTable)
 
-			LANG.Msg("body_call", {player = ply:Nick(), victim = CORPSE.GetPlayerNick(rag, "someone")}, MSG_CHAT_PLAIN)
+			LANG.MsgAll("body_call", {player = ply:Nick(), victim = CORPSE.GetPlayerNick(rag, "someone")}, MSG_CHAT_PLAIN)
 		else
 			LANG.Msg(ply, "body_call_error")
 		end
 	end
 end
 concommand.Add("ttt_call_detective", ttt_call_detective)
+
+---
+-- This hook is called after a players pressed the "call detective" button and
+-- all requirements were met. It can be used to modify the table of players that
+-- should receive the corpse radar ping.
+-- @param Player notifiedPlayers The table of players that will be notified
+-- @param Entity ragdoll The ragdoll whose coordinates are about to be sent
+-- @param Player ply The player that pressed the "call detective" button
+-- @hook
+-- @realm server
+function GM:TTT2ModifyCorpseCallRadarReceipients(nofifiedPlayers, ragdoll, ply)
+
+end
 
 local function bitsRequired(num)
 	local bits, max = 0, 1

--- a/gamemodes/terrortown/gamemode/server/sv_corpse.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_corpse.lua
@@ -261,7 +261,7 @@ concommand.Add("ttt_call_detective", ttt_call_detective)
 -- @param Player ply The player that pressed the "call detective" button
 -- @hook
 -- @realm server
-function GM:TTT2ModifyCorpseCallRadarReceipients(nofifiedPlayers, ragdoll, ply)
+function GM:TTT2ModifyCorpseCallRadarReceipients(notifiedPlayers, ragdoll, ply)
 
 end
 

--- a/lua/terrortown/entities/items/item_ttt_radar/cl_init.lua
+++ b/lua/terrortown/entities/items/item_ttt_radar/cl_init.lua
@@ -159,7 +159,7 @@ function RADAR:Draw(client)
 	end
 
 	-- Corpse calls
-	if client:IsActiveRole(ROLE_DETECTIVE) and not table.IsEmpty(self.called_corpses) then
+	if not table.IsEmpty(self.called_corpses) then
 		surface.SetTexture(det_beacon)
 		surface.SetTextColor(255, 255, 255, 240)
 		surface.SetDrawColor(255, 255, 255, 230)


### PR DESCRIPTION
This is a really small change that adds a serverside hook that is called once a player pressed the "call detective" button. This was requested by @blackmagicfine on discord.

Additionally I changed `LANG.Msg` to `LANG.MsgAll`. The previous usage of the function already resulted in a message to everybody, however it isn't obvious to someone new and therefore bad coding style.

Please don't merge this until it is tested. While it doesn't throw errors and looks good to me, the functionality has to be confirmed.