### PR TITLE
Speed: Fix initialization of oldval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed correctly saving setting a bind to NONE, while a default is defined
 - Fixed a weapon pickup targetID bug where the +use key was displayed even though pickup has its own keybind
 - Fixed DNA scanner crash if using an old/different weapon base
+- Fixed rare initialization bug in the speed calculation when joining as a spectator
 
 ## [v0.7.3b](https://github.com/TTT-2/TTT2/tree/v0.7.3b) (2020-08-09)
 

--- a/gamemodes/terrortown/gamemode/shared/sh_speed.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_speed.lua
@@ -25,7 +25,7 @@ function SPEED:HandleSpeedCalculation(ply, moveData)
 	local speedMultiplierModifier = {1}
 	local returnMultiplier = hook.Run("TTTPlayerSpeedModifier", ply, isSlowed, moveData, speedMultiplierModifier) or 1
 
-	local oldval = ply.speedModifier
+	local oldval = ply:GetSpeedMultiplier()
 	ply.speedModifier = baseMultiplier * returnMultiplier * speedMultiplierModifier[1]
 
 	if SERVER then return end


### PR DESCRIPTION
This patch avoids the invalid nil state of the oldval variable in case the users speedMultiplier is not 1 at the initialization.
This is now fixed, by using the GetSpeedMultiplier method, which returns either the speedModifier or 1.0