### PR TITLE
Weapon Pickup: Fixed pickup bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - TargetID text is now scaled with the global scale factor
 - Cleaned up draw function files
 
+### Fixed
+
+- Fixed weapon pickup bug, where weapons would not get dropped but stayed in inventory
+
 ## [v0.7.4b](https://github.com/TTT-2/TTT2/tree/v0.7.4b) (2020-09-28)
 
 ### Added

--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -1369,6 +1369,8 @@ function plymeta:SafePickupWeapon(wep, ammoOnly, forcePickup, dropBlockingWeapon
 		if dropWeapon == wep then return end
 
 		timer.Simple(0, function()
+			if not IsValid(self) or not IsValid(dropWeapon) then return end
+
 			self:SafeDropWeapon(dropWeapon, true)
 		end)
 

--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -1368,7 +1368,9 @@ function plymeta:SafePickupWeapon(wep, ammoOnly, forcePickup, dropBlockingWeapon
 		-- Very very rarely happens but definitely breaks the weapon and should be avoided at all costs
 		if dropWeapon == wep then return end
 
-		self:SafeDropWeapon(dropWeapon, true)
+		timer.Simple(0, function()
+			self:SafeDropWeapon(dropWeapon, true)
+		end)
 
 		-- set flag to new weapon that is used to autoselect it later on
 		shouldAutoSelect = shouldAutoSelect or isActiveWeapon


### PR DESCRIPTION
Fixed bug where some weapons would stay in inventory even though they should get dropped, leading to a player being able to pickup pretty much infinite weapons. (Yes I know its just a timer)