### PR TITLE
[WIP] Migrations: Added migration library to enable schema changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,15 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ## Unreleased
 
+### Added
+
+- Added `migrations` library to enable easy schema changes of database tables
+
 ### Changed
 
 - Added global alias for IsOffScreen function to util.IsOffScreen
 - Updated Japanese localization (by @Westoon)
 - Moved rendering modules to libraries
-
 
 ## [v0.8.1b](https://github.com/TTT-2/TTT2/tree/v0.8.1b) (2021-02-19)
 

--- a/gamemodes/terrortown/gamemode/client/cl_main.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_main.lua
@@ -112,10 +112,6 @@ fileloader.LoadFolder("terrortown/migrations/client/", false, CLIENT_FILE, funct
 	MsgN("Added TTT2 client migration file: ", path)
 end)
 
-fileloader.LoadFolder("terrortown/migrations/shared/", false, SHARED_FILE, function(path)
-	MsgN("Added TTT2 shared migration file: ", path)
-end)
-
 -- all files are loaded
 local TryT = LANG.TryTranslation
 

--- a/gamemodes/terrortown/gamemode/client/cl_main.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_main.lua
@@ -108,6 +108,14 @@ fileloader.LoadFolder("terrortown/autorun/shared/", false, SHARED_FILE, function
 	MsgN("Added TTT2 shared autorun file: ", path)
 end)
 
+fileloader.LoadFolder("terrortown/migrations/client/", false, CLIENT_FILE, function(path)
+	MsgN("Added TTT2 client migration file: ", path)
+end)
+
+fileloader.LoadFolder("terrortown/migrations/shared/", false, SHARED_FILE, function(path)
+	MsgN("Added TTT2 shared migration file: ", path)
+end)
+
 -- all files are loaded
 local TryT = LANG.TryTranslation
 

--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -267,6 +267,18 @@ fileloader.LoadFolder("terrortown/autorun/server/", false, SERVER_FILE, function
 	MsgN("Added TTT2 server autorun file: ", path)
 end)
 
+fileloader.LoadFolder("terrortown/migrations/client/", false, CLIENT_FILE, function(path)
+	MsgN("Marked TTT2 client migration file for distribution: ", path)
+end)
+
+fileloader.LoadFolder("terrortown/migrations/shared/", false, SHARED_FILE, function(path)
+	MsgN("Marked and added TTT2 shared migration file for distribution: ", path)
+end)
+
+fileloader.LoadFolder("terrortown/migrations/server/", false, SERVER_FILE, function(path)
+	MsgN("Added TTT2 server migration file: ", path)
+end)
+
 CHANGED_EQUIPMENT = {}
 
 ---

--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -271,10 +271,6 @@ fileloader.LoadFolder("terrortown/migrations/client/", false, CLIENT_FILE, funct
 	MsgN("Marked TTT2 client migration file for distribution: ", path)
 end)
 
-fileloader.LoadFolder("terrortown/migrations/shared/", false, SHARED_FILE, function(path)
-	MsgN("Marked and added TTT2 shared migration file for distribution: ", path)
-end)
-
 fileloader.LoadFolder("terrortown/migrations/server/", false, SERVER_FILE, function(path)
 	MsgN("Added TTT2 server migration file: ", path)
 end)

--- a/gamemodes/terrortown/gamemode/shared/sh_init.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_init.lua
@@ -522,6 +522,7 @@ include("ttt2/libraries/thermalvision.lua")
 include("ttt2/libraries/events.lua")
 include("ttt2/libraries/none.lua")
 include("ttt2/libraries/targetid.lua")
+include("ttt2/libraries/migrations.lua")
 
 -- include ttt required files
 ttt_include("sh_decal")

--- a/lua/ttt2/libraries/migrations.lua
+++ b/lua/ttt2/libraries/migrations.lua
@@ -1,0 +1,85 @@
+---
+-- A database schema migration library
+-- @author Histalek
+
+if SERVER then
+	AddCSLuaFile()
+end
+
+migration = migration or {}
+
+if not sql.TableExists("migration_master") then
+	sql.Query("CREATE TABLE \"migration_master\" ( \"identifier\" TEXT, \"version\" INTEGER, \"up\" TEXT, \"down\" TEXT, \"created_at\" TEXT, \"executed_at\" TEXT, PRIMARY KEY(\"identifier\",\"version\"));")
+end
+
+---
+-- Adds a migration to the database and also runs the migration.
+-- @param string identifier The unique identifier for a series of migrations. Together with `version` used to control the sequence of migrations.
+-- @param number version The unique version in the series of migrations. Together with `identifier` used to control the sequence of migrations.
+-- @param string upQuery The sqlQuery to execute.
+-- @param string downQuery The sqlQuery used to revert the `upQuery`.
+-- @return boolean|nil Returns `true` if the migration succeeded, `nil` if the migration was already executed and `false` in case of an error.
+function migration.Add(identifier, version, upQuery, downQuery)
+
+	local checkQuery = "SELECT \"executed_at\" FROM \"migration_master\""
+						.. " WHERE \"identifier\"=" .. sql.SQLStr(identifier)
+						.. " AND \"version\"=" .. sql.SQLStr(version)
+	local checkResult = sql.Query(checkQuery)
+
+	if istable(checkResult) then return end -- migration was already executed
+
+	if checkResult == false then
+		print("checkResult: " .. sql.LastError())
+		return false
+	end
+
+	local masterQuery = "INSERT OR IGNORE INTO \"migration_master\" (\"identifier\", \"version\", \"up\", \"down\", \"created_at\") VALUES ("
+						.. sql.SQLStr(identifier) .. ", "
+						.. sql.SQLStr(version) .. ", "
+						.. sql.SQLStr(upQuery) .. ", "
+						.. sql.SQLStr(downQuery) .. ", "
+						.. sql.SQLStr(os.time()) .. ")"
+
+	if sql.Query(masterQuery) == false then
+		print("masterResult: " .. sql.LastError())
+		return false
+	end
+
+	if sql.Query(upQuery) == false then
+		print("upresult: " .. sql.LastError())
+		return false
+	end
+
+	local setExecutedQuery = "UPDATE \"migration_master\" SET \"executed_at\"=" .. sql.SQLStr(os.time())
+							.. " WHERE \"identifier\"=" .. sql.SQLStr(identifier)
+							.. " AND \"version\"=" .. sql.SQLStr(version)
+
+	if sql.Query(setExecutedQuery) == false then
+		print("setexecutedresult: " .. sql.LastError())
+		return false
+	end
+
+	return true
+end
+
+---
+-- Runs all unrun migrations with the given identifier.
+-- @param string identifier The identifier for which all migrations should be run.
+-- @return boolean|nil Returns `true` if at least one migration was run, `nil` if all migrations were already run and `false` in case of an error.
+function migration.MigrateAll(identifier)
+end
+
+---
+-- Reverts all run migrations with the given identifier.
+-- @param string identifier The identifier for which all migrations should be reverted.
+-- @return boolean|nil Returns `true` if at least one migration was reverted, `nil` if no migrations was reverted and `false` in case of an error.
+function migration.RevertAll(identifier)
+end
+
+---
+-- Runs or reverts migrations with the given identifier to the given version (the state after the upQuery of the specified version).
+-- @param string identifier The identifier for the migrations which should be set.
+-- @param number version The desired version of the databaseschema.
+-- @return boolean|nil Returns `true` if at least one migration was run or reverted, `nil` if no migrations were run or reverted and `false` in case of an error.
+function migration.MigrateToVersion(identifier, version)
+end

--- a/lua/ttt2/libraries/migrations.lua
+++ b/lua/ttt2/libraries/migrations.lua
@@ -45,10 +45,13 @@ function migration.Add(identifier, version, upQuery, downQuery)
 		return false
 	end
 
+	sql.Begin()
 	if sql.Query(upQuery) == false then
 		print("upresult: " .. sql.LastError())
+		sql.Query("Rollback;")
 		return false
 	end
+	sql.Commit()
 
 	local setExecutedQuery = "UPDATE \"migration_master\" SET \"executed_at\"=" .. sql.SQLStr(os.time())
 							.. " WHERE \"identifier\"=" .. sql.SQLStr(identifier)

--- a/lua/ttt2/libraries/migrations.lua
+++ b/lua/ttt2/libraries/migrations.lua
@@ -1,5 +1,5 @@
 ---
--- A database schema migration library
+-- A database schema migrations library
 -- @author Histalek
 -- @module migrations
 
@@ -7,7 +7,7 @@ if SERVER then
 	AddCSLuaFile()
 end
 
-migration = migration or {}
+migrations = migrations or {}
 
 local sql = sql
 
@@ -23,7 +23,7 @@ end
 -- @param string downQuery The sqlQuery used to revert the `upQuery`.
 -- @return boolean|nil Returns `true` if the migration succeeded, `nil` if the migration was already executed and `false` in case of an error.
 -- @realm shared
-function migration.Add(identifier, version, upQuery, downQuery)
+function migrations.Add(identifier, version, upQuery, downQuery)
 
 	local checkQuery = "SELECT \"executed_at\" FROM \"migration_master\""
 						.. " WHERE \"identifier\"=" .. sql.SQLStr(identifier)
@@ -70,7 +70,7 @@ end
 -- @param string identifier The identifier for which all migrations should be run.
 -- @return boolean|nil Returns `true` if at least one migration was run, `nil` if all migrations were already run and `false` in case of an error.
 -- @realm shared
-function migration.MigrateAll(identifier)
+function migrations.MigrateAll(identifier)
 end
 
 ---
@@ -78,7 +78,7 @@ end
 -- @param string identifier The identifier for which all migrations should be reverted.
 -- @return boolean|nil Returns `true` if at least one migration was reverted, `nil` if no migration was reverted and `false` in case of an error.
 -- @realm shared
-function migration.RevertAll(identifier)
+function migrations.RevertAll(identifier)
 end
 
 ---
@@ -87,5 +87,5 @@ end
 -- @param number version The desired version of the databaseschema.
 -- @return boolean|nil Returns `true` if at least one migration was run or reverted, `nil` if no migrations were run or reverted and `false` in case of an error.
 -- @realm shared
-function migration.MigrateToVersion(identifier, version)
+function migrations.MigrateToVersion(identifier, version)
 end

--- a/lua/ttt2/libraries/migrations.lua
+++ b/lua/ttt2/libraries/migrations.lua
@@ -18,7 +18,7 @@ if not sql.TableExists("migration_master") then
 end
 
 ---
--- Adds a migration to the database. Use @{migrations.MigrateToVersion()} once after all migrations are added.
+-- Adds a migration to the database. Use @{migrations.MigrateToVersion} once after all migrations are added.
 -- @note This should be used in an extra file at `terrortown/migrations/<realm>/<namespace>.lua`.
 -- @param string namespace The unique namespace for a series of migrations.
 -- @param number version The unique version in the namespace. Should incremented by 1 for each new version.

--- a/lua/ttt2/libraries/migrations.lua
+++ b/lua/ttt2/libraries/migrations.lua
@@ -10,26 +10,29 @@ end
 migrations = migrations or {}
 
 local sql = sql
+local tonumber = tonumber
+local isnumber = isnumber
 
 if not sql.TableExists("migration_master") then
-	sql.Query("CREATE TABLE \"migration_master\" ( \"identifier\" TEXT, \"version\" INTEGER, \"up\" TEXT, \"down\" TEXT, \"created_at\" TEXT, \"executed_at\" TEXT, PRIMARY KEY(\"identifier\",\"version\"));")
+	sql.Query("CREATE TABLE \"migration_master\" ( \"identifier\" TEXT, \"version\" INTEGER, \"up\" TEXT, \"down\" TEXT, \"created_at\" INTEGER, \"executed_at\" INTEGER, PRIMARY KEY(\"identifier\",\"version\"));")
 end
 
 ---
--- Adds a migration to the database and also runs the migration.
+-- Adds a migration to the database. Use @{migrations.MigrateToVersion()} once after all migrations are added.
 -- @note This should be used in an extra file at `terrortown/migrations/<realm>/<identifier>.lua`.
 -- @param string identifier The unique identifier for a series of migrations.
 -- @param number version The unique version in the series of migrations. Should incremented by 1 for each new version.
 -- @param string upQuery The sqlQuery to execute.
 -- @param [opt]string downQuery The sqlQuery used to revert the `upQuery`.
 -- @param [opt]string existingTable The name of the database table to port to the 'migrations' library.
--- @return boolean|nil Returns `true` if the migration succeeded, `nil` if the migration was already executed and `false` in case of an error.
+-- @return boolean|nil Returns `false` in case of an error and `nil` otherwise.
 -- @realm shared
 function migrations.Add(identifier, version, upQuery, downQuery, existingTable)
 
 	local checkQuery = "SELECT \"executed_at\" FROM \"migration_master\""
 						.. " WHERE \"identifier\"=" .. sql.SQLStr(identifier)
 						.. " AND \"version\"=" .. sql.SQLStr(version)
+
 	local checkResult = sql.Query(checkQuery)
 
 	if istable(checkResult) then return end -- migration was already executed
@@ -38,42 +41,80 @@ function migrations.Add(identifier, version, upQuery, downQuery, existingTable)
 		return false
 	end
 
-	local masterQuery = "INSERT OR IGNORE INTO \"migration_master\" (\"identifier\", \"version\", \"up\", \"down\", \"created_at\") VALUES ("
+	local masterQuery = "INSERT OR IGNORE INTO \"migration_master\" (\"identifier\", \"version\", \"up\", \"down\", \"created_at\", \"executed_at\") VALUES ("
 						.. sql.SQLStr(identifier) .. ", "
 						.. sql.SQLStr(version) .. ", "
 						.. sql.SQLStr(upQuery) .. ", "
 						.. sql.SQLStr(downQuery) .. ", "
-						.. sql.SQLStr(os.time()) .. ")"
+						.. sql.SQLStr(os.time()) .. ", "
+						.. sql.SQLStr(0) .. ")"
 
 	if sql.Query(masterQuery) == false then
 		return false
 	end
 
-	if existingTable and not sql.TableExists(existingTable) then
+	if not existingTable then return end
+
+	local setExecutedQuery = "UPDATE \"migration_master\" SET \"executed_at\"=" .. sql.SQLStr(os.time())
+						.. " WHERE \"identifier\"=" .. sql.SQLStr(identifier)
+						.. " AND \"version\"=" .. sql.SQLStr(version)
+
+	if sql.Query(setExecutedQuery) == false then
+		return false
+	end
+end
+
+---
+-- Runs or reverts migrations with the given identifier to the given version (the state after the upQuery of the specified version).
+-- @param string identifier The identifier for the migrations which should be run.
+-- @param number version The desired version of the databaseschema.
+-- @return boolean Returns `true` if the desired version was successfully migrated and `false` in case of an error.
+-- @realm shared
+function migrations.MigrateToVersion(identifier, version)
+
+	local currentVersion = tonumber(sql.QueryValue("SELECT max(\"version\") FROM \"migration_master\" WHERE \"executed_at\">0"))
+
+	if isnumber(currentVersion) and currentVersion == version then
+		return true
+	end
+
+	local migrationTable
+
+	if isnumber(currentVersion) and currentVersion > version then -- higher versin than desired -> execute down queries
+		local getMigrationQuery = "SELECT \"version\", \"down\" as query FROM \"migration_master\""
+						.. " WHERE \"identifier\"=" .. sql.SQLStr(identifier)
+						.. " AND \"version\"<" .. sql.SQLStr(currentVersion)
+						.. " ORDER BY \"version\" DESC"
+
+		migrationTable = sql.Query(getMigrationQuery)
+	else -- lower version or no version -> execute up queries
+		local getMigrationQuery = "SELECT \"version\", \"up\" as query FROM \"migration_master\""
+						.. " WHERE \"identifier\"=" .. sql.SQLStr(identifier)
+						.. " AND \"version\">" .. sql.SQLStr(currentVersion)
+						.. " ORDER BY \"version\" ASC"
+
+		migrationTable = sql.Query(getMigrationQuery)
+	end
+
+	-- loop through migrationTable and execute queries
+	for _, value in ipairs(migrationTable) do
+
 		sql.Begin()
-		if sql.Query(upQuery) == false then
+		if sql.Query(value.query) == false then
+			sql.Query("Rollback;")
+			return false
+		end
+
+		local setExecutedQuery = "UPDATE \"migration_master\" SET \"executed_at\"=" .. sql.SQLStr(os.time())
+								.. " WHERE \"identifier\"=" .. sql.SQLStr(identifier)
+								.. " AND \"version\"=" .. sql.SQLStr(version)
+
+		if sql.Query(setExecutedQuery) == false then
 			sql.Query("Rollback;")
 			return false
 		end
 		sql.Commit()
 	end
 
-	local setExecutedQuery = "UPDATE \"migration_master\" SET \"executed_at\"=" .. sql.SQLStr(os.time())
-							.. " WHERE \"identifier\"=" .. sql.SQLStr(identifier)
-							.. " AND \"version\"=" .. sql.SQLStr(version)
-
-	if sql.Query(setExecutedQuery) == false then
-		return false
-	end
-
 	return true
-end
-
----
--- Runs or reverts migrations with the given identifier to the given version (the state after the upQuery of the specified version).
--- @param string identifier The identifier for the migrations which should be set.
--- @param number version The desired version of the databaseschema.
--- @return boolean|nil Returns `true` if at least one migration was run or reverted, `nil` if no migrations were run or reverted and `false` in case of an error.
--- @realm shared
-function migrations.MigrateToVersion(identifier, version)
 end

--- a/lua/ttt2/libraries/migrations.lua
+++ b/lua/ttt2/libraries/migrations.lua
@@ -1,12 +1,15 @@
 ---
 -- A database schema migration library
 -- @author Histalek
+-- @module migrations
 
 if SERVER then
 	AddCSLuaFile()
 end
 
 migration = migration or {}
+
+local sql = sql
 
 if not sql.TableExists("migration_master") then
 	sql.Query("CREATE TABLE \"migration_master\" ( \"identifier\" TEXT, \"version\" INTEGER, \"up\" TEXT, \"down\" TEXT, \"created_at\" TEXT, \"executed_at\" TEXT, PRIMARY KEY(\"identifier\",\"version\"));")
@@ -45,7 +48,7 @@ function migration.Add(identifier, version, upQuery, downQuery)
 
 	sql.Begin()
 	if sql.Query(upQuery) == false then
-		sql.Rollback()
+		sql.Query("Rollback;")
 		return false
 	end
 	sql.Commit()
@@ -71,7 +74,7 @@ end
 ---
 -- Reverts all run migrations with the given identifier.
 -- @param string identifier The identifier for which all migrations should be reverted.
--- @return boolean|nil Returns `true` if at least one migration was reverted, `nil` if no migrations was reverted and `false` in case of an error.
+-- @return boolean|nil Returns `true` if at least one migration was reverted, `nil` if no migration was reverted and `false` in case of an error.
 function migration.RevertAll(identifier)
 end
 

--- a/lua/ttt2/libraries/migrations.lua
+++ b/lua/ttt2/libraries/migrations.lua
@@ -70,22 +70,6 @@ function migrations.Add(identifier, version, upQuery, downQuery, existingTable)
 end
 
 ---
--- Runs all unrun migrations with the given identifier.
--- @param string identifier The identifier for which all migrations should be run.
--- @return boolean|nil Returns `true` if at least one migration was run, `nil` if all migrations were already run and `false` in case of an error.
--- @realm shared
-function migrations.MigrateAll(identifier)
-end
-
----
--- Reverts all run migrations with the given identifier.
--- @param string identifier The identifier for which all migrations should be reverted.
--- @return boolean|nil Returns `true` if at least one migration was reverted, `nil` if no migration was reverted and `false` in case of an error.
--- @realm shared
-function migrations.RevertAll(identifier)
-end
-
----
 -- Runs or reverts migrations with the given identifier to the given version (the state after the upQuery of the specified version).
 -- @param string identifier The identifier for the migrations which should be set.
 -- @param number version The desired version of the databaseschema.

--- a/lua/ttt2/libraries/migrations.lua
+++ b/lua/ttt2/libraries/migrations.lua
@@ -14,23 +14,23 @@ local tonumber = tonumber
 local isnumber = isnumber
 
 if not sql.TableExists("migration_master") then
-	sql.Query("CREATE TABLE \"migration_master\" ( \"identifier\" TEXT, \"version\" INTEGER, \"up\" TEXT, \"down\" TEXT, \"created_at\" INTEGER, \"executed_at\" INTEGER, PRIMARY KEY(\"identifier\",\"version\"));")
+	sql.Query("CREATE TABLE \"migration_master\" ( \"namespace\" TEXT, \"version\" INTEGER, \"up\" TEXT, \"down\" TEXT, \"created_at\" INTEGER, \"executed_at\" INTEGER, PRIMARY KEY(\"namespace\",\"version\"));")
 end
 
 ---
 -- Adds a migration to the database. Use @{migrations.MigrateToVersion()} once after all migrations are added.
--- @note This should be used in an extra file at `terrortown/migrations/<realm>/<identifier>.lua`.
--- @param string identifier The unique identifier for a series of migrations.
--- @param number version The unique version in the series of migrations. Should incremented by 1 for each new version.
+-- @note This should be used in an extra file at `terrortown/migrations/<realm>/<namespace>.lua`.
+-- @param string namespace The unique namespace for a series of migrations.
+-- @param number version The unique version in the namespace. Should incremented by 1 for each new version.
 -- @param string upQuery The sqlQuery to execute.
 -- @param [opt]string downQuery The sqlQuery used to revert the `upQuery`.
 -- @param [opt]string existingTable The name of the database table to port to the 'migrations' library.
 -- @return boolean|nil Returns `false` in case of an error and `nil` otherwise.
 -- @realm shared
-function migrations.Add(identifier, version, upQuery, downQuery, existingTable)
+function migrations.Add(namespace, version, upQuery, downQuery, existingTable)
 
 	local checkQuery = "SELECT \"executed_at\" FROM \"migration_master\""
-						.. " WHERE \"identifier\"=" .. sql.SQLStr(identifier)
+						.. " WHERE \"namespace\"=" .. sql.SQLStr(namespace)
 						.. " AND \"version\"=" .. sql.SQLStr(version)
 
 	local checkResult = sql.Query(checkQuery)
@@ -41,8 +41,8 @@ function migrations.Add(identifier, version, upQuery, downQuery, existingTable)
 		return false
 	end
 
-	local masterQuery = "INSERT OR IGNORE INTO \"migration_master\" (\"identifier\", \"version\", \"up\", \"down\", \"created_at\", \"executed_at\") VALUES ("
-						.. sql.SQLStr(identifier) .. ", "
+	local masterQuery = "INSERT OR IGNORE INTO \"migration_master\" (\"namespace\", \"version\", \"up\", \"down\", \"created_at\", \"executed_at\") VALUES ("
+						.. sql.SQLStr(namespace) .. ", "
 						.. sql.SQLStr(version) .. ", "
 						.. sql.SQLStr(upQuery) .. ", "
 						.. sql.SQLStr(downQuery) .. ", "
@@ -56,7 +56,7 @@ function migrations.Add(identifier, version, upQuery, downQuery, existingTable)
 	if not existingTable then return end
 
 	local setExecutedQuery = "UPDATE \"migration_master\" SET \"executed_at\"=" .. sql.SQLStr(os.time())
-						.. " WHERE \"identifier\"=" .. sql.SQLStr(identifier)
+						.. " WHERE \"namespace\"=" .. sql.SQLStr(namespace)
 						.. " AND \"version\"=" .. sql.SQLStr(version)
 
 	if sql.Query(setExecutedQuery) == false then
@@ -65,12 +65,12 @@ function migrations.Add(identifier, version, upQuery, downQuery, existingTable)
 end
 
 ---
--- Runs or reverts migrations with the given identifier to the given version (the state after the upQuery of the specified version).
--- @param string identifier The identifier for the migrations which should be run.
+-- Runs or reverts migrations with the given namespace to the given version (the state after the upQuery of the specified version).
+-- @param string namespace The namespace for the migrations which should be run.
 -- @param number version The desired version of the databaseschema.
 -- @return boolean Returns `true` if the desired version was successfully migrated and `false` in case of an error.
 -- @realm shared
-function migrations.MigrateToVersion(identifier, version)
+function migrations.MigrateToVersion(namespace, version)
 
 	local currentVersion = tonumber(sql.QueryValue("SELECT max(\"version\") FROM \"migration_master\" WHERE \"executed_at\">0"))
 
@@ -80,23 +80,22 @@ function migrations.MigrateToVersion(identifier, version)
 
 	local migrationTable
 
-	if isnumber(currentVersion) and currentVersion > version then -- higher versin than desired -> execute down queries
+	if isnumber(currentVersion) and currentVersion > version then -- higher version than desired -> execute down queries
 		local getMigrationQuery = "SELECT \"version\", \"down\" as query FROM \"migration_master\""
-						.. " WHERE \"identifier\"=" .. sql.SQLStr(identifier)
+						.. " WHERE \"namespace\"=" .. sql.SQLStr(namespace)
 						.. " AND \"version\"<" .. sql.SQLStr(currentVersion)
 						.. " ORDER BY \"version\" DESC"
 
 		migrationTable = sql.Query(getMigrationQuery)
 	else -- lower version or no version -> execute up queries
 		local getMigrationQuery = "SELECT \"version\", \"up\" as query FROM \"migration_master\""
-						.. " WHERE \"identifier\"=" .. sql.SQLStr(identifier)
+						.. " WHERE \"namespace\"=" .. sql.SQLStr(namespace)
 						.. " AND \"version\">" .. sql.SQLStr(currentVersion)
 						.. " ORDER BY \"version\" ASC"
 
 		migrationTable = sql.Query(getMigrationQuery)
 	end
 
-	-- loop through migrationTable and execute queries
 	for _, value in ipairs(migrationTable) do
 
 		sql.Begin()
@@ -106,7 +105,7 @@ function migrations.MigrateToVersion(identifier, version)
 		end
 
 		local setExecutedQuery = "UPDATE \"migration_master\" SET \"executed_at\"=" .. sql.SQLStr(os.time())
-								.. " WHERE \"identifier\"=" .. sql.SQLStr(identifier)
+								.. " WHERE \"namespace\"=" .. sql.SQLStr(namespace)
 								.. " AND \"version\"=" .. sql.SQLStr(version)
 
 		if sql.Query(setExecutedQuery) == false then

--- a/lua/ttt2/libraries/migrations.lua
+++ b/lua/ttt2/libraries/migrations.lua
@@ -29,7 +29,6 @@ function migration.Add(identifier, version, upQuery, downQuery)
 	if istable(checkResult) then return end -- migration was already executed
 
 	if checkResult == false then
-		print("checkResult: " .. sql.LastError())
 		return false
 	end
 
@@ -41,14 +40,12 @@ function migration.Add(identifier, version, upQuery, downQuery)
 						.. sql.SQLStr(os.time()) .. ")"
 
 	if sql.Query(masterQuery) == false then
-		print("masterResult: " .. sql.LastError())
 		return false
 	end
 
 	sql.Begin()
 	if sql.Query(upQuery) == false then
-		print("upresult: " .. sql.LastError())
-		sql.Query("Rollback;")
+		sql.Rollback()
 		return false
 	end
 	sql.Commit()
@@ -58,7 +55,6 @@ function migration.Add(identifier, version, upQuery, downQuery)
 							.. " AND \"version\"=" .. sql.SQLStr(version)
 
 	if sql.Query(setExecutedQuery) == false then
-		print("setexecutedresult: " .. sql.LastError())
 		return false
 	end
 

--- a/lua/ttt2/libraries/migrations.lua
+++ b/lua/ttt2/libraries/migrations.lua
@@ -22,6 +22,7 @@ end
 -- @param string upQuery The sqlQuery to execute.
 -- @param string downQuery The sqlQuery used to revert the `upQuery`.
 -- @return boolean|nil Returns `true` if the migration succeeded, `nil` if the migration was already executed and `false` in case of an error.
+-- @realm shared
 function migration.Add(identifier, version, upQuery, downQuery)
 
 	local checkQuery = "SELECT \"executed_at\" FROM \"migration_master\""
@@ -68,6 +69,7 @@ end
 -- Runs all unrun migrations with the given identifier.
 -- @param string identifier The identifier for which all migrations should be run.
 -- @return boolean|nil Returns `true` if at least one migration was run, `nil` if all migrations were already run and `false` in case of an error.
+-- @realm shared
 function migration.MigrateAll(identifier)
 end
 
@@ -75,6 +77,7 @@ end
 -- Reverts all run migrations with the given identifier.
 -- @param string identifier The identifier for which all migrations should be reverted.
 -- @return boolean|nil Returns `true` if at least one migration was reverted, `nil` if no migration was reverted and `false` in case of an error.
+-- @realm shared
 function migration.RevertAll(identifier)
 end
 
@@ -83,5 +86,6 @@ end
 -- @param string identifier The identifier for the migrations which should be set.
 -- @param number version The desired version of the databaseschema.
 -- @return boolean|nil Returns `true` if at least one migration was run or reverted, `nil` if no migrations were run or reverted and `false` in case of an error.
+-- @realm shared
 function migration.MigrateToVersion(identifier, version)
 end


### PR DESCRIPTION
This library should allow for changes of the database schema in a reversible and controlled manner.

Right now only the addition of migrations is implemented but the other functions are already documented, so let me know if you miss any functionality.

Depending on which other included files will use the migration library we may need to include it sooner (in `gamemodes/terrortown/gamemode/shared/sh_init.lua`).