### PR TITLE
Overhead Icon: Fixed material name

### DIFF
--- a/gamemodes/terrortown/gamemode/client/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_targetid.lua
@@ -37,7 +37,7 @@ local colorKeyBack = Color(0, 0, 0, 150)
 -- cached materials for overhead icons and outlines
 local materialPropspecOutline = Material("models/props_combine/portalball001_sheet")
 local materialBase = Material("vgui/ttt/dynamic/sprite_base")
-local materialBaseOverlay = Material("vgui/ttt/dynamic/sprite_materialBaseOverlay")
+local materialBaseOverlay = Material("vgui/ttt/dynamic/sprite_base_overlay")
 
 -- materials for targetid
 local materialRing = Material("effects/select_ring")


### PR DESCRIPTION
While renaming variables in a previous PR, a material path was affected as well. This resulted in the checkerboard pattern of overheadicons