### PR TITLE
[FIX, util] Fixed library cache name

### DIFF
--- a/lua/ttt2/extensions/util.lua
+++ b/lua/ttt2/extensions/util.lua
@@ -20,7 +20,7 @@ local playerGetAll = player.GetAll
 local stringSplit = string.Split
 local tableConcat = table.concat
 local weaponsGetStored = weapons.GetStored
-local sentsGetStored = sentsGetStored
+local sentsGetStored = scripted_ents.GetStored
 local sentsGet = scripted_ents.Get
 
 local mathMax = math.max


### PR DESCRIPTION
Fixed a library cache variable to point to the correct library instead of `nil`