### PR TITLE
LANG: Fix indefinitely rebuilding language settings menu

### DIFF
--- a/gamemodes/terrortown/gamemode/client/cl_help/populate_language.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_help/populate_language.lua
@@ -1,5 +1,6 @@
 local materialIcon = Material("vgui/ttt/vskin/helpscreen/language")
 
+local GetActiveLanguageName = LANG.GetActiveLanguageName
 local GetTranslatedLanguageName = LANG.GetTranslatedLanguageName
 local TryT = LANG.TryTranslation
 
@@ -10,21 +11,32 @@ local function PopulateLanguagePanel(parent)
 		label = "label_language_set",
 		convar = "ttt_language",
 		OnChange = function(slf, index, value, rawdata)
+
+			if rawdata == "auto" and GetActiveLanguageName() == "auto" then return end
+
+			if value == GetTranslatedLanguageName(GetActiveLanguageName()) then return end
+
 			vguihandler.InvalidateVSkin()
 			vguihandler.Rebuild()
 		end
 	})
 
 	-- since these are no simple strings, the choices have to be added manually
-	dlang:AddChoice(TryT("lang_server_default"), "auto")
+	dlang:AddChoice(TryT("lang_server_default"), "auto", false)
 
 	for _, lang in pairs(LANG.GetLanguages()) do
-		dlang:AddChoice(GetTranslatedLanguageName(lang), lang)
+		dlang:AddChoice(GetTranslatedLanguageName(lang), lang, false)
+	end
+
+	if GetActiveLanguageName() == "auto" then
+		dlang:ChooseOptionName(TryT("lang_server_default"))
+	else
+		dlang:ChooseOptionName(GetTranslatedLanguageName(GetActiveLanguageName()))
 	end
 
 	form:MakeHelp({
 		label = "help_lang_info",
-		params = {coverage = math.Round(100 * LANG.GetDefaultCoverage(LANG.GetActiveLanguageName()), 1)}
+		params = {coverage = math.Round(100 * LANG.GetDefaultCoverage(GetActiveLanguageName()), 1)}
 	})
 end
 

--- a/gamemodes/terrortown/gamemode/client/cl_lang.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_lang.lua
@@ -281,7 +281,7 @@ end
 function LANG.SetActiveLanguage(langName)
 	if langName == nil then return end
 
-	langName = string.lower(langName)
+	langName = LANG.GetNameFromAlias(langName)
 
 	if LANG.IsLanguage(langName) then
 		local oldName = LANG.ActiveLanguage
@@ -361,7 +361,7 @@ end
 cvars.AddChangeCallback("ttt_language", LanguageChanged)
 
 local function ForceReload()
-	LANG.SetActiveLanguage("english")
+	LANG.SetActiveLanguage(LANG.DefaultLanguage)
 end
 concommand.Add("ttt_reloadlang", ForceReload)
 
@@ -514,6 +514,8 @@ function LANG.GetDefaultCoverage(langName)
 	end
 
 	local englishTbl = LANG.Strings[LANG.DefaultLanguage]
+
+	langName = LANG.GetNameFromAlias(langName)
 
 	return table.GetEqualEntriesAmount(LANG.Strings[langName], englishTbl) / table.Count(englishTbl)
 end

--- a/gamemodes/terrortown/gamemode/client/cl_radio.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_radio.lua
@@ -305,7 +305,7 @@ local function RadioCommand(ply, cmd, arg)
 
 		if msg.cmd ~= msg_type then continue end
 
-		local eng = LANG.GetTranslationFromLanguage(msg.text, "english")
+		local eng = LANG.GetTranslationFromLanguage(msg.text, "en")
 		local _tmp = {player = RADIO.ToPrintable(target)}
 
 		text = msg.format and string.Interp(eng, _tmp) or eng

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcombobox_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcombobox_ttt2.lua
@@ -154,7 +154,7 @@ end
 ---
 -- @param string value
 -- @param any data
--- @param any _ (unused)
+-- @param any select
 -- @param string icon
 -- @return number index
 -- @realm client

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcombobox_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcombobox_ttt2.lua
@@ -158,7 +158,7 @@ end
 -- @param string icon
 -- @return number index
 -- @realm client
-function PANEL:AddChoice(value, data, _, icon)
+function PANEL:AddChoice(value, data, select, icon)
 	local i = #self.choices + 1
 
 	self.choices[i] = value

--- a/gamemodes/terrortown/gamemode/shared/lang/chef.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/chef.lua
@@ -24,7 +24,7 @@ local realised = false
 local function LanguageChanged(old, new)
 	if realised or new ~= "swedish_chef" then return end
 
-	local eng = LANG.GetUnsafeNamed("english")
+	local eng = LANG.GetUnsafeNamed("en")
 
 	for k, v in pairs(eng) do
 		L[k] = gsub(v, "[{}%w]+", Borkify)
@@ -39,6 +39,6 @@ local GetFrom = LANG.GetTranslationFromLanguage
 
 setmetatable(L, {
 	__index = function(_, k)
-		return gsub(GetFrom(k, "english") or "bork", "[{}%w]+", "BORK")
+		return gsub(GetFrom(k, "en") or "bork", "[{}%w]+", "BORK")
 	end
 })

--- a/gamemodes/terrortown/gamemode/shared/sh_lang.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_lang.lua
@@ -112,7 +112,7 @@ if SERVER then
 
 	---
 	-- @realm server
-	local cv_ttt_lang_serverdefault = CreateConVar("ttt_lang_serverdefault", "english", FCVAR_ARCHIVE)
+	local cv_ttt_lang_serverdefault = CreateConVar("ttt_lang_serverdefault", "en", FCVAR_ARCHIVE)
 
 	local function ServerLangRequest(ply, cmd, args)
 		if not IsValid(ply) then return end
@@ -150,7 +150,7 @@ else -- CLIENT
 	local function RecvServerLang()
 		local lang_name = net.ReadString()
 
-		lang_name = lang_name and string.lower(lang_name)
+		lang_name = LANG.GetNameFromAlias(lang_name)
 
 		if LANG.Strings[lang_name] then
 			if LANG.IsServerDefault(GetConVar("ttt_language"):GetString()) then


### PR DESCRIPTION
Prevent the language menu from rebuilding indefinitely. fixes #705 