### PR TITLE
CI: NeoDoc bump to v0.1.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 env:
   GLUALINT_VERSION: 1.16.4
-  NEODOC_VERSION: 0.1.2
+  NEODOC_VERSION: 0.1.3
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 env:
   GLUALINT_VERSION: 1.16.4
-  NEODOC_VERSION: 0.1.3
+  NEODOC_VERSION: 0.1.4
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch

--- a/gamemodes/terrortown/gamemode/client/cl_lang.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_lang.lua
@@ -30,7 +30,7 @@ local colorWarn = Color(255, 70, 45)
 -- Creates a new language
 -- @param string langName The new language name
 -- @return table initialized language table that should be extended with translated @{string}s
--- @ealm client
+-- @realm client
 function LANG.CreateLanguage(langName)
 	if not langName then return end
 

--- a/gamemodes/terrortown/gamemode/client/cl_lang.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_lang.lua
@@ -30,7 +30,7 @@ local colorWarn = Color(255, 70, 45)
 -- Creates a new language
 -- @param string langName The new language name
 -- @return table initialized language table that should be extended with translated @{string}s
--- @realm client
+-- @ealm client
 function LANG.CreateLanguage(langName)
 	if not langName then return end
 


### PR DESCRIPTION
This bumps the NeoDoc version to the newest, which can provide annotations with its errors to pull requests.

This is how it would look like in a PR "Files changed" view:
![image](https://user-images.githubusercontent.com/10776964/103491941-d8079a00-4e27-11eb-978f-40c14a58f305.png)
