### PR TITLE
Roleselection: Fix Layering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 - Fixed weapon pickup bug, where weapons would not get dropped but stayed in inventory
 - Fixed a roleselection bug, where forced roles would not be deducted from the available roles
+- Fixed a roleselection bug, where only one special baserole was selected
 
 ## [v0.7.4b](https://github.com/TTT-2/TTT2/tree/v0.7.4b) (2020-09-28)
 

--- a/gamemodes/terrortown/gamemode/server/sv_roleselection.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_roleselection.lua
@@ -414,7 +414,7 @@ function roleselection.GetSelectableRolesList(maxPlys, rolesAmountList)
 
 		-- if there are still defined layer
 		if #layeredBaseRolesTbl >= i then
-			for j = i , #layeredBaseRolesTbl do
+			for j = i, #layeredBaseRolesTbl do
 				local cleanedLayerTbl = CleanupAvailableRolesLayerTbl(availableBaseRolesTbl, layeredBaseRolesTbl[i]) -- clean the currently indexed layer (so that it just includes selectable roles), because we working with predefined layers that probably includes roles that aren't selectable with the current amount of players, etc.
 
 				-- if there is no selectable role left in the current layer
@@ -439,7 +439,6 @@ function roleselection.GetSelectableRolesList(maxPlys, rolesAmountList)
 		end
 
 		selectableRoles[subrole] = rolesAmountList[subrole]
-
 		baseroleLoopTbl[#baseroleLoopTbl + 1] = subrole
 
 		curRoles = curRoles + 1
@@ -468,24 +467,28 @@ function roleselection.GetSelectableRolesList(maxPlys, rolesAmountList)
 
 			-- the selected role
 			local subrole = nil
-			local currentSubroleLayer = layeredSubRolesTbl[currentBaserole]
+			local currentSubroleLayers = layeredSubRolesTbl[currentBaserole]
 
-			-- if there are still defined layer
-			if currentSubroleLayer ~= nil and #currentSubroleLayer >= i then
-				local cleanedLayerTbl = CleanupAvailableRolesLayerTbl(currentSubroleTbl, currentSubroleLayer[i]) -- clean the currently indexed layer (so that it just includes selectable roles), because we working with predefined layers that probably includes roles that aren't selectable with the current amount of players, etc.
+			-- if there are still defined layers
+			if currentSubroleLayers ~= nil and #currentSubroleLayers >= i then
+				for j = i, #currentSubroleLayers do
+					local cleanedLayerTbl = CleanupAvailableRolesLayerTbl(currentSubroleTbl, currentSubroleLayers[i]) -- clean the currently indexed layer (so that it just includes selectable roles), because we working with predefined layers that probably includes roles that aren't selectable with the current amount of players, etc.
 
-				-- if there is no selectable role left in the current layer
-				if #cleanedLayerTbl < 1 then
-					table.remove(layeredSubRolesTbl, i) -- remove the current layer
+					-- if there is no selectable role left in the current layer
+					if #cleanedLayerTbl < 1 then
+						table.remove(layeredSubRolesTbl, i) -- remove the current layer
 
-					-- redo the current loop with the same index
-					i = i - 1
+						-- redo the current loop with the same index
+						continue
+					end
 
-					continue
+					subrole = cleanedLayerTbl[math.random(#cleanedLayerTbl)]
+					break;
 				end
+			end
 
-				subrole = cleanedLayerTbl[math.random(#cleanedLayerTbl)]
-			else -- if no subrole was selected (no layer left or no layer defined)
+			-- if no subrole was selected (no layer left or no layer defined)
+			if not subrole then
 				local rnd = math.random(#currentSubroleTbl)
 				subrole = currentSubroleTbl[rnd]
 

--- a/gamemodes/terrortown/gamemode/server/sv_roleselection.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_roleselection.lua
@@ -386,6 +386,10 @@ function roleselection.GetSelectableRolesList(maxPlys, rolesAmountList)
 			availableBaseRolesTbl[availableBaseRolesAmount] = subrole
 		end
 	end
+	print("\nAll Available Subroles:")
+	PrintTable(availableSubRolesTbl)
+	print("\nAll Available BaseRoles:")
+	PrintTable(availableBaseRolesTbl)
 
 	local selectableRoles = {
 		[ROLE_TRAITOR] = rolesAmountList[ROLE_TRAITOR],
@@ -396,9 +400,16 @@ function roleselection.GetSelectableRolesList(maxPlys, rolesAmountList)
 
 	local layeredBaseRolesTbl = table.Copy(roleselection.baseroleLayers) -- layered roles list, the order defines the pick order. Just one role per layer is picked. Before a role is picked, the given layer is cleared (checked if the given roles are still selectable). Insert a table as a "or" list
 
+	print("\nLayerd BaseRoles before hook:")
+	PrintTable(layeredBaseRolesTbl)
 	---
 	-- @realm server
 	hook.Run("TTT2ModifyLayeredBaseRoles", layeredBaseRolesTbl, availableBaseRolesTbl)
+
+	print("\nLayerd BaseRoles after hook:")
+	PrintTable(layeredBaseRolesTbl)
+	print("\nAll Available BaseRoles after Hook:")
+	PrintTable(availableBaseRolesTbl)
 
 	local baseroleLoopTbl = { -- just contains available / selectable baseroles
 		ROLE_TRAITOR,
@@ -774,7 +785,11 @@ function roleselection.SelectRoles(plys, maxPlys)
 	if maxPlys < 2 then return end -- we don't need to select anything if there is just one player
 
 	local allAvailableRoles = roleselection.GetAllSelectableRolesList(maxPlys)
+	print("\nAll Available Roles:")
+	PrintTable(allAvailableRoles)
 	local selectableRoles = roleselection.GetSelectableRolesList(maxPlys, allAvailableRoles) -- update roleselection.selectableRoles table
+	print("\nAll Selectable Roles:")
+	PrintTable(selectableRoles)
 
 	UpdateFinalRoles() -- Update the roleselection.finalRoles table by removing all invalid players
 
@@ -809,6 +824,8 @@ function roleselection.SelectRoles(plys, maxPlys)
 
 			list[#list + 1] = subrole
 		end
+		print("\nAll Roles for Distribution:")
+		PrintTable(list)
 
 		-- Check all base roles, and assign players where possible.
 		-- After that, this will also try to upgrade the selected players, to any applicable subrole, that might replace the baserole.


### PR DESCRIPTION
Before this fix, there was a for-loop that should have been repeated with the same index, if certain conditions were met. As lua creates a fixed set of indizes, which it internally iterates through changes to the index i in this case had no effect. Therefore if an empty layer was found, the next layer got also skipped as a consequence.

The Fix therefore now safely iterates through the layers until a valid layer is found and chooses a role out of it.
In case it still has baseroles left, but doesnt find a valid layer, the rest of available base roles are chosen after that. That's why I switched from if-else to two if-statements.

Still missing is a fix to the subroles, which are a bit more tricky. But this is my first draft for discussion.