### PR TITLE
Karma: Fixed karma damage bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 - Fixed weapon pickup bug, where weapons would not get dropped but stayed in inventory
 - Fixed a roleselection bug, where forced roles would not be deducted from the available roles
+- Fixed a karma bug, where damage would still be reduced even though the karma system was disabled
 
 ## [v0.7.4b](https://github.com/TTT-2/TTT2/tree/v0.7.4b) (2020-09-28)
 

--- a/gamemodes/terrortown/gamemode/server/sv_karma.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_karma.lua
@@ -93,6 +93,11 @@ local function ttt_karma_max(cvar, old, new)
 end
 cvars.AddChangeCallback("ttt_karma_max", ttt_karma_max)
 
+local function ttt_karma(cvar, old, new)
+	SetGlobalBool("ttt_karma", tobool(new))
+end
+cvars.AddChangeCallback("ttt_karma", ttt_karma)
+
 ---
 -- Initializes the KARMA System
 -- @realm server

--- a/gamemodes/terrortown/gamemode/server/sv_player.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player.lua
@@ -1387,7 +1387,7 @@ function GM:PlayerTakeDamage(ent, infl, att, amount, dmginfo)
 
 	-- handle damage scaling by karma
 	if IsValid(att) and att:IsPlayer() and GetRoundState() == ROUND_ACTIVE and math.floor(dmginfo:GetDamage()) > 0 then
-		if ent ~= att and not dmginfo:IsDamageType(DMG_SLASH) then
+		if KARMA.IsEnabled() and ent ~= att and not dmginfo:IsDamageType(DMG_SLASH) then
 			-- scale everything to karma damage factor except the knife, because it assumes a kill
 			dmginfo:ScaleDamage(att:GetDamageFactor())
 		end


### PR DESCRIPTION
Fixed so karma will no longer be accounted for in the damage if the system was disabled.
Related to https://github.com/TTT-2/TTT2/issues/686