### PR TITLE
Weapon - Magnetostick: Fix inno ragdoll pinning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed a credit award bug, where detectives would receive a pointless notification about being awarded with 0 credits
 - Fixed a karma bug, where damage would still be reduced even though the karma system was disabled
 - Fixed a roleselection bug, where invalid layers led to skipping the next layer too
+- Fixed Magneto Stick ragdoll pinning instructions not showing for innocents when `ttt_ragdoll_pinning_innocents` is enabled
 
 ## [v0.7.4b](https://github.com/TTT-2/TTT2/tree/v0.7.4b) (2020-09-28)
 

--- a/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
@@ -666,6 +666,7 @@ function SWEP:SetupDataTables()
 	-- we've got these dt slots anyway, might as well use them instead of a
 	-- globalvar, probably cheaper
 	self:DTVar("Bool", 0, "can_rag_pin")
+	self:DTVar("Bool", 0, "can_rag_pin_inno")
 
 	-- client actually has no idea what we're holding, and almost never needs to
 	-- know
@@ -679,6 +680,7 @@ if SERVER then
 	-- @ignore
 	function SWEP:Initialize()
 		self.dt.can_rag_pin = GetGlobalBool("ttt_ragdoll_pinning")
+		self.dt.can_pin_rag_inno = GetGlobalBool("ttt_ragdoll_pinning_innocents")
 		self.dt.carried_rag = nil
 
 		return self.BaseClass.Initialize(self)
@@ -733,7 +735,7 @@ if CLIENT then
 		if self.dt.can_rag_pin and IsValid(self.dt.carried_rag) then
 			local client = LocalPlayer()
 
-			if client:IsSpec() or not client:IsTraitor() then return end
+			if client:IsSpec() or not client:IsTraitor() and not self.dt.can_rag_pin_inno then return end
 
 			local tr = util.TraceLine({
 				start = client:EyePos(),


### PR DESCRIPTION
Fixed Magneto Stick ragdoll pinning instructions not showing for innocents when ttt_ragdoll_pinning_innocents is enabled