### PR TITLE
Classbuilder: Fixed inheriting from same base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ### Fixed
 
-- Inheriting from the same base in different folders did not work
+- Inheriting from the same base using the classbuilder in different folders did not work
 
 ## [v0.8.0b](https://github.com/TTT-2/TTT2/tree/v0.8.0b) (2021-02-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed a karma bug, where damage would still be reduced even though the karma system was disabled
 - Fixed a roleselection bug, where invalid layers led to skipping the next layer too
 - Fixed Magneto Stick ragdoll pinning instructions not showing for innocents when `ttt_ragdoll_pinning_innocents` is enabled
+- Fixed a bug where the targetID info broke if the pickup key is unbound
 
 ## [v0.7.4b](https://github.com/TTT-2/TTT2/tree/v0.7.4b) (2020-09-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ## Unreleased
 
+### Fixed
+
+- Inheriting from the same base in different folders did not work
+
 ### Added
 
 - Added a new vgui system

--- a/lua/ttt2/libraries/classbuilder.lua
+++ b/lua/ttt2/libraries/classbuilder.lua
@@ -24,9 +24,10 @@ classbuilder = classbuilder or {}
 -- @param[opt] function OnInitialization This callback function is called on initialization of the class
 -- @param[default=false] boolean shouldInherit Set this to true if this class should inherit from its base
 -- @param[opt] function SpecialCheck A function that makes a special check, inheritance is blocked if false is returned
+-- @param[opt] table passthrough A table that can be passed through if the classdata table should be extended
 -- @return table Returns a table of all the created classes
 -- @realm shared
-function classbuilder.BuildFromFolder(path, realm, scope, OnInitialization, shouldInherit, SpecialCheck)
+function classbuilder.BuildFromFolder(path, realm, scope, OnInitialization, shouldInherit, SpecialCheck, passthrough)
 	-- In case this function is run on the server but the class should only exist
 	-- on the client, this function should work only as a proxy.
 	if SERVER and realm == CLIENT_FILE then
@@ -70,7 +71,7 @@ function classbuilder.BuildFromFolder(path, realm, scope, OnInitialization, shou
 		for name, class in pairs(classTable) do
 			if not class.base then continue end
 
-			local base = classTable[class.base]
+			local base = classTable[class.base] or passthrough[class.base]
 
 			if isfunction(SpecialCheck) and not SpecialCheck(class, base) then continue end
 

--- a/lua/ttt2/libraries/events.lua
+++ b/lua/ttt2/libraries/events.lua
@@ -289,7 +289,7 @@ local function OnInitialization(class, path, name)
 
 	_G["EVENT_" .. string.upper(name)] = name
 
-	MsgN("Added TTT2 event file: ", path)
+	MsgN("Added TTT2 event file: ", path, name)
 end
 
 eventTypes = classbuilder.BuildFromFolder(
@@ -307,5 +307,6 @@ table.Merge(eventTypes, classbuilder.BuildFromFolder(
 	"EVENT", -- class scope
 	OnInitialization, -- on class loaded
 	true, -- should inherit
-	ShouldInherit -- special inheritance check
+	ShouldInherit, -- special inheritance check
+	eventTypes
 ))

--- a/lua/ttt2/libraries/targetid.lua
+++ b/lua/ttt2/libraries/targetid.lua
@@ -253,7 +253,7 @@ function targetid.HUDDrawTargetIDWeapons(tData)
 	tData:SetTitle(TryT(weapon_name) .. " [" .. ParT("target_slot_info", {slot = kind_pickup_wep}) .. "]")
 
 	local key_params_wep = {
-		usekey = string.upper(input.GetKeyName(bind.Find("ttt2_weaponswitch"))),
+		usekey = string.upper(input.GetKeyName(bind.Find("ttt2_weaponswitch")) or ""),
 		walkkey = Key("+walk", "WALK")
 	}
 


### PR DESCRIPTION
Right now inheriting on the same base from different calls does not work because the base is restricted to the one call for one specific folder. I change it in such a way that a table can be passed through.

Additionally I improved the event loading print.