### PR TITLE
Docs: Module name fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ### Fixed
 
 - Inheriting from the same base using the classbuilder in different folders did not work
+- Fixed a docstring in the vskin module
 
 ## [v0.8.0b](https://github.com/TTT-2/TTT2/tree/v0.8.0b) (2021-02-06)
 

--- a/lua/ttt2/libraries/vskin.lua
+++ b/lua/ttt2/libraries/vskin.lua
@@ -1,7 +1,7 @@
 ---
 -- A handler for the skin colors
 -- @author Mineotopia
--- @module skin
+-- @module vskin
 
 if SERVER then
 	AddCSLuaFile()


### PR DESCRIPTION
Fixed the module name for the `vskin` module.