### PR TITLE
Credits: Made TTT2CanTransferCredits a part of GM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 - Inheriting from the same base using the classbuilder in different folders did not work
 - Fixed a docstring in the vskin module
+- Made TTT2CanTransferCredits hook a part of GM for API Documentation sanity
 
 ## [v0.8.0b](https://github.com/TTT-2/TTT2/tree/v0.8.0b) (2021-02-06)
 

--- a/gamemodes/terrortown/gamemode/client/cl_transfer.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_transfer.lua
@@ -16,7 +16,7 @@ local selected_sid
 -- Called to check if a transaction between two players is allowed.
 -- @param Player sender that wants to send credits
 -- @param Player recipient that would receive the credits
--- @param Number credits_per_xfer that would be transferred
+-- @param number credits_per_xfer that would be transferred
 -- @return[default=nil] boolean which disallows a transaction when false
 -- @return[default=nil] string for the client which offers info related to the transaction
 -- @hook

--- a/gamemodes/terrortown/gamemode/client/cl_transfer.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_transfer.lua
@@ -21,7 +21,7 @@ local selected_sid
 -- @return[default=nil] string for the client which offers info related to the transaction
 -- @hook
 -- @realm client
-function TTT2CanTransferCredits(sender, recipient, credits_per_xfer)
+function GM:TTT2CanTransferCredits(sender, recipient, credits_per_xfer)
 
 end
 

--- a/gamemodes/terrortown/gamemode/server/sv_shop.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_shop.lua
@@ -202,7 +202,7 @@ concommand.Add("ttt_cheat_credits", CheatCredits, nil, nil, FCVAR_CHEAT)
 -- @return[default=nil] string for the client which offers info related to the transaction
 -- @hook
 -- @realm server
-function TTT2CanTransferCredits(sender, recipient, credits_per_xfer)
+function GM:TTT2CanTransferCredits(sender, recipient, credits_per_xfer)
 
 end
 

--- a/gamemodes/terrortown/gamemode/server/sv_shop.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_shop.lua
@@ -197,7 +197,7 @@ concommand.Add("ttt_cheat_credits", CheatCredits, nil, nil, FCVAR_CHEAT)
 -- Called to check if a transaction between two players is allowed.
 -- @param Player sender that wants to send credits
 -- @param Player recipient that would receive the credits
--- @param Number credits_per_xfer that would be transferred
+-- @param number credits_per_xfer that would be transferred
 -- @return[default=nil] boolean which disallows a transaction when false
 -- @return[default=nil] string for the client which offers info related to the transaction
 -- @hook


### PR DESCRIPTION
The TTT2CanTransferCredits hook from my previous pull request seems to have messed with the API Documentation somewhat:
![Credit_Hook_Whoops](https://user-images.githubusercontent.com/5722300/108473240-a1080f00-7242-11eb-9446-538aa3cd9aa3.PNG)

Based on the layout, it seems like it should be a part of the GM section, so I went ahead and made that change. Not sure why the right panel has "()" and nothing else.