### PR TITLE
Compat: Add global alias for util.IsOffScreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ### Changed
 
+- Added global alias for IsOffScreen function to util.IsOffScreen
 - Updated Japanese localization (by @Westoon)
 
 

--- a/lua/ttt2/extensions/util.lua
+++ b/lua/ttt2/extensions/util.lua
@@ -463,6 +463,9 @@ if CLIENT then
 		death = Color(255, 0, 0, 255)
 	}
 
+	-- Backward compatibility
+	IsOffScreen = util.IsOffScreen
+
 	---
 	-- Checks whether a given position is on screen
 	-- @param table scrpos table with x and y attributes


### PR DESCRIPTION
This small patch just adds an alias for the util function IsOffScreen() as a global function, cause this breaks tttdamagelogs for example.