### PR TITLE
Fixed outline library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Inheriting from the same base using the classbuilder in different folders did not work
 - Fixed a docstring in the vskin module
 - Made TTT2CanTransferCredits hook a part of GM for API Documentation sanity
+- Fixed outline library not working
 
 ## [v0.8.0b](https://github.com/TTT-2/TTT2/tree/v0.8.0b) (2021-02-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 - TTT: fix instant reload of dropped weapon (by @svdm)
 - TTT: fix ragdoll pinning HUD for innocents (by @Flapchik)
+- Fixed outline library not working
 
 ### Changed
 
@@ -23,7 +24,6 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Inheriting from the same base using the classbuilder in different folders did not work
 - Fixed a docstring in the vskin module
 - Made TTT2CanTransferCredits hook a part of GM for API Documentation sanity
-- Fixed outline library not working
 
 ## [v0.8.0b](https://github.com/TTT-2/TTT2/tree/v0.8.0b) (2021-02-06)
 

--- a/lua/ttt2/libraries/outline.lua
+++ b/lua/ttt2/libraries/outline.lua
@@ -112,8 +112,8 @@ local function Render()
 			local ent = ents[j]
 
 			if not IsValid(ent)
-			or mode == OUTLINE_MODE_NOTVISIBLE and IsLineOfSightClear(ent)
-			or mode == OUTLINE_MODE_VISIBLE and not IsLineOfSightClear(ent) then
+			or mode == OUTLINE_MODE_NOTVISIBLE and IsLineOfSightClear(client, ent)
+			or mode == OUTLINE_MODE_VISIBLE and not IsLineOfSightClear(client, ent) then
 				continue
 			end
 


### PR DESCRIPTION
This will fix #736 and therefore makes the outline library finally work as intended.
By inputting the client as self into the function call, we now really get if the line of sight is clear.
Before that, the call broke as it didnt get enough arguments.

Also explaining why it didn't occur before with addons like glowing teammates and probably the glowing jester:
Global variables of modules created with module("name",package.seeall) need to be accessed via their modulename:
So outline.OUTLINE_MODE_NOTVISIBLE instead of just the variablename.

This might lead to addons not working as intended anymore. They should evaluate if they might need the OUTLINE_MODE_NOTVISIBLE mode instead now, so that teammates are visible only through walls or the other way round with OUTLINE_MODE_VISIBLE only if visible/inlineofsight or even always with OUTLINE_MODE_BOTH.
