### PR TITLE
CI: fix CI by bumping glualint to v1.17.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 env:
-  GLUALINT_VERSION: 1.17.0
+  GLUALINT_VERSION: 1.17.2
   NEODOC_VERSION: 0.1.4
 
 # Controls when the action will run. Triggers the workflow on push or pull request
@@ -38,7 +38,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - uses: actions/checkout@v2
-    
+
     - name: Setup .NET Core
       run: sudo apt-get install -y mono-complete
 


### PR DESCRIPTION
This should fix the `./glualint: error while loading shared libraries: libffi.so.6: cannot open shared object file: No such file or directory` error in CI.

ref: https://github.com/FPtje/GLuaFixer/releases/tag/1.17.2