### PR TITLE
Util: Fixed IsOffScreen function being global for compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ### Fixed
 
-- Fixed IsOffsceen function being global for compatibility
+- Fixed IsOffScreen function being global for compatibility
 
 ## [v0.8.2b](https://github.com/TTT-2/TTT2/tree/v0.8.2b) (2021-03-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ## Unreleased
 
+### Fixed
+
+- Fixed IsOffsceen function being global for compatibility
+
 ## [v0.8.2b](https://github.com/TTT-2/TTT2/tree/v0.8.2b) (2021-03-25)
 
 ### Fixed

--- a/lua/ttt2/extensions/util.lua
+++ b/lua/ttt2/extensions/util.lua
@@ -463,9 +463,6 @@ if CLIENT then
 		death = Color(255, 0, 0, 255)
 	}
 
-	-- Backward compatibility
-	IsOffScreen = util.IsOffScreen
-
 	---
 	-- Checks whether a given position is on screen
 	-- @param table scrpos table with x and y attributes
@@ -474,6 +471,9 @@ if CLIENT then
 	function util.IsOffScreen(scrpos)
 		return not scrpos.visible or scrpos.x < 0 or scrpos.y < 0 or scrpos.x > ScrW() or scrpos.y > ScrH()
 	end
+
+	-- Backward compatibility
+	IsOffScreen = util.IsOffScreen
 
 	---
 	-- Creates a @{string} based on the given health and maxhealth


### PR DESCRIPTION
This fixes a mistake, where the `util.IsOffScreen` function is being exposed as a global function, before it is defined.
PR, that introduced the mistake: https://github.com/TTT-2/TTT2/pull/731
