### PR TITLE
[WIP] Add completed Roles Guide to Help Menu

### DIFF
--- a/gamemodes/terrortown/gamemode/client/cl_help/populate_guide.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_help/populate_guide.lua
@@ -1,5 +1,39 @@
 local materialIcon = Material("vgui/ttt/vskin/helpscreen/guide")
 
+local function PopulateRolesPanel(parent)
+	local roles = roles.GetList()
+
+	for i = 1, #roles do
+		local role = roles[i]
+
+		local rolename = role.name
+
+		local Collapsible = vgui.Create( "DCollapsibleCategoryTTT2", parent); //Create a frame
+		Collapsible:CopyWidth(parent);
+		Collapsible:SetLabel(rolename)
+		Collapsible:SetPos(0, (i - 1) * 150)
+
+		local Content = vgui.Create("DContentPanelTTT2");
+		-- Rich Text panel
+		local richtext = vgui.Create( "RichText", Content )
+		richtext:Dock( TOP )
+
+		-- Text segment #1 (grayish color)
+		richtext:InsertColorChange(192, 192, 192, 255)
+		richtext:AppendText("This \nRichText \nis \n")
+
+		-- Text segment #2 (light yellow)
+		richtext:InsertColorChange(255, 255, 224, 255)
+		richtext:AppendText("AWESOME\n\n")
+
+		-- Text segment #3 (red ESRB notice localized string)
+		richtext:InsertColorChange(255, 64, 64, 255)
+		richtext:AppendText("#ServerBrowser_ESRBNotice")
+
+		Collapsible:SetContents(Content);
+	end
+end
+
 HELPSCRN.populate["ttt2_guide"] = function(helpData, id)
 	local bindingsData = helpData:RegisterSubMenu(id)
 
@@ -18,6 +52,7 @@ HELPSCRN.subPopulate["ttt2_guide"] = function(helpData, id)
 	local roleData = helpData:PopulateSubMenu(id .. "_roles")
 
 	roleData:SetTitle("submenu_guide_roles_title")
+	roleData:PopulatePanel(PopulateRolesPanel)
 
 	-- equipment
 	local equipmentData = helpData:PopulateSubMenu(id .. "_equipment")


### PR DESCRIPTION
Currently work in progress! At the moment it loads the roles and creates a panel for each role in the roles help menu. What's still needed:
- [ ] Fix panels so that when they collapse, other panels will fill empty space (also just get rid of excess empty space in general)
- [ ] Create callback function that Roles can pass data to in order to fill out their guide entry
- [ ] Write logic to use Role data to populate panel for the role entry