### PR TITLE
Fixed c4 plant event references for GetText()

### DIFF
--- a/gamemodes/terrortown/gamemode/shared/events/c4explode.lua
+++ b/gamemodes/terrortown/gamemode/shared/events/c4explode.lua
@@ -9,9 +9,9 @@ if CLIENT then
 			{
 				string = "desc_event_c4_explode",
 				params = {
-					owner = self.event.owner.nick,
-					role = roles.GetByIndex(self.event.owner.role).name,
-					team = self.event.owner.team
+					owner = self.event.nick,
+					role = roles.GetByIndex(self.event.role).name,
+					team = self.event.team
 				},
 				translateParams = true
 			}

--- a/gamemodes/terrortown/gamemode/shared/events/c4plant.lua
+++ b/gamemodes/terrortown/gamemode/shared/events/c4plant.lua
@@ -9,9 +9,9 @@ if CLIENT then
 			{
 				string = "desc_event_c4_plant",
 				params = {
-					owner = self.event.owner.nick,
-					role = roles.GetByIndex(self.event.owner.role).name,
-					team = self.event.owner.team
+					owner = self.event.nick,
+					role = roles.GetByIndex(self.event.role).name,
+					team = self.event.team
 				},
 				translateParams = true
 			}


### PR DESCRIPTION
Removed .owner as the Event doesn't have an owner sub table. Alternatively, could change the self:Add() to add the parameters in an owner table.