### PR TITLE
Hook: Traitor tester role change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
   - Enables the possibility to give Innocents access to a custom shop (`shopeditor`)
 - Karma now stores changes
   - Is shown in roundend menu
+- Added a hook `ttt2_get_logic_check_role` that is called when a traitor test or logic role check is performed
 
 ### Fixed
 

--- a/gamemodes/terrortown/entities/entities/ttt_logic_role.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_logic_role.lua
@@ -42,7 +42,7 @@ end
 function ENT:AcceptInput(name, activator)
 	if name == "TestActivator" then
 		if IsValid(activator) and activator:IsPlayer() then
-			local activator_role = (GetRoundState() == ROUND_PREP) and ROLE_INNOCENT or activator:GetBaseRole()
+			local activator_role = (GetRoundState() == ROUND_PREP) and ROLE_INNOCENT or hook.run("ttt2_get_logic_check_role",activator)
 
 			if self.Role == ROLE_NONE or self.Role == activator_role then
 				Dev(2, activator, "passed logic_role test of", self:GetName())

--- a/gamemodes/terrortown/entities/entities/ttt_traitor_check.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_traitor_check.lua
@@ -1,0 +1,43 @@
+
+ENT.Type = "brush"
+ENT.Base = "base_brush"
+
+function ENT:KeyValue(key, value)
+   if key == "TraitorsFound" then
+      -- this is our output, so handle it as such
+      self:StoreOutput(key, value)
+   end
+end
+
+local function VectorInside(vec, mins, maxs)
+   return (vec.x > mins.x and vec.x < maxs.x
+           and vec.y > mins.y and vec.y < maxs.y
+           and vec.z > mins.z and vec.z < maxs.z)
+end
+
+function ENT:CountTraitors()
+   local mins = self:LocalToWorld(self:OBBMins())
+   local maxs = self:LocalToWorld(self:OBBMaxs())
+
+   local trs = 0
+   for _,ply in ipairs(player.GetAll()) do
+      if IsValid(ply) and hook.run("ttt2_get_logic_check_role",ply) == ROLE_TRAITOR and ply:Alive() then
+         local pos = ply:GetPos()
+         if VectorInside(pos, mins, maxs) then
+            trs = trs + 1
+         end
+      end
+   end
+
+   return trs
+end
+
+function ENT:AcceptInput(name, activator, caller)
+   if name == "CheckForTraitor" then
+      local traitors = self:CountTraitors()
+
+      self:TriggerOutput("TraitorsFound", activator, traitors)
+
+      return true
+   end
+end


### PR DESCRIPTION
Okay, this is just a draft to showcase a general idea.

We could just call a hook and ask for the players role.
-For general deactivation of traitor testers, we could just return the innocent role
Problem then is, that traitor only buttons are not working anymore, therefore one would need to add a change.
For example on minecraft_b5 non-traitors get killed when they enter a traitor only room.
You could instead allow every traitor to hide their identity per keypress if that option is enabled.

-Other items are now easily possible