### PR TITLE
Footsteps: Fixed silenced footsteps when moving fast while crouching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed a German translation string (by @FaRLeZz)
 - Fixed a Polish translation by adding new lines (by @Wuker)
 - Fixed a data initialization bug that appeared on the first (initial) spawn
+- Fixed silent Footsteps, while crouched bhopping
 
 ### Changed
 

--- a/gamemodes/terrortown/gamemode/shared/sh_main.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_main.lua
@@ -8,7 +8,7 @@ local UpdateSprint = UpdateSprint
 
 local MAX_DROWN_TIME = 8
 
-local sneakSpeedSquared = math.pow(150,2)
+local sneakSpeedSquared = math.pow(150, 2)
 
 ---
 -- Initializes TTT2

--- a/gamemodes/terrortown/gamemode/shared/sh_main.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_main.lua
@@ -8,6 +8,8 @@ local UpdateSprint = UpdateSprint
 
 local MAX_DROWN_TIME = 8
 
+local sneakSpeedSquared = math.pow(150,2)
+
 ---
 -- Initializes TTT2
 -- @hook
@@ -63,7 +65,7 @@ end
 -- @realm shared
 -- @ref https://wiki.facepunch.com/gmod/GM:PlayerFootstep
 function GM:PlayerFootstep(ply, pos, foot, sound, volume, rf)
-	if IsValid(ply) and (ply:Crouching() or ply:GetMaxSpeed() < 150 or ply:IsSpec()) then
+	if IsValid(ply) and (ply:GetVelocity():LengthSqr() < sneakSpeedSquared or ply:IsSpec()) then
 		-- do not play anything, just prevent normal sounds from playing
 		return true
 	end


### PR DESCRIPTION
#810
Instead of limiting to the players max speed, which doesnt change while crouching, we now check for the real speed, which is 60 for crouching, 100 for slowwalking and 220 for normal walking. Everything below 150 is now muted.
If someone can bhop and is faster than 150 you can hear him. Therefore cant be abused anymore.