### PR TITLE
TeamChat: Fixed issue where base innocents could bypass chat hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed a German translation string (by @FaRLeZz)
 - Fixed a Polish translation by adding new lines (by @Wuker)
 - Fixed a data initialization bug that appeared on the first (initial) spawn
+- Fixed issue where base innocents could bypass the TTT2AvoidGeneralChat and TTT2AvoidTeamChat hooks with the team chat key
+- Fixed issue where roles with unknownTeam could see messages sent with the team chat key
 
 ### Changed
 

--- a/gamemodes/terrortown/gamemode/client/cl_chat.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_chat.lua
@@ -119,13 +119,13 @@ function GM:OnPlayerChat(ply, text, teamChat, isDead)
 		return true
 	end
 
-	local team = ply:Team() == TEAM_SPEC
+	local sTeam = ply:Team() == TEAM_SPEC
 
-	if team and not isDead then
+	if sTeam and not isDead then
 		isDead = true
 	end
 
-	if teamChat and (not team and not ply:IsSpecial() or team) then
+	if teamChat and (sTeam or ply:GetSubRoleData().unknownTeam) then
 		teamChat = false
 	end
 

--- a/gamemodes/terrortown/gamemode/server/sv_gamemsg.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_gamemsg.lua
@@ -80,7 +80,7 @@ local function RoleChatMsg(sender, msg)
 
 	---
 	-- @realm server
-	if tm == TEAM_NONE or sender:GetSubRoleData().disabledTeamChat or TEAMS[tm].alone or hook.Run("TTT2AvoidTeamChat", sender, tm, msg) == false then return end
+	if tm == TEAM_NONE or sender:GetSubRoleData().unknownTeam or sender:GetSubRoleData().disabledTeamChat or TEAMS[tm].alone or hook.Run("TTT2AvoidTeamChat", sender, tm, msg) == false then return end
 
 	net.Start("TTT_RoleChat")
 	net.WriteEntity(sender)
@@ -267,8 +267,8 @@ function GM:PlayerCanSeePlayersChat(text, teamOnly, reader, sender)
 	if GetRoundState() ~= ROUND_ACTIVE -- Round isn't active
 	or not cv_ttt_limit_spectator_chat:GetBool() -- Spectators can chat freely
 	or not DetectiveMode() -- Mumbling
-	or not sTeam and (teamOnly and not sender:IsSpecial() or not teamOnly) -- If someone alive talks (and not a special role in teamchat's case)
-	or not sTeam and teamOnly and (
+	or not sTeam and not teamOnly -- General Chat
+	or not sTeam and teamOnly and ( -- Team Chat
 		sender:IsInTeam(reader)
 		and not sender:GetSubRoleData().unknownTeam
 		and not sender:GetSubRoleData().disabledTeamChat
@@ -364,11 +364,11 @@ function GM:PlayerSay(ply, text, teamOnly)
 			table.insert(filtered, 1, "[MUMBLED]")
 
 			return table.concat(filtered, " ")
-		elseif teamOnly and not team_spec and ply:IsSpecial() then
+		elseif teamOnly and not team_spec then -- Team Chat handling
 			RoleChatMsg(ply, text)
 
 			return ""
-		elseif not teamOnly and not team_spec then
+		elseif not team_spec then -- General Chat handling
 			---
 			-- @realm server
 			if ply:GetSubRoleData().disabledGeneralChat or hook.Run("TTT2AvoidGeneralChat", ply, text) == false then


### PR DESCRIPTION
This pull request fixes two issues:
- Fixed issue where base innocents could bypass the TTT2AvoidGeneralChat and TTT2AvoidTeamChat hooks with the team chat key.
- Fixed issue where roles with unknownTeam could see messages sent with the team chat key

Explicitly, checks for determining whether a player can use/read team chat messages involved the "IsSpecial" function, which only checks if the player is a non-innocent (and further lead to strange behavior with the team chat key). I altered the functionality to be more like voice chat: unknownTeam is used instead now. If the player is on an unknownTeam (Innocents, Detectives, Amnesiacs, etc.), they can technically open up the text box to type messages with the team chat key, but no message will be displayed or sent.