### PR TITLE
Round End Screen: Fixing killer role/team for "something"

### DIFF
--- a/gamemodes/terrortown/gamemode/shared/events/kill.lua
+++ b/gamemodes/terrortown/gamemode/shared/events/kill.lua
@@ -78,7 +78,7 @@ local function KillText(event)
 	if not event.attacker then
 		attackerWasPlayer = false
 
-		params.attacker = trap or "something"
+		params.attacker = trap or "trap_something"
 	end
 
 	-- typically the "_using" strings are only for traps

--- a/gamemodes/terrortown/gamemode/shared/lang/de.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/de.lua
@@ -1292,7 +1292,7 @@ L.desc_event_selected = "Die Rollen und Teams wurden für alle {amount} Spieler 
 L.desc_event_spawn = "{player} ist erschienen."
 
 -- Name of a trap that killed us that has not been named by the mapper
-L.something = "etwas"
+L.trap_something = "etwas"
 
 -- Kill events
 L.desc_event_kill_suicide = "Es war Selbstmord."
@@ -1306,36 +1306,36 @@ L.desc_event_kill_sui = "{victim} ({vrole} / {vteam}) hielt es nicht mehr aus un
 L.desc_event_kill_sui_using = "{victim} ({vrole} / {vteam}) brachte sich mit {tool} um."
 
 L.desc_event_kill_fall = "{victim} ({vrole} / {vteam}) fiel in den Tod."
-L.desc_event_kill_fall_pushed = "{victim} ({vrole} / {vteam}) fiel in den Tod nachdem {attacker} ({arole} / {ateam}) ihn schuppste."
+L.desc_event_kill_fall_pushed = "{victim} ({vrole} / {vteam}) fiel in den Tod nachdem {attacker} ihn schuppste."
 L.desc_event_kill_fall_pushed_using = "{victim} ({vrole} / {vteam}) fiel in den Tod nachdem {attacker} ({arole} / {ateam}) {trap} benutzte, um ihn zu schubsen."
 
-L.desc_event_kill_shot = "{victim} ({vrole} / {vteam}) wurde von {attacker} ({arole} / {ateam}) erschossen."
+L.desc_event_kill_shot = "{victim} ({vrole} / {vteam}) wurde von {attacker} erschossen."
 L.desc_event_kill_shot_using = "{victim} ({vrole} / {vteam}) wurde von {attacker} ({arole} / {ateam}) mit einer/m {weapon} erschossen."
 
-L.desc_event_kill_drown = "{victim} ({vrole} / {vteam}) wurde von {attacker} ({arole} / {ateam}) ertränkt."
+L.desc_event_kill_drown = "{victim} ({vrole} / {vteam}) wurde von {attacker} ertränkt."
 L.desc_event_kill_drown_using = "{victim} ({vrole} / {vteam}) wurde durch {trap} von {attacker} ({arole} / {ateam}) ertränkt."
 
-L.desc_event_kill_boom = "{victim} ({vrole} / {vteam}) wurde von {attacker} ({arole} / {ateam}) gesprengt."
+L.desc_event_kill_boom = "{victim} ({vrole} / {vteam}) wurde von {attacker} gesprengt."
 L.desc_event_kill_boom_using = "{victim} ({vrole} / {vteam}) wurde von {attacker} ({arole} / {ateam}) durch {trap} gesprengt."
 
-L.desc_event_kill_burn = "{victim} ({vrole} / {vteam}) wurde von {attacker} ({arole} / {ateam}) verbrannt."
+L.desc_event_kill_burn = "{victim} ({vrole} / {vteam}) wurde von {attacker} verbrannt."
 L.desc_event_kill_burn_using = "{victim} ({vrole} / {vteam}) wurde durch {trap} von {attacker} ({arole} / {ateam}) verbrannt."
 
-L.desc_event_kill_club = "{victim} ({vrole} / {vteam}) wurde von {attacker} ({arole} / {ateam}) zu Tode geprügelt."
+L.desc_event_kill_club = "{victim} ({vrole} / {vteam}) wurde von {attacker} zu Tode geprügelt."
 L.desc_event_kill_club_using = "{victim} ({vrole} / {vteam}) wurde von {attacker} ({arole} / {ateam}) durch/mit {trap} zu Tode geprügelt."
 
-L.desc_event_kill_slash = "{victim} ({vrole} / {vteam}) wurde von {attacker} ({arole} / {ateam}) erstochen."
+L.desc_event_kill_slash = "{victim} ({vrole} / {vteam}) wurde von {attacker} erstochen."
 L.desc_event_kill_slash_using = "{victim} ({vrole} / {vteam}) wurde von {attacker} ({arole} / {ateam}) durch/mit {trap} aufgeschlitzt."
 
-L.desc_event_kill_tele = "{victim} ({vrole} / {vteam}) wurde von {attacker} ({arole} / {ateam}) telefragged."
+L.desc_event_kill_tele = "{victim} ({vrole} / {vteam}) wurde von {attacker} telefragged."
 L.desc_event_kill_tele_using = "{victim} ({vrole} / {vteam}) wurde atomisiert durch {trap} von {attacker} ({arole} / {ateam})."
 
 L.desc_event_kill_goomba = "{victim} ({vrole} / {vteam}) wurde unter der Masse von {attacker} ({arole} / {ateam}) zerquetscht."
 
-L.desc_event_kill_crush = "{victim} ({vrole} / {vteam}) wurde von {attacker} ({arole} / {ateam}) zerquetscht."
+L.desc_event_kill_crush = "{victim} ({vrole} / {vteam}) wurde von {attacker} zerquetscht."
 L.desc_event_kill_crush_using = "{victim} ({vrole} / {vteam}) wurde durch {trap} von {attacker} ({arole} / {ateam}) zerquetscht."
 
-L.desc_event_kill_other = "{victim} ({vrole} / {vteam}) wurde von {attacker} ({arole} / {ateam}) getötet."
+L.desc_event_kill_other = "{victim} ({vrole} / {vteam}) wurde von {attacker} getötet."
 L.desc_event_kill_other_using = "{victim} ({vrole} / {vteam}) wurde von {attacker} ({arole} / {ateam}) durch {trap} getötet."
 
 -- 2021-04-20

--- a/gamemodes/terrortown/gamemode/shared/lang/en.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/en.lua
@@ -1293,7 +1293,7 @@ L.desc_event_selected = "The teams and roles were selected for all {amount} play
 L.desc_event_spawn = "{player} has spawned."
 
 -- Name of a trap that killed us that has not been named by the mapper
-L.something = "something"
+L.trap_something = "something"
 
 -- Kill events
 L.desc_event_kill_suicide = "It was suicide."
@@ -1307,36 +1307,36 @@ L.desc_event_kill_sui = "{victim} ({vrole} / {vteam}) couldn't take it and kille
 L.desc_event_kill_sui_using = "{victim} ({vrole} / {vteam}) killed themselves using {tool}."
 
 L.desc_event_kill_fall = "{victim} ({vrole} / {vteam}) fell to their death."
-L.desc_event_kill_fall_pushed = "{victim} ({vrole} / {vteam}) fell to their death after {attacker} ({arole} / {ateam}) pushed them."
+L.desc_event_kill_fall_pushed = "{victim} ({vrole} / {vteam}) fell to their death after {attacker} pushed them."
 L.desc_event_kill_fall_pushed_using = "{victim} ({vrole} / {vteam}) fell to their death after {attacker} ({arole} / {ateam}) used {trap} to push them."
 
-L.desc_event_kill_shot = "{victim} ({vrole} / {vteam}) was shot by {attacker} ({arole} / {ateam})."
+L.desc_event_kill_shot = "{victim} ({vrole} / {vteam}) was shot by {attacker}."
 L.desc_event_kill_shot_using = "{victim} ({vrole} / {vteam}) was shot by {attacker} ({arole} / {ateam}) using a {weapon}."
 
-L.desc_event_kill_drown = "{victim} ({vrole} / {vteam}) was drowned by {attacker} ({arole} / {ateam})."
+L.desc_event_kill_drown = "{victim} ({vrole} / {vteam}) was drowned by {attacker}."
 L.desc_event_kill_drown_using = "{victim} ({vrole} / {vteam}) was drowned by {trap} triggered by {attacker} ({arole} / {ateam})."
 
-L.desc_event_kill_boom = "{victim} ({vrole} / {vteam}) was exploded by {attacker} ({arole} / {ateam})."
+L.desc_event_kill_boom = "{victim} ({vrole} / {vteam}) was exploded by {attacker}."
 L.desc_event_kill_boom_using = "{victim} ({vrole} / {vteam}) was blown up by {attacker} ({arole} / {ateam}) using {trap}."
 
-L.desc_event_kill_burn = "{victim} ({vrole} / {vteam}) was fried by {attacker} ({arole} / {ateam})."
+L.desc_event_kill_burn = "{victim} ({vrole} / {vteam}) was fried by {attacker}."
 L.desc_event_kill_burn_using = "{victim} ({vrole} / {vteam}) was burned by {trap} due to {attacker} ({arole} / {ateam})."
 
-L.desc_event_kill_club = "{victim} ({vrole} / {vteam}) was beaten up by {attacker} ({arole} / {ateam})."
+L.desc_event_kill_club = "{victim} ({vrole} / {vteam}) was beaten up by {attacker}."
 L.desc_event_kill_club_using = "{victim} ({vrole} / {vteam}) was pummeled to death by {attacker} ({arole} / {ateam}) using {trap}."
 
-L.desc_event_kill_slash = "{victim} ({vrole} / {vteam}) was stabbed by {attacker} ({arole} / {ateam})."
+L.desc_event_kill_slash = "{victim} ({vrole} / {vteam}) was stabbed by {attacker}."
 L.desc_event_kill_slash_using = "{victim} ({vrole} / {vteam}) was cut up by {attacker} ({arole} / {ateam}) using {trap}."
 
-L.desc_event_kill_tele = "{victim} ({vrole} / {vteam}) was telefragged by {attacker} ({arole} / {ateam})."
+L.desc_event_kill_tele = "{victim} ({vrole} / {vteam}) was telefragged by {attacker}."
 L.desc_event_kill_tele_using = "{victim} ({vrole} / {vteam}) was atomized by {trap} set by {attacker} ({arole} / {ateam})."
 
 L.desc_event_kill_goomba = "{victim} ({vrole} / {vteam}) was crushed by the massive bulk of {attacker} ({arole} / {ateam})."
 
-L.desc_event_kill_crush = "{victim} ({vrole} / {vteam}) was crushed by {attacker} ({arole} / {ateam})."
+L.desc_event_kill_crush = "{victim} ({vrole} / {vteam}) was crushed by {attacker}."
 L.desc_event_kill_crush_using = "{victim} ({vrole} / {vteam}) was crushed by {trap} of {attacker} ({arole} / {ateam})."
 
-L.desc_event_kill_other = "{victim} ({vrole} / {vteam}) was killed by {attacker} ({arole} / {ateam})."
+L.desc_event_kill_other = "{victim} ({vrole} / {vteam}) was killed by {attacker}."
 L.desc_event_kill_other_using = "{victim} ({vrole} / {vteam}) was killed by {attacker} ({arole} / {ateam}) using {trap}."
 
 -- 2021-04-20

--- a/gamemodes/terrortown/gamemode/shared/lang/es.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/es.lua
@@ -1292,7 +1292,7 @@ L.pickup_error_noslot = "No puedes recoger esto porque no tienes un espacio disp
 --L.desc_event_spawn = "{player} has spawned."
 
 -- Name of a trap that killed us that has not been named by the mapper
-L.something = "Algo"
+L.trap_something = "Algo"
 
 -- Kill events
 --L.desc_event_kill_suicide = "It was suicide."
@@ -1306,36 +1306,36 @@ L.desc_event_kill_sui = "{victim} ({vrole} / {vteam}) no pudo soportarlo y se su
 L.desc_event_kill_sui_using = "{victim} ({vrole} / {vteam}) se suicidó usando {tool}."
 
 L.desc_event_kill_fall = "{victim} ({vrole} / {vteam}) cayó hacia su muerte."
-L.desc_event_kill_fall_pushed = "{victim} ({vrole} / {vteam}) cayó hacia su muerta luego de que {attacker} ({arole} / {ateam}) lo empujara."
+L.desc_event_kill_fall_pushed = "{victim} ({vrole} / {vteam}) cayó hacia su muerta luego de que {attacker} lo empujara."
 L.desc_event_kill_fall_pushed_using = "{victim} ({vrole} / {vteam}) cayó hacia su muerte luego de que {attacker} ({arole} / {ateam}) usara {trap} para empujarlo."
 
-L.desc_event_kill_shot = "{victim} ({vrole} / {vteam}) fue fusilado por {attacker} ({arole} / {ateam})."
+L.desc_event_kill_shot = "{victim} ({vrole} / {vteam}) fue fusilado por {attacker}."
 L.desc_event_kill_shot_using = "{victim} ({vrole} / {vteam}) fue fusilado por {attacker} ({arole} / {ateam}) usando un/a {weapon}."
 
-L.desc_event_kill_drown = "{victim} ({vrole} / {vteam}) fue asfixiado hasta la muerte por {attacker} ({arole} / {ateam})."
+L.desc_event_kill_drown = "{victim} ({vrole} / {vteam}) fue asfixiado hasta la muerte por {attacker}."
 L.desc_event_kill_drown_using = "{victim} ({vrole} / {vteam}) fue asfixiado hasta la muerte con {trap} activado por {attacker} ({arole} / {ateam})."
 
-L.desc_event_kill_boom = "{attacker} ({vrole} / {vteam}) hizo volar por los aires a {victim} ({arole} / {ateam})."
+L.desc_event_kill_boom = "{attacker} ({vrole} / {vteam}) hizo volar por los aires a {victim}."
 L.desc_event_kill_boom_using = "{attacker} ({vrole} / {vteam}) hizo volar por los aires a {victim} usando {trap} ({arole} / {ateam})."
 
-L.desc_event_kill_burn = "{victim} ({vrole} / {vteam}) fue incinerado por {attacker} ({arole} / {ateam})."
+L.desc_event_kill_burn = "{victim} ({vrole} / {vteam}) fue incinerado por {attacker}."
 L.desc_event_kill_burn_using = "{victim} ({vrole} / {vteam}) fue incinerado con {trap} por {attacker} ({arole} / {ateam})."
 
-L.desc_event_kill_club = "{victim} ({vrole} / {vteam}) fue golpeado hasta la muerte por {attacker} ({arole} / {ateam})."
+L.desc_event_kill_club = "{victim} ({vrole} / {vteam}) fue golpeado hasta la muerte por {attacker}."
 L.desc_event_kill_club_using = "{victim} ({vrole} / {vteam}) fue golpeado hasta la muerte por {attacker} ({arole} / {ateam}) usando {trap}."
 
-L.desc_event_kill_slash = "{victim} ({vrole} / {vteam}) fue apuñalado por {attacker} ({arole} / {ateam})."
+L.desc_event_kill_slash = "{victim} ({vrole} / {vteam}) fue apuñalado por {attacker}."
 L.desc_event_kill_slash_using = "{victim} ({vrole} / {vteam}) fue cortado en partes por {attacker} ({arole} / {ateam}) usando {trap}."
 
-L.desc_event_kill_tele = "{victim} ({vrole} / {vteam}) fue tele-asesinado por {attacker} ({arole} / {ateam})."
+L.desc_event_kill_tele = "{victim} ({vrole} / {vteam}) fue tele-asesinado por {attacker}."
 L.desc_event_kill_tele_using = "{victim} ({vrole} / {vteam}) a muerto con {trap} por {attacker} ({arole} / {ateam})."
 
 L.desc_event_kill_goomba = "{victim} ({vrole} / {vteam}) fue aplastado por una masa contundente de {attacker} ({arole} / {ateam})."
 
-L.desc_event_kill_crush = "{victim} ({vrole} / {vteam}) fue aplastado por {attacker} ({arole} / {ateam})."
+L.desc_event_kill_crush = "{victim} ({vrole} / {vteam}) fue aplastado por {attacker}."
 L.desc_event_kill_crush_using = "{victim} ({vrole} / {vteam}) fue aplastado con {trap} por {attacker} ({arole} / {ateam})."
 
-L.desc_event_kill_other = "{victim} ({vrole} / {vteam}) fue asesinado por {attacker} ({arole} / {ateam})."
+L.desc_event_kill_other = "{victim} ({vrole} / {vteam}) fue asesinado por {attacker}."
 L.desc_event_kill_other_using = "{victim} ({vrole} / {vteam}) fue asesinado por {attacker} ({arole} / {ateam}) usando {trap}."
 
 -- 2021-04-20

--- a/gamemodes/terrortown/gamemode/shared/lang/fr.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/fr.lua
@@ -1303,7 +1303,7 @@ L.desc_event_selected = "Les teams et les rôles ont été distribuer pour les {
 L.desc_event_spawn = "{player} est apparu."
 
 -- Name of a trap that killed us that has not been named by the mapper
-L.something = "quelque chose"
+L.trap_something = "quelque chose"
 
 -- Kill events
 L.desc_event_kill_suicide = "C'était un suicide."
@@ -1317,36 +1317,36 @@ L.desc_event_kill_sui = "{victim} ({vrole} / {vteam}) n'en pouvait plus et s'est
 L.desc_event_kill_sui_using = "{victim} ({vrole} / {vteam}) s'est tué avec un(e) {tool}."
 
 L.desc_event_kill_fall = "{victim} ({vrole} / {vteam}) a fait une chute mortelle."
-L.desc_event_kill_fall_pushed = "{victim} ({vrole} / {vteam}) a fait une chute mortelle après que {attacker} ({arole} / {ateam}) l'est poussé."
+L.desc_event_kill_fall_pushed = "{victim} ({vrole} / {vteam}) a fait une chute mortelle après que {attacker} l'est poussé."
 L.desc_event_kill_fall_pushed_using = "{victim} ({vrole} / {vteam}) a fait une chute mortelle après que {attacker} ({arole} / {ateam}) est utilisé un {trap} pour le pousser."
 
-L.desc_event_kill_shot = "{victim} ({vrole} / {vteam}) s'est fait tirer dessus par {attacker} ({arole} / {ateam})."
+L.desc_event_kill_shot = "{victim} ({vrole} / {vteam}) s'est fait tirer dessus par {attacker}."
 L.desc_event_kill_shot_using = "{victim} ({vrole} / {vteam}) s'est fait tirer dessus par {attacker} ({arole} / {ateam}) avec un {weapon}."
 
-L.desc_event_kill_drown = "{victim} ({vrole} / {vteam}) s'est noyé à cause de {attacker} ({arole} / {ateam})."
+L.desc_event_kill_drown = "{victim} ({vrole} / {vteam}) s'est noyé à cause de {attacker}."
 L.desc_event_kill_drown_using = "{victim} ({vrole} / {vteam}) s'est noyé à cause de {trap} activé par {attacker} ({arole} / {ateam})."
 
-L.desc_event_kill_boom = "{victim} ({vrole} / {vteam}) est mort d'une explosion causée par {attacker} ({arole} / {ateam})."
+L.desc_event_kill_boom = "{victim} ({vrole} / {vteam}) est mort d'une explosion causée par {attacker}."
 L.desc_event_kill_boom_using = "{victim} ({vrole} / {vteam}) est mort d'une explosion causée par {attacker} ({arole} / {ateam}) avec {trap}."
 
-L.desc_event_kill_burn = "{victim} ({vrole} / {vteam}) s'est fait griller par {attacker} ({arole} / {ateam})."
+L.desc_event_kill_burn = "{victim} ({vrole} / {vteam}) s'est fait griller par {attacker}."
 L.desc_event_kill_burn_using = "{victim} ({vrole} / {vteam}) a brûlé de {trap} à cause de {attacker} ({arole} / {ateam})."
 
-L.desc_event_kill_club = "{victim} ({vrole} / {vteam}) a été battu par {attacker} ({arole} / {ateam})."
+L.desc_event_kill_club = "{victim} ({vrole} / {vteam}) a été battu par {attacker}."
 L.desc_event_kill_club_using = "{victim} ({vrole} / {vteam}) a été roué de coups {attacker} ({arole} / {ateam}) avec {trap}."
 
-L.desc_event_kill_slash = "{victim} ({vrole} / {vteam}) a été poignardé par {attacker} ({arole} / {ateam})."
+L.desc_event_kill_slash = "{victim} ({vrole} / {vteam}) a été poignardé par {attacker}."
 L.desc_event_kill_slash_using = "{victim} ({vrole} / {vteam}) s'est fait coupé par {attacker} ({arole} / {ateam}) avec {trap}."
 
-L.desc_event_kill_tele = "{victim} ({vrole} / {vteam}) s'est fait téléfrag par {attacker} ({arole} / {ateam})."
+L.desc_event_kill_tele = "{victim} ({vrole} / {vteam}) s'est fait téléfrag par {attacker}."
 L.desc_event_kill_tele_using = "{victim} ({vrole} / {vteam}) s'est fait atomiser par {attacker} ({arole} / {ateam}) en utilisant {trap}."
 
 L.desc_event_kill_goomba = "{victim} ({vrole} / {vteam}) s'est fait écrasé par la masse imposante de {attacker} ({arole} / {ateam})."
 
-L.desc_event_kill_crush = "{victim} ({vrole} / {vteam}) s'est fait broyer par {attacker} ({arole} / {ateam})."
+L.desc_event_kill_crush = "{victim} ({vrole} / {vteam}) s'est fait broyer par {attacker}."
 L.desc_event_kill_crush_using = "{victim} ({vrole} / {vteam}) s'est fait broyer par {attacker} ({arole} / {ateam}) avec {trap}."
 
-L.desc_event_kill_other = "{victim} ({vrole} / {vteam}) est mort à cause de {attacker} ({arole} / {ateam})."
+L.desc_event_kill_other = "{victim} ({vrole} / {vteam}) est mort à cause de {attacker}."
 L.desc_event_kill_other_using = "{victim} ({vrole} / {vteam}) est mort à cause de {attacker} ({arole} / {ateam}) avec {trap}."
 
 -- 2021-04-20

--- a/gamemodes/terrortown/gamemode/shared/lang/it.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/it.lua
@@ -1302,7 +1302,7 @@ L.pickup_error_noslot = "Non puoi prendere questo perchè non hai nessuno slot l
 --L.desc_event_spawn = "{player} has spawned."
 
 -- Name of a trap that killed us that has not been named by the mapper
-L.something = "qualcosa"
+L.trap_something = "qualcosa"
 
 -- Kill events
 --L.desc_event_kill_suicide = "It was suicide."
@@ -1316,36 +1316,36 @@ L.desc_event_kill_sui = "{victim} ({vrole} / {vteam}) non ce l'ha fatta e si è 
 L.desc_event_kill_sui_using = "{victim} ({vrole} / {vteam}) si è ucciso usando {tool}."
 
 L.desc_event_kill_fall = "{victim} ({vrole} / {vteam}) è morto di caduta."
-L.desc_event_kill_fall_pushed = "{victim} ({vrole} / {vteam}) è morto di caduta dopo essere stato spinto da {attacker} ({arole} / {ateam})."
+L.desc_event_kill_fall_pushed = "{victim} ({vrole} / {vteam}) è morto di caduta dopo essere stato spinto da {attacker}."
 L.desc_event_kill_fall_pushed_using = "{victim} ({vrole} / {vteam}) è morto di caduta dopo essere stato spinto da {attacker} ({arole} / {ateam}) con la trappola {trap}."
 
-L.desc_event_kill_shot = "{victim} ({vrole} / {vteam}) è stata ucciso con un arma da {attacker} ({arole} / {ateam})."
+L.desc_event_kill_shot = "{victim} ({vrole} / {vteam}) è stata ucciso con un arma da {attacker}."
 L.desc_event_kill_shot_using = "{victim} ({vrole} / {vteam}) è stata ucciso da {attacker} ({arole} / {ateam}) con l'arma {weapon}."
 
-L.desc_event_kill_drown = "{victim} ({vrole} / {vteam}) è stato affogato da {attacker} ({arole} / {ateam})."
+L.desc_event_kill_drown = "{victim} ({vrole} / {vteam}) è stato affogato da {attacker}."
 L.desc_event_kill_drown_using = "{victim} ({vrole} / {vteam}) è stato affogato da {trap} tramite {attacker} ({arole} / {ateam})."
 
-L.desc_event_kill_boom = "{victim} ({vrole} / {vteam}) è stato fatto esplodere da {attacker} ({arole} / {ateam})."
+L.desc_event_kill_boom = "{victim} ({vrole} / {vteam}) è stato fatto esplodere da {attacker}."
 L.desc_event_kill_boom_using = "{victim} ({vrole} / {vteam}) è stato fatto esplodere da {attacker} ({arole} / {ateam}) con la trappola {trap}."
 
-L.desc_event_kill_burn = "{victim} ({vrole} / {vteam}) è stato bruciato da {attacker} ({arole} / {ateam})."
+L.desc_event_kill_burn = "{victim} ({vrole} / {vteam}) è stato bruciato da {attacker}."
 L.desc_event_kill_burn_using = "{victim} ({vrole} / {vteam}) è stato bruciato dalla trappola {trap} attivata da {attacker} ({arole} / {ateam})."
 
-L.desc_event_kill_club = "{victim} ({vrole} / {vteam}) è stato massacrato da {attacker} ({arole} / {ateam})."
+L.desc_event_kill_club = "{victim} ({vrole} / {vteam}) è stato massacrato da {attacker}."
 L.desc_event_kill_club_using = "{victim} ({vrole} / {vteam}) è stato massacrato da {attacker} ({arole} / {ateam}) usando la trappola {trap}."
 
-L.desc_event_kill_slash = "{victim} ({vrole} / {vteam}) è stato accoltellato da {attacker} ({arole} / {ateam})."
+L.desc_event_kill_slash = "{victim} ({vrole} / {vteam}) è stato accoltellato da {attacker}."
 L.desc_event_kill_slash_using = "{victim} ({vrole} / {vteam}) è stato accoltellato da {attacker} ({arole} / {ateam}) usando la trappola {trap}."
 
-L.desc_event_kill_tele = "{victim} ({vrole} / {vteam}) è stato telefraggato da {attacker} ({arole} / {ateam})."
+L.desc_event_kill_tele = "{victim} ({vrole} / {vteam}) è stato telefraggato da {attacker}."
 L.desc_event_kill_tele_using = "{victim} ({vrole} / {vteam}) è stato atomizzato dalla trappola {trap} attivata da {attacker} ({arole} / {ateam})."
 
 L.desc_event_kill_goomba = "{victim} ({vrole} / {vteam}) è stata schiacciato dall'enorme masso di {attacker} ({arole} / {ateam})."
 
-L.desc_event_kill_crush = "{victim} ({vrole} / {vteam}) è stato schiacciato da {attacker} ({arole} / {ateam})."
+L.desc_event_kill_crush = "{victim} ({vrole} / {vteam}) è stato schiacciato da {attacker}."
 L.desc_event_kill_crush_using = "{victim} ({vrole} / {vteam}) è stato schiacciato dalla trappola {trap} attivata da {attacker} ({arole} / {ateam})."
 
-L.desc_event_kill_other = "{victim} ({vrole} / {vteam}) è stata ucciso da {attacker} ({arole} / {ateam})."
+L.desc_event_kill_other = "{victim} ({vrole} / {vteam}) è stata ucciso da {attacker}."
 L.desc_event_kill_other_using = "{victim} ({vrole} / {vteam}) è stata ucciso da {attacker} ({arole} / {ateam}) con la trappola {trap}."
 
 -- 2021-04-20

--- a/gamemodes/terrortown/gamemode/shared/lang/ja.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/ja.lua
@@ -1303,7 +1303,7 @@ L.help_lang_info = [[
 --L.desc_event_spawn = "{player} has spawned."
 
 -- Name of a trap that killed us that has not been named by the mapper
-L.something = "何か"
+L.trap_something = "何か"
 
 -- Kill events
 --L.desc_event_kill_suicide = "It was suicide."
@@ -1317,36 +1317,36 @@ L.desc_event_kill_sui = "{victim}({vrole}/{vteam})は何かを受け入れられ
 L.desc_event_kill_sui_using = "{victim}({vrole}/{vteam})は{tool}を使用して自殺した。"
 
 L.desc_event_kill_fall = "{victim}({vrole}/{vteam})は転落死した。"
-L.desc_event_kill_fall_pushed = "{victim}({vrole}/{vteam})は{attacker}({arole}/{ateam})に押されて転落死。"
+L.desc_event_kill_fall_pushed = "{victim}({vrole}/{vteam})は{attacker}に押されて転落死。"
 L.desc_event_kill_fall_pushed_using = "{victim}({vrole}/{vteam})は{attacker}({arole}/{ateam})に{trap}で押されて転落死。"
 
-L.desc_event_kill_shot = "{victim}({vrole}/{vteam})は{attacker}({arole}/{ateam})に撃たれた。"
+L.desc_event_kill_shot = "{victim}({vrole}/{vteam})は{attacker}に撃たれた。"
 L.desc_event_kill_shot_using = "{victim}({vrole}/{vteam})は{attacker}({arole}/{ateam})に{weapon}で撃たれた。"
 
-L.desc_event_kill_drown = "{victim}({vrole}/{vteam})は{attacker}({arole}/{ateam})によって溺死させられた。"
+L.desc_event_kill_drown = "{victim}({vrole}/{vteam})は{attacker}によって溺死させられた。"
 L.desc_event_kill_drown_using = "{victim}({vrole}/{vteam})は{attacker}({arole}/{ateam})が{trap}を起動したことにより溺死させられた。"
 
-L.desc_event_kill_boom = "{victim}({vrole}/{vteam})は{attacker}({arole}/{ateam})によって爆破された。"
+L.desc_event_kill_boom = "{victim}({vrole}/{vteam})は{attacker}によって爆破された。"
 L.desc_event_kill_boom_using = "{victim}({vrole}/{vteam})は{attacker}({arole}/{ateam})の使用した{trap}によって吹き飛ばされた。"
 
-L.desc_event_kill_burn = "{victim}({vrole}/{vteam})は{attacker}({arole}/{ateam})によって焼かれた。"
+L.desc_event_kill_burn = "{victim}({vrole}/{vteam})は{attacker}によって焼かれた。"
 L.desc_event_kill_burn_using = "{victim}({vrole}/{vteam})は{attacker}({arole}/{ateam})の仕組んだ{trap}により燃やされた。"
 
-L.desc_event_kill_club = "{victim}({vrole}/{vteam})は{attacker}({arole}/{ateam})によって殴られた。"
+L.desc_event_kill_club = "{victim}({vrole}/{vteam})は{attacker}によって殴られた。"
 L.desc_event_kill_club_using = "{victim}({vrole}/{vteam})は{attacker}({arole}/{ateam})の{trap}でしたたかに殴り殺された。"
 
-L.desc_event_kill_slash = "{victim}({vrole}/{vteam})は{attacker}({arole}/{ateam})に刺された。"
+L.desc_event_kill_slash = "{victim}({vrole}/{vteam})は{attacker}に刺された。"
 L.desc_event_kill_slash_using = "{victim}({vrole}/{vteam})は{attacker}({arole}/{ateam})に{trap}で切り刻まれた。"
 
-L.desc_event_kill_tele = "{victim}({vrole}/{vteam})は{attacker}({arole}/{ateam})により手榴弾で爆殺された。"
+L.desc_event_kill_tele = "{victim}({vrole}/{vteam})は{attacker}により手榴弾で爆殺された。"
 L.desc_event_kill_tele_using = "{victim}({vrole}/{vteam})は{attacker}({arole}/{ateam})が仕掛けた{trap}により粉々にされた。"
 
 L.desc_event_kill_goomba = "{victim}({vrole}/{vteam})は巨大な{attacker}({arole}/{ateam})により踏み潰された。"
 
-L.desc_event_kill_crush = "{victim}({vrole}/{vteam})は{attacker}({arole}/{ateam})により押し潰された。"
+L.desc_event_kill_crush = "{victim}({vrole}/{vteam})は{attacker}により押し潰された。"
 L.desc_event_kill_crush_using = "{victim}({vrole}/{vteam})は{attacker}({arole}/{ateam})の{trap}により押し潰された。"
 
-L.desc_event_kill_other = "{victim}({vrole}/{vteam})は{attacker}({arole}/{ateam})により殺害された。"
+L.desc_event_kill_other = "{victim}({vrole}/{vteam})は{attacker}により殺害された。"
 L.desc_event_kill_other_using = "{victim}({vrole}/{vteam})は{attacker}({arole}/{ateam})の使用した{trap}により殺害された。"
 
 -- 2021-04-20

--- a/gamemodes/terrortown/gamemode/shared/lang/pl.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/pl.lua
@@ -1302,7 +1302,7 @@ Te tłumaczenie ma w sobie {coverage}% angielskich tłumaczeń.
 --L.desc_event_spawn = "{player} has spawned."
 
 -- Name of a trap that killed us that has not been named by the mapper
-L.something = "coś"
+L.trap_something = "coś"
 
 -- Kill events
 --L.desc_event_kill_suicide = "It was suicide."
@@ -1316,36 +1316,36 @@ L.something = "coś"
 --L.desc_event_kill_sui_using = "{victim} ({vrole} / {vteam}) killed themselves using {tool}."
 
 --L.desc_event_kill_fall = "{victim} ({vrole} / {vteam}) fell to their death."
---L.desc_event_kill_fall_pushed = "{victim} ({vrole} / {vteam}) fell to their death after {attacker} ({arole} / {ateam}) pushed them."
+--L.desc_event_kill_fall_pushed = "{victim} ({vrole} / {vteam}) fell to their death after {attacker} pushed them."
 --L.desc_event_kill_fall_pushed_using = "{victim} ({vrole} / {vteam}) fell to their death after {attacker} ({arole} / {ateam}) used {trap} to push them."
 
---L.desc_event_kill_shot = "{victim} ({vrole} / {vteam}) was shot by {attacker} ({arole} / {ateam})."
+--L.desc_event_kill_shot = "{victim} ({vrole} / {vteam}) was shot by {attacker}."
 --L.desc_event_kill_shot_using = "{victim} ({vrole} / {vteam}) was shot by {attacker} ({arole} / {ateam}) using a {weapon}."
 
---L.desc_event_kill_drown = "{victim} ({vrole} / {vteam}) was drowned by {attacker} ({arole} / {ateam})."
+--L.desc_event_kill_drown = "{victim} ({vrole} / {vteam}) was drowned by {attacker}."
 --L.desc_event_kill_drown_using = "{victim} ({vrole} / {vteam}) was drowned by {trap} triggered by {attacker} ({arole} / {ateam})."
 
---L.desc_event_kill_boom = "{victim} ({vrole} / {vteam}) was exploded by {attacker} ({arole} / {ateam})."
+--L.desc_event_kill_boom = "{victim} ({vrole} / {vteam}) was exploded by {attacker}."
 --L.desc_event_kill_boom_using = "{victim} ({vrole} / {vteam}) was blown up by {attacker} ({arole} / {ateam}) using {trap}."
 
---L.desc_event_kill_burn = "{victim} ({vrole} / {vteam}) was fried by {attacker} ({arole} / {ateam})."
+--L.desc_event_kill_burn = "{victim} ({vrole} / {vteam}) was fried by {attacker}."
 --L.desc_event_kill_burn_using = "{victim} ({vrole} / {vteam}) was burned by {trap} due to {attacker} ({arole} / {ateam})."
 
---L.desc_event_kill_club = "{victim} ({vrole} / {vteam}) was beaten up by {attacker} ({arole} / {ateam})."
+--L.desc_event_kill_club = "{victim} ({vrole} / {vteam}) was beaten up by {attacker}."
 --L.desc_event_kill_club_using = "{victim} ({vrole} / {vteam}) was pummeled to death by {attacker} ({arole} / {ateam}) using {trap}."
 
---L.desc_event_kill_slash = "{victim} ({vrole} / {vteam}) was stabbed by {attacker} ({arole} / {ateam})."
+--L.desc_event_kill_slash = "{victim} ({vrole} / {vteam}) was stabbed by {attacker}."
 --L.desc_event_kill_slash_using = "{victim} ({vrole} / {vteam}) was cut up by {attacker} ({arole} / {ateam}) using {trap}."
 
---L.desc_event_kill_tele = "{victim} ({vrole} / {vteam}) was telefragged by {attacker} ({arole} / {ateam})."
+--L.desc_event_kill_tele = "{victim} ({vrole} / {vteam}) was telefragged by {attacker}."
 --L.desc_event_kill_tele_using = "{victim} ({vrole} / {vteam}) was atomized by {trap} set by {attacker} ({arole} / {ateam})."
 
 --L.desc_event_kill_goomba = "{victim} ({vrole} / {vteam}) was crushed by the massive bulk of {attacker} ({arole} / {ateam})."
 
---L.desc_event_kill_crush = "{victim} ({vrole} / {vteam}) was crushed by {attacker} ({arole} / {ateam})."
+--L.desc_event_kill_crush = "{victim} ({vrole} / {vteam}) was crushed by {attacker}."
 --L.desc_event_kill_crush_using = "{victim} ({vrole} / {vteam}) was crushed by {trap} of {attacker} ({arole} / {ateam})."
 
---L.desc_event_kill_other = "{victim} ({vrole} / {vteam}) was killed by {attacker} ({arole} / {ateam})."
+--L.desc_event_kill_other = "{victim} ({vrole} / {vteam}) was killed by {attacker}."
 --L.desc_event_kill_other_using = "{victim} ({vrole} / {vteam}) was killed by {attacker} ({arole} / {ateam}) using {trap}."
 
 -- 2021-04-20

--- a/gamemodes/terrortown/gamemode/shared/lang/ru.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/ru.lua
@@ -1302,7 +1302,7 @@ L.help_lang_info = [[
 --L.desc_event_spawn = "{player} has spawned."
 
 -- Name of a trap that killed us that has not been named by the mapper
-L.something = "что-то"
+L.trap_something = "что-то"
 
 -- Kill events
 --L.desc_event_kill_suicide = "It was suicide."
@@ -1316,36 +1316,36 @@ L.desc_event_kill_sui = "{victim} ({vrole} / {vteam}) не выдерживае�
 L.desc_event_kill_sui_using = "{victim} ({vrole} / {vteam}) совершает самоубийство при помощи {tool}."
 
 L.desc_event_kill_fall = "{victim} ({vrole} / {vteam}) разбивается насмерть."
-L.desc_event_kill_fall_pushed = "{victim} ({vrole} / {vteam}) разбивается насмерть после толчка от {attacker} ({arole} / {ateam})."
+L.desc_event_kill_fall_pushed = "{victim} ({vrole} / {vteam}) разбивается насмерть после толчка от {attacker}."
 L.desc_event_kill_fall_pushed_using = "{victim} ({vrole} / {vteam}) разбивается насмерть после толчка от {trap}, активированной {attacker} ({arole} / {ateam})."
 
-L.desc_event_kill_shot = "{victim} ({vrole} / {vteam}) был застрелен {attacker} ({arole} / {ateam})."
+L.desc_event_kill_shot = "{victim} ({vrole} / {vteam}) был застрелен {attacker}."
 L.desc_event_kill_shot_using = "{victim} ({vrole} / {vteam}) был застрелен {attacker} ({arole} / {ateam}) с помощью {weapon}."
 
-L.desc_event_kill_drown = "{victim} ({vrole} / {vteam}) был утоплен {attacker} ({arole} / {ateam})."
+L.desc_event_kill_drown = "{victim} ({vrole} / {vteam}) был утоплен {attacker}."
 L.desc_event_kill_drown_using = "{victim} ({vrole} / {vteam}) был утоплен {trap}, активированной {attacker} ({arole} / {ateam})."
 
-L.desc_event_kill_boom = "{victim} ({vrole} / {vteam}) был взорван {attacker} ({arole} / {ateam})."
+L.desc_event_kill_boom = "{victim} ({vrole} / {vteam}) был взорван {attacker}."
 L.desc_event_kill_boom_using = "{victim} ({vrole} / {vteam}) был взорван {attacker} ({arole} / {ateam}) при помощи {trap}."
 
-L.desc_event_kill_burn = "{victim} ({vrole} / {vteam}) был сожжён {attacker} ({arole} / {ateam})."
+L.desc_event_kill_burn = "{victim} ({vrole} / {vteam}) был сожжён {attacker}."
 L.desc_event_kill_burn_using = "{victim} ({vrole} / {vteam}) был сожжён {trap} из-за {attacker} ({arole} / {ateam})."
 
-L.desc_event_kill_club = "{victim} ({vrole} / {vteam}) был избит {attacker} ({arole} / {ateam})."
+L.desc_event_kill_club = "{victim} ({vrole} / {vteam}) был избит {attacker}."
 L.desc_event_kill_club_using = "{{victim} ({vrole} / {vteam}) был избит {attacker} ({arole} / {ateam}) при помощи {trap}"
 
-L.desc_event_kill_slash = "{victim} ({vrole} / {vteam}) был зарезан {attacker} ({arole} / {ateam})."
+L.desc_event_kill_slash = "{victim} ({vrole} / {vteam}) был зарезан {attacker}."
 L.desc_event_kill_slash_using = "{victim} ({vrole} / {vteam}) был зарезан {attacker} ({arole} / {ateam}) при помощи {trap}."
 
-L.desc_event_kill_tele = "{victim} ({vrole} / {vteam}) был убит телепортацией {attacker} ({arole} / {ateam})."
+L.desc_event_kill_tele = "{victim} ({vrole} / {vteam}) был убит телепортацией {attacker}."
 L.desc_event_kill_tele_using = "{victim} ({vrole} / {vteam}) был распылён {trap}, установленной {attacker} ({arole} / {ateam})."
 
 L.desc_event_kill_goomba = "{victim} ({vrole} / {vteam}) был раздавлен большой массой {attacker} ({arole} / {ateam})."
 
-L.desc_event_kill_crush = "{victim} ({vrole} / {vteam}) был раздавлен {attacker} ({arole} / {ateam})."
+L.desc_event_kill_crush = "{victim} ({vrole} / {vteam}) был раздавлен {attacker}."
 L.desc_event_kill_crush_using = "{victim} ({vrole} / {vteam}) был раздавлен {attacker} ({arole} / {ateam}) при помощи {trap}."
 
-L.desc_event_kill_other = "{victim} ({vrole} / {vteam}) был убит {attacker} ({arole} / {ateam})."
+L.desc_event_kill_other = "{victim} ({vrole} / {vteam}) был убит {attacker}."
 L.desc_event_kill_other_using = "{victim} ({vrole} / {vteam}) был убит {attacker} ({arole} / {ateam}) при помощи {trap}."
 
 -- 2021-04-20

--- a/gamemodes/terrortown/gamemode/shared/lang/zh_hans.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/zh_hans.lua
@@ -1302,7 +1302,7 @@ L.pickup_error_noslot = "你没有对应空槽位，无法捡起这个"
 --L.desc_event_spawn = "{player} has spawned."
 
 -- Name of a trap that killed us that has not been named by the mapper
-L.something = "某件物品"
+L.trap_something = "某件物品"
 
 -- Kill events
 --L.desc_event_kill_suicide = "It was suicide."
@@ -1316,36 +1316,36 @@ L.desc_event_kill_sui = "{victim} ({vrole} / {vteam}) 受不了然后自杀了�
 L.desc_event_kill_sui_using = "{victim} ({vrole} / {vteam}) 用 {tool} 杀了自己。"
 
 L.desc_event_kill_fall = "{victim} ({vrole} / {vteam}) 摔死了。"
-L.desc_event_kill_fall_pushed = "{victim} ({vrole} / {vteam}) 因为 {attacker} ({arole} / {ateam}) 而摔死了。"
+L.desc_event_kill_fall_pushed = "{victim} ({vrole} / {vteam}) 因为 {attacker} 而摔死了。"
 L.desc_event_kill_fall_pushed_using = "{victim} ({vrole} / {vteam}) 被 {attacker} ({arole} / {ateam}) 用 {trap} 推下摔死。"
 
-L.desc_event_kill_shot = "{victim} ({vrole} / {vteam}) 被 {attacker} ({arole} / {ateam}) 射杀。"
+L.desc_event_kill_shot = "{victim} ({vrole} / {vteam}) 被 {attacker}射杀。"
 L.desc_event_kill_shot_using = "{victim} ({vrole} / {vteam}) 被 {attacker} ({arole} / {ateam}) 用 {weapon} 射杀。"
 
-L.desc_event_kill_drown = "{victim} ({vrole} / {vteam}) 被 {attacker} ({arole} / {ateam}) 推入水中溺死。"
+L.desc_event_kill_drown = "{victim} ({vrole} / {vteam}) 被 {attacker} 推入水中溺死。"
 L.desc_event_kill_drown_using = "{victim} ({vrole} / {vteam}) 被 {attacker} ({arole} / {ateam}) 用 {trap} 推入水中溺死。"
 
-L.desc_event_kill_boom = "{victim} ({vrole} / {vteam}) 被 {attacker} ({arole} / {ateam}) 炸死。"
+L.desc_event_kill_boom = "{victim} ({vrole} / {vteam}) 被 {attacker} 炸死。"
 L.desc_event_kill_boom_using = "{victim} ({vrole} / {vteam}) 被 {attacker} ({arole} / {ateam}) 用 {trap} 炸烂。"
 
-L.desc_event_kill_burn = "{victim} ({vrole} / {vteam}) 被 {attacker} ({arole} / {ateam}) 烧死。"
+L.desc_event_kill_burn = "{victim} ({vrole} / {vteam}) 被 {attacker} 烧死。"
 L.desc_event_kill_burn_using = "{victim} ({vrole} / {vteam}) 被 {attacker} ({arole} / {ateam}) 用 {trap} 烧成焦尸。"
 
-L.desc_event_kill_club = "{victim} ({vrole} / {vteam}) 被 {attacker} ({arole} / {ateam}) 打死。"
+L.desc_event_kill_club = "{victim} ({vrole} / {vteam}) 被 {attacker} 打死。"
 L.desc_event_kill_club_using = "{victim} ({vrole} / {vteam}) 被 {attacker} ({arole} / {ateam}) 用 {trap} 打成烂泥。"
 
-L.desc_event_kill_slash = "{victim} ({vrole} / {vteam}) 被 {attacker} ({arole} / {ateam}) 砍死。"
+L.desc_event_kill_slash = "{victim} ({vrole} / {vteam}) 被 {attacker} 砍死。"
 L.desc_event_kill_slash_using = "{victim} ({vrole} / {vteam}) 被 {attacker} ({arole} / {ateam}) 用 {trap} 砍成两半。"
 
-L.desc_event_kill_tele = "{victim} ({vrole} / {vteam}) 被 {attacker} ({arole} / {ateam}) 传送杀。"
+L.desc_event_kill_tele = "{victim} ({vrole} / {vteam}) 被 {attacker} 传送杀。"
 L.desc_event_kill_tele_using = "{victim} ({vrole} / {vteam}) 被 {attacker} ({arole} / {ateam}) 用 {trap} 传送时之能量分裂成原子。"
 
 L.desc_event_kill_goomba = "{victim} ({vrole} / {vteam}) 被 {attacker} ({arole} / {ateam}) 用巨大物体压烂。"
 
-L.desc_event_kill_crush = "{victim} ({vrole} / {vteam}) 被 {attacker} ({arole} / {ateam}) 压烂。"
+L.desc_event_kill_crush = "{victim} ({vrole} / {vteam}) 被 {attacker} 压烂。"
 L.desc_event_kill_crush_using = "{victim} ({vrole} / {vteam}) 被 {attacker} ({arole} / {ateam}) 用 {trap} 压碎。"
 
-L.desc_event_kill_other = "{victim} ({vrole} / {vteam}) 被 {attacker} ({arole} / {ateam}) 杀死。"
+L.desc_event_kill_other = "{victim} ({vrole} / {vteam}) 被 {attacker} 杀死。"
 L.desc_event_kill_other_using = "{victim} ({vrole} / {vteam}) 被 {attacker} ({arole} / {ateam}) 用 {trap} 杀死。"
 
 -- 2021-04-20


### PR DESCRIPTION
In the current version the game tries to display the killer information even if it is unknown. I therefore removed it. I *think* the `_using` flag to the strings is only set if a player was the killer and the info is therefore available. This is at least what I'd say after looking at the text generating code (which is from original TTT) and I confirmed it with bot tests.

In the screenshot you see the problem before the fix:
![image](https://user-images.githubusercontent.com/13639408/119502230-01d74400-bd6a-11eb-9e2a-d6e95d7ed55d.png)
