### PR TITLE
Scoreboard: Added per-player volume control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Karma now stores changes
   - Is shown in roundend menu
 - Added the ConVar `ttt2_random_shop_items` for the number of items in the randomshop
+- Added per-player voice control by hovering over the mute icon and scrolling
 
 ### Fixed
 

--- a/gamemodes/terrortown/gamemode/client/vgui/cl_sb_row.lua
+++ b/gamemodes/terrortown/gamemode/client/vgui/cl_sb_row.lua
@@ -12,6 +12,7 @@ local table = table
 local IsValid = IsValid
 local surface = surface
 local vgui = vgui
+local drawRoundedBox = draw.RoundedBox
 
 local color_trans = Color(0, 0, 0, 0)
 
@@ -725,8 +726,8 @@ function PANEL:ScrollPlayerVolume(delta)
 	frame:ShowCloseButton(false)
 	frame:SetDraggable(false)
 	frame:SetSizable(false)
-	frame.Paint = function(self, w, h)
-		draw.RoundedBox(8, 0, 0, w, h, Color(24, 25, 28, 180))
+	frame.Paint = function(_, w, h)
+		drawRoundedBox(8, 0, 0, w, h, Color(24, 25, 28, 180))
 	end
 
 	self.voice.percentage_frame = frame
@@ -743,7 +744,7 @@ function PANEL:ScrollPlayerVolume(delta)
 	timer.Remove("ttt_score_close_perc_frame_" .. identifier)
 
 	timer.Create("ttt_score_close_perc_frame_" .. identifier, 1.5, 1, function()
-		if not self.voice and frame ~= nil and frame:IsVisible() then
+		if not self.voice and frame and frame:IsVisible() then
 			frame:Close()
 			frame = nil
 
@@ -756,7 +757,7 @@ function PANEL:ScrollPlayerVolume(delta)
 	end)
 
 	hook.Add("ScoreboardHide", "TTTCloseVolumeFrame_" .. identifier, function()
-		if not self.voice and frame ~= nil and frame:IsVisible() then
+		if not self.voice and frame and frame:IsVisible() then
 			frame:Close()
 			frame = nil
 

--- a/gamemodes/terrortown/gamemode/client/vgui/cl_sb_row.lua
+++ b/gamemodes/terrortown/gamemode/client/vgui/cl_sb_row.lua
@@ -344,7 +344,9 @@ function PANEL:SetPlayer(ply)
 	self.Player = ply
 	self.avatar:SetPlayer(ply)
 
-	if ply ~= LocalPlayer() then
+	local client = LocalPlayer()
+
+	if ply ~= client then
 		self.voice:SetTooltip(GetTranslation("scoreboard_voice_tooltip"))
 	end
 
@@ -369,13 +371,13 @@ function PANEL:SetPlayer(ply)
 	end
 
 	self.voice.DoClick = function()
-		if IsValid(ply) and ply ~= LocalPlayer() then
+		if IsValid(ply) and ply ~= client then
 			ply:SetMuted(not ply:IsMuted())
 		end
 	end
 
 	self.voice.OnMouseWheeled = function(label, delta)
-		if IsValid(ply) and ply ~= LocalPlayer() then
+		if IsValid(ply) and ply ~= client then
 			self:ScrollPlayerVolume(delta)
 		end
 	end
@@ -701,7 +703,7 @@ function PANEL:ScrollPlayerVolume(delta)
 	local cur_volume = ply:GetVoiceVolumeScale()
 	cur_volume = cur_volume ~= nil and cur_volume or 1
 
-	local new_volume = delta == -1 and math.max(0, cur_volume-0.01) or math.min(1, cur_volume+0.01)
+	local new_volume = delta == -1 and math.max(0, cur_volume - 0.01) or math.min(1, cur_volume + 0.01)
 	new_volume = math.Round(new_volume, 2)
 
 	ply:SetVoiceVolumeScale(new_volume)
@@ -717,14 +719,14 @@ function PANEL:ScrollPlayerVolume(delta)
 
 	-- Frame
 	local frame = self.voice.percentage_frame ~= nil and self.voice.percentage_frame or vgui.Create("DFrame")
-	frame:SetPos(x-10, y+25)
+	frame:SetPos(x - 10, y + 25)
 	frame:SetSize(width, height)
 	frame:SetTitle("")
 	frame:ShowCloseButton(false)
 	frame:SetDraggable(false)
 	frame:SetSizable(false)
 	frame.Paint = function(self, w, h)
-	  draw.RoundedBox(8, 0, 0, w, h, Color(24, 25, 28, 180))
+		draw.RoundedBox(8, 0, 0, w, h, Color(24, 25, 28, 180))
 	end
 
 	self.voice.percentage_frame = frame
@@ -734,38 +736,39 @@ function PANEL:ScrollPlayerVolume(delta)
 	label:SetFont("treb_small")
 	label:SetSize(width - padding * 2, 20)
 	label:SetColor(COLOR_WHITE)
-	label:SetText(tostring(math.Round(new_volume*100)) .. "%")
+	label:SetText(tostring(math.Round(new_volume * 100)) .. "%")
 
 	self.voice.percentage_frame_label = label
 
-	timer.Remove("ttt_score_close_perc_frame_"..identifier)
+	timer.Remove("ttt_score_close_perc_frame_" .. identifier)
 
-	timer.Create("ttt_score_close_perc_frame_"..identifier, 1.5, 1, function()
+	timer.Create("ttt_score_close_perc_frame_" .. identifier, 1.5, 1, function()
 		if not self.voice and frame ~= nil and frame:IsVisible() then
 			frame:Close()
 			frame = nil
+
 			return
 		end
 
-		if not self.voice or self.voice.percentage_frame == nil or not self.voice.percentage_frame:IsVisible() then return end
+		if not self.voice or not self.voice.percentage_frame or not self.voice.percentage_frame:IsVisible() then return end
 
 		self.voice.percentage_frame:Hide()
 	end)
 
-	hook.Add("ScoreboardHide", "TTTCloseVolumeFrame_"..identifier, function()
+	hook.Add("ScoreboardHide", "TTTCloseVolumeFrame_" .. identifier, function()
 		if not self.voice and frame ~= nil and frame:IsVisible() then
 			frame:Close()
 			frame = nil
+
 			return
 		end
 
-		if not self.voice or self.voice.percentage_frame == nil or not self.voice.percentage_frame:IsVisible() then return end
+		if not self.voice or not self.voice.percentage_frame or not self.voice.percentage_frame:IsVisible() then return end
 
 		self.voice.percentage_frame:Hide()
 
-		timer.Remove("ttt_score_close_perc_frame_"..identifier)
+		timer.Remove("ttt_score_close_perc_frame_" .. identifier)
 	end)
-
 end
 
 vgui.Register("TTTScorePlayerRow", PANEL, "DButton")

--- a/gamemodes/terrortown/gamemode/shared/lang/de.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/de.lua
@@ -1366,4 +1366,4 @@ L.shopeditor_name_random_shop_reroll_cost = "Kosten pro Auswürfeln"
 L.shopeditor_name_random_shop_reroll_per_buy = "Automatisches Auswürfeln nach jedem Kauf"
 
 --2021-06-09
-L.scoreboard_voice_tooltip = "Scrolle um die Lautstärke zu ändern."
+L.scoreboard_voice_tooltip = "Scrolle um die Lautstärke zu ändern"

--- a/gamemodes/terrortown/gamemode/shared/lang/de.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/de.lua
@@ -1364,3 +1364,6 @@ L.shopeditor_name_random_team_shops = "Aktiviere Team-Shops"
 L.shopeditor_name_random_shop_reroll = "Aktiviere Möglichkeit Shop neu auszuwürfeln"
 L.shopeditor_name_random_shop_reroll_cost = "Kosten pro Auswürfeln"
 L.shopeditor_name_random_shop_reroll_per_buy = "Automatisches Auswürfeln nach jedem Kauf"
+
+--2021-06-09
+L.scoreboard_voice_tooltip = "Scrolle um die Lautstärke zu ändern."

--- a/gamemodes/terrortown/gamemode/shared/lang/en.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/en.lua
@@ -1367,4 +1367,4 @@ L.shopeditor_name_random_shop_reroll_cost = "Cost per reroll"
 L.shopeditor_name_random_shop_reroll_per_buy = "Auto reroll after buy"
 
 --2021-06-09
-L.scoreboard_voice_tooltip = "Scroll to change the volume."
+L.scoreboard_voice_tooltip = "Scroll to change the volume"

--- a/gamemodes/terrortown/gamemode/shared/lang/en.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/en.lua
@@ -1365,3 +1365,6 @@ L.shopeditor_name_random_team_shops = "Enable team shops"
 L.shopeditor_name_random_shop_reroll = "Enable shop reroll availability"
 L.shopeditor_name_random_shop_reroll_cost = "Cost per reroll"
 L.shopeditor_name_random_shop_reroll_per_buy = "Auto reroll after buy"
+
+--2021-06-09
+L.scoreboard_voice_tooltip = "Scroll to change the volume."

--- a/gamemodes/terrortown/gamemode/shared/lang/es.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/es.lua
@@ -1364,3 +1364,6 @@ L.desc_event_kill_other_using = "{victim} ({vrole} / {vteam}) fue asesinado por 
 --L.shopeditor_name_random_shop_reroll = "Enable shop reroll availability"
 --L.shopeditor_name_random_shop_reroll_cost = "Cost per reroll"
 --L.shopeditor_name_random_shop_reroll_per_buy = "Auto reroll after buy"
+
+--2021-06-09
+--L.scoreboard_voice_tooltip = "Scroll to change the volume"

--- a/gamemodes/terrortown/gamemode/shared/lang/fr.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/fr.lua
@@ -1375,3 +1375,6 @@ L.karma_unknown_tooltip = "Inconnu"
 --L.shopeditor_name_random_shop_reroll = "Enable shop reroll availability"
 --L.shopeditor_name_random_shop_reroll_cost = "Cost per reroll"
 --L.shopeditor_name_random_shop_reroll_per_buy = "Auto reroll after buy"
+
+--2021-06-09
+--L.scoreboard_voice_tooltip = "Scroll to change the volume"

--- a/gamemodes/terrortown/gamemode/shared/lang/it.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/it.lua
@@ -1374,3 +1374,6 @@ L.desc_event_kill_other_using = "{victim} ({vrole} / {vteam}) è stata ucciso da
 --L.shopeditor_name_random_shop_reroll = "Enable shop reroll availability"
 --L.shopeditor_name_random_shop_reroll_cost = "Cost per reroll"
 --L.shopeditor_name_random_shop_reroll_per_buy = "Auto reroll after buy"
+
+--2021-06-09
+--L.scoreboard_voice_tooltip = "Scroll to change the volume"

--- a/gamemodes/terrortown/gamemode/shared/lang/ja.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/ja.lua
@@ -1375,3 +1375,6 @@ L.desc_event_kill_other_using = "{victim}({vrole}/{vteam})は{attacker}({arole}/
 --L.shopeditor_name_random_shop_reroll = "Enable shop reroll availability"
 --L.shopeditor_name_random_shop_reroll_cost = "Cost per reroll"
 --L.shopeditor_name_random_shop_reroll_per_buy = "Auto reroll after buy"
+
+--2021-06-09
+--L.scoreboard_voice_tooltip = "Scroll to change the volume"

--- a/gamemodes/terrortown/gamemode/shared/lang/pl.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/pl.lua
@@ -1374,3 +1374,6 @@ L.none = "Brak Roli"
 --L.shopeditor_name_random_shop_reroll = "Enable shop reroll availability"
 --L.shopeditor_name_random_shop_reroll_cost = "Cost per reroll"
 --L.shopeditor_name_random_shop_reroll_per_buy = "Auto reroll after buy"
+
+--2021-06-09
+--L.scoreboard_voice_tooltip = "Scroll to change the volume"

--- a/gamemodes/terrortown/gamemode/shared/lang/ru.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/ru.lua
@@ -1374,3 +1374,6 @@ L.desc_event_kill_other_using = "{victim} ({vrole} / {vteam}) был убит {a
 --L.shopeditor_name_random_shop_reroll = "Enable shop reroll availability"
 --L.shopeditor_name_random_shop_reroll_cost = "Cost per reroll"
 --L.shopeditor_name_random_shop_reroll_per_buy = "Auto reroll after buy"
+
+--2021-06-09
+--L.scoreboard_voice_tooltip = "Scroll to change the volume"

--- a/gamemodes/terrortown/gamemode/shared/lang/zh_hans.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/zh_hans.lua
@@ -1374,3 +1374,6 @@ L.desc_event_kill_other_using = "{victim} ({vrole} / {vteam}) 被 {attacker} ({a
 --L.shopeditor_name_random_shop_reroll = "Enable shop reroll availability"
 --L.shopeditor_name_random_shop_reroll_cost = "Cost per reroll"
 --L.shopeditor_name_random_shop_reroll_per_buy = "Auto reroll after buy"
+
+--2021-06-09
+--L.scoreboard_voice_tooltip = "Scroll to change the volume"


### PR DESCRIPTION
Added per-player volume control by hovering over the mute icon and scrolling up/down.

Demonstration again: https://cloud.nickcloud.at/index.php/s/XELpDHGTLZfXJBf
