### PR TITLE
F1 Menu: Legacy Addons: Fix Null Panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed issue where roles with unknownTeam could see messages sent with the team chat key
 - Fixed the admin section label not being visible in the main menu
 - Fixed the auto resizing of the buttons based on the availability of a scrollbar not working
+- Fixed reopening submenus of the legacy addons in F1 menu not working
 
 ### Changed
 

--- a/lua/terrortown/menus/gamemode/legacy.lua
+++ b/lua/terrortown/menus/gamemode/legacy.lua
@@ -108,7 +108,8 @@ function CLGAMEMODEMENU:Initialize()
 
 		virtualSubmenus[i] = tableCopy(legacyMenuBase)
 		virtualSubmenus[i].title = legacyTab.name
-		virtualSubmenus[i].panel = legacyTab.panel
+		virtualSubmenus[i].elemStore = elemStore
+		virtualSubmenus[i].index = i
 	end
 end
 

--- a/lua/terrortown/menus/gamemode/legacy/base_legacy.lua
+++ b/lua/terrortown/menus/gamemode/legacy/base_legacy.lua
@@ -3,14 +3,36 @@
 CLGAMEMODESUBMENU.priority = 0
 CLGAMEMODESUBMENU.title = ""
 
+local function GetLegacyTabs(elemStore)
+	if not elemStore then
+		return {}
+	end
+
+	elemStore:Clear()
+	elemStore:ResetItems()
+
+	---
+	-- @realm client
+	hook.Run("TTTSettingsTabs", elemStore)
+
+	return elemStore:GetItems()
+end
+
 function CLGAMEMODESUBMENU:Populate(parent)
+	-- Always recreate LegacyTabs to prevent a NULL panel from parent deletion
+	local legacyTab = GetLegacyTabs(self.elemStore)[self.index]
+
+	if not legacyTab then return end
+
+	local panel = legacyTab.panel
+
 	local psizeX, psizeY = parent:GetSize()
 	local ppadLeft, _, ppadRight, _ = parent:GetDockPadding()
 
-	self.panel:SetParent(parent)
-	self.panel:SetSize(
+	panel:SetParent(parent)
+	panel:SetSize(
 		psizeX - ppadLeft - ppadRight,
 		psizeY - 2 * HELPSCRN.padding
 	)
-	self.panel:Dock(FILL)
+	panel:Dock(FILL)
 end


### PR DESCRIPTION
As the panel always gets deleted, when it's parent gets deleted, we have to recreate it everytime we fetch a submenu.

This is a dirty workaround to get the job done. Better would be to free the child of its parent before clearing it. This also calls the hook  `TTTSettingsTabs` again everytime we open another legacy addon submenu.