### PR TITLE
Credit transfer: Sort teammates first and show indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Shopeditor equipment is now available in F1 menu
 - Moved the role layering menu to the F1 menu (administration submenu)
   - removed the command `ttt2_edit_rolelayering`
+- Sort teammates first in credit transfer selection and add an indicator to them
 
 ### Removed
 

--- a/gamemodes/terrortown/gamemode/client/cl_transfer.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_transfer.lua
@@ -88,9 +88,14 @@ function CreateTransferMenu(parent)
 	end
 
 	dpick:SetWide(250)
+	dpick:SetSortItems(false)
 
 	-- fill combobox
 	local plys = player.GetAll()
+
+	table.sort(plys, function (a, b)
+		return a:IsInTeam(client) and not b:IsInTeam(client)
+	end)
 
 	for i = 1, #plys do
 		local ply = plys[i]
@@ -99,7 +104,13 @@ function CreateTransferMenu(parent)
 		--SteamID64() returns nil for bots on the client, and so credits can't be transferred to them.
 		--Transfers can be made to players who have died (as the sender may not know if they're alive), but can't be made to spectators who joined in the middle of a match.
 		if ply ~= client and (ply:IsTerror() or ply:IsDeadTerror()) and sid then
-			dpick:AddChoice(ply:Nick(), sid)
+			local choiceText = ply:Nick()
+
+			if ply:IsInTeam(client) then
+				choiceText = choiceText .. " (" .. GetTranslation("xfer_team_indicator") .. ")"
+			end
+
+			dpick:AddChoice(choiceText, sid)
 		end
 	end
 

--- a/gamemodes/terrortown/gamemode/shared/lang/de.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/de.lua
@@ -1402,3 +1402,6 @@ L.scoreboard_voice_tooltip = "Scrolle um die Lautstärke zu ändern"
 --2021-06-15
 L.header_shop_linker = "Einstellungen"
 L.label_shop_linker_set = "Wähle Shopart aus:"
+
+--2021-08-18
+L.xfer_team_indicator = "Team"

--- a/gamemodes/terrortown/gamemode/shared/lang/en.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/en.lua
@@ -1403,3 +1403,6 @@ L.scoreboard_voice_tooltip = "Scroll to change the volume"
 --2021-06-15
 L.header_shop_linker = "Settings"
 L.label_shop_linker_set = "Select shop type:"
+
+--2021-08-18
+L.xfer_team_indicator = "Team"

--- a/gamemodes/terrortown/gamemode/shared/lang/es.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/es.lua
@@ -1402,3 +1402,7 @@ L.desc_event_kill_other_using = "{victim} ({vrole} / {vteam}) fue asesinado por 
 --2021-06-15
 --L.header_shop_linker = "Settings"
 --L.label_shop_linker_set = "Shopsetting"
+
+
+--2021-08-18
+--L.xfer_team_indicator = "Team"

--- a/gamemodes/terrortown/gamemode/shared/lang/fr.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/fr.lua
@@ -1413,3 +1413,7 @@ L.karma_unknown_tooltip = "Inconnu"
 --2021-06-15
 --L.header_shop_linker = "Settings"
 --L.label_shop_linker_set = "Shopsetting"
+
+
+--2021-08-18
+--L.xfer_team_indicator = "Team"

--- a/gamemodes/terrortown/gamemode/shared/lang/it.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/it.lua
@@ -1412,3 +1412,6 @@ L.desc_event_kill_other_using = "{victim} ({vrole} / {vteam}) è stata ucciso da
 --2021-06-15
 --L.header_shop_linker = "Settings"
 --L.label_shop_linker_set = "Shopsetting"
+
+--2021-08-18
+--L.xfer_team_indicator = "Team"

--- a/gamemodes/terrortown/gamemode/shared/lang/ja.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/ja.lua
@@ -1413,3 +1413,6 @@ L.desc_event_kill_other_using = "{victim}({vrole}/{vteam})は{attacker}({arole}/
 --2021-06-15
 --L.header_shop_linker = "Settings"
 --L.label_shop_linker_set = "Shopsetting"
+
+--2021-08-18
+--L.xfer_team_indicator = "Team"

--- a/gamemodes/terrortown/gamemode/shared/lang/pl.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/pl.lua
@@ -1412,3 +1412,6 @@ L.none = "Brak Roli"
 --2021-06-15
 --L.header_shop_linker = "Settings"
 --L.label_shop_linker_set = "Shopsetting"
+
+--2021-08-18
+--L.xfer_team_indicator = "Team"

--- a/gamemodes/terrortown/gamemode/shared/lang/ru.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/ru.lua
@@ -1412,3 +1412,6 @@ L.desc_event_kill_other_using = "{victim} ({vrole} / {vteam}) был убит {a
 --2021-06-15
 --L.header_shop_linker = "Settings"
 --L.label_shop_linker_set = "Shopsetting"
+
+--2021-08-18
+--L.xfer_team_indicator = "Team"

--- a/gamemodes/terrortown/gamemode/shared/lang/zh_hans.lua
+++ b/gamemodes/terrortown/gamemode/shared/lang/zh_hans.lua
@@ -1412,3 +1412,6 @@ L.desc_event_kill_other_using = "{victim} ({vrole} / {vteam}) 被 {attacker} ({a
 --2021-06-15
 --L.header_shop_linker = "Settings"
 --L.label_shop_linker_set = "Shopsetting"
+
+--2021-08-18
+--L.xfer_team_indicator = "Team"


### PR DESCRIPTION
This patch will list teammates first in the credit transfer menu and prepend a "(Team)" string behind their names to make them easily distinguishable for sending out credits to people that are important.

This fixes #734

![image](https://user-images.githubusercontent.com/10776964/122598649-6639aa80-d06d-11eb-9804-9b439c28b321.png)
