### PR TITLE
Classbuilder: added recursion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ### Fixed
 
-- Fixed mult-layer inheritance by introducing a recursion based approach
+- Fixed multi-layer inheritance by introducing a recursion based approach
 
 ## [v0.9.1b](https://github.com/TTT-2/TTT2/tree/v0.9.1b) (2021-06-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ## Unreleased
 
+### Fixed
+
+- Fixed mult-layer inheritance by introducing a recursion based approach
+
 ## [v0.9.1b](https://github.com/TTT-2/TTT2/tree/v0.9.1b) (2021-06-19)
 
 ### Fixed

--- a/lua/ttt2/extensions/table.lua
+++ b/lua/ttt2/extensions/table.lua
@@ -351,9 +351,10 @@ end
 -- @note This function will not create a new table. It modifies the existing table.
 -- @param table t The target table that will be modified
 -- @param table base The (fallback) base table
+-- @param[default=false] boolean isSubTable Defines if this is a subtable or the top layer table
 -- @return table The modified target table
 -- @realm shared
-function table.DeepInherit(t, base)
+function table.DeepInherit(t, base, isSubTable)
 	if not base then
 		return t
 	end
@@ -362,11 +363,13 @@ function table.DeepInherit(t, base)
 		if t[k] == nil then
 			t[k] = v
 		elseif k ~= "BaseClass" and istable(t[k]) then
-			table.DeepInherit(t[k], v)
+			table.DeepInherit(t[k], v, true)
 		end
 	end
 
-	t.BaseClass = base
+	if not isSubTable then
+		t.BaseClass = base
+	end
 
 	return t
 end

--- a/lua/ttt2/extensions/table.lua
+++ b/lua/ttt2/extensions/table.lua
@@ -351,10 +351,9 @@ end
 -- @note This function will not create a new table. It modifies the existing table.
 -- @param table t The target table that will be modified
 -- @param table base The (fallback) base table
--- @param[default=false] boolean isSubTable Defines if this is a subtable or the top layer table
 -- @return table The modified target table
 -- @realm shared
-function table.DeepInherit(t, base, isSubTable)
+function table.DeepInherit(t, base)
 	if not base then
 		return t
 	end
@@ -363,7 +362,7 @@ function table.DeepInherit(t, base, isSubTable)
 		if t[k] == nil then
 			t[k] = v
 		elseif k ~= "BaseClass" and istable(t[k]) then
-			table.DeepInherit(t[k], v, true)
+			table.DeepInherit(t[k], v)
 		end
 	end
 

--- a/lua/ttt2/extensions/table.lua
+++ b/lua/ttt2/extensions/table.lua
@@ -367,9 +367,5 @@ function table.DeepInherit(t, base, isSubTable)
 		end
 	end
 
-	if not isSubTable then
-		t.BaseClass = base
-	end
-
 	return t
 end

--- a/lua/ttt2/libraries/classbuilder.lua
+++ b/lua/ttt2/libraries/classbuilder.lua
@@ -12,7 +12,7 @@ local stringSplit = string.Split
 local stringLower = string.lower
 local isfunction = isfunction
 
-local function Inherit(name, class, classTable, passthrough, SpecialCheck)
+local function Inherit(class, classTable, passthrough, SpecialCheck)
 	if not class.base then
 		return class
 	end
@@ -28,7 +28,7 @@ local function Inherit(name, class, classTable, passthrough, SpecialCheck)
 	if not baseclass.base or (isfunction(SpecialCheck) and not SpecialCheck(baseclass, deepbaseclass)) then
 		return tableDeepInherit(class, baseclass)
 	else
-		return tableDeepInherit(class, Inherit(name, baseclass, classTable, passthrough, SpecialCheck))
+		return tableDeepInherit(class, Inherit(baseclass, classTable, passthrough, SpecialCheck))
 	end
 end
 
@@ -90,7 +90,7 @@ function classbuilder.BuildFromFolder(path, realm, scope, OnInitialization, shou
 	-- class if enabled.
 	if shouldInherit then
 		for name, class in pairs(classTable) do
-			classTable[name] = Inherit(name, class, classTable, passthrough, SpecialCheck)
+			classTable[name] = Inherit(class, classTable, passthrough, SpecialCheck)
 		end
 	end
 

--- a/lua/ttt2/libraries/classbuilder.lua
+++ b/lua/ttt2/libraries/classbuilder.lua
@@ -12,6 +12,26 @@ local stringSplit = string.Split
 local stringLower = string.lower
 local isfunction = isfunction
 
+local function Inherit(name, class, classTable, passthrough, SpecialCheck)
+	if not class.base then
+		return class
+	end
+
+	local baseclass = classTable[class.base] or passthrough[class.base]
+
+	if isfunction(SpecialCheck) and not SpecialCheck(class, baseclass) then
+		return class
+	end
+
+	local deepbaseclass = classTable[baseclass.base] or passthrough[baseclass.base]
+
+	if not baseclass.base or (isfunction(SpecialCheck) and not SpecialCheck(baseclass, deepbaseclass)) then
+		return tableDeepInherit(class, baseclass)
+	else
+		return tableDeepInherit(class, Inherit(name, baseclass, classTable, passthrough, SpecialCheck))
+	end
+end
+
 classbuilder = classbuilder or {}
 
 ---
@@ -70,13 +90,7 @@ function classbuilder.BuildFromFolder(path, realm, scope, OnInitialization, shou
 	-- class if enabled.
 	if shouldInherit then
 		for name, class in pairs(classTable) do
-			if not class.base then continue end
-
-			local base = classTable[class.base] or passthrough[class.base]
-
-			if isfunction(SpecialCheck) and not SpecialCheck(class, base) then continue end
-
-			classTable[name] = tableDeepInherit(class, base)
+			classTable[name] = Inherit(name, class, classTable, passthrough, SpecialCheck)
 		end
 	end
 

--- a/lua/ttt2/libraries/classbuilder.lua
+++ b/lua/ttt2/libraries/classbuilder.lua
@@ -25,6 +25,8 @@ local function Inherit(class, classTable, passthrough, SpecialCheck)
 
 	local deepbaseclass = classTable[baseclass.base] or passthrough[baseclass.base]
 
+	class.BaseClass = baseclass
+
 	if not baseclass.base or (isfunction(SpecialCheck) and not SpecialCheck(baseclass, deepbaseclass)) then
 		return tableDeepInherit(class, baseclass)
 	else

--- a/lua/ttt2/libraries/classbuilder.lua
+++ b/lua/ttt2/libraries/classbuilder.lua
@@ -12,24 +12,32 @@ local stringSplit = string.Split
 local stringLower = string.lower
 local isfunction = isfunction
 
+---
+-- recursive inheritance function
 local function Inherit(class, classTable, passthrough, SpecialCheck)
+	-- do not do anything if the base has no base class name assigned
 	if not class.base then
 		return class
 	end
 
+	-- get the base class entry from the class table
 	local baseclass = classTable[class.base] or passthrough[class.base]
 
+	-- if the special inheritance check is failed, no inheritance should take place
 	if isfunction(SpecialCheck) and not SpecialCheck(class, baseclass) then
 		return class
 	end
 
 	local deepbaseclass = classTable[baseclass.base] or passthrough[baseclass.base]
 
+	-- assign a reference to the base class functions
 	class.BaseClass = baseclass
 
 	if not baseclass.base or (isfunction(SpecialCheck) and not SpecialCheck(baseclass, deepbaseclass)) then
+		-- the base of the baseclass is non-existent: only inherit one last time
 		return tableDeepInherit(class, baseclass)
 	else
+		-- the base of the baseclass exists: call inheritance function recursively
 		return tableDeepInherit(class, Inherit(baseclass, classTable, passthrough, SpecialCheck))
 	end
 end


### PR DESCRIPTION
This bug was unnoticable before todays rework in #823 because we never inherited more than two layers deep which worked because the files were in different folders. Therefore this bug was only noticed this late. Now inheritance works on infinitely deep layers.

Additionally I had to add this modification to the `table.DeepInherit` function to prevent the function to add a baseclass to every empty table. I'm not 100% sure why I had to do this now, but I guess it makes sense.