### PR TITLE
pure_skin: consistent text positioning in pure_skin bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ### Fixed
 
 - Updated Japense translation (by @westooooo)
+- Fixed text positioning in pure_skin bar (by @LukasMandok)
 
 ## [v0.9.2b](https://github.com/TTT-2/TTT2/tree/v0.9.2b) (2021-06-20)
 

--- a/gamemodes/terrortown/gamemode/shared/hud_elements/base_elements/pure_skin_element.lua
+++ b/gamemodes/terrortown/gamemode/shared/hud_elements/base_elements/pure_skin_element.lua
@@ -62,7 +62,7 @@ if CLIENT then
 
 		-- draw text
 		if t then
-			draw.AdvancedText(t, "PureSkinBar", x + 14, y + 1, util.GetDefaultColor(c), TEXT_ALIGN_LEFT, TEXT_ALIGN_LEFT, true, s)
+			draw.AdvancedText(t, "PureSkinBar", x + 14, y + h/2 - 1, util.GetDefaultColor(c), TEXT_ALIGN_LEFT, TEXT_ALIGN_CENTER, true, s)
 		end
 	end
 

--- a/gamemodes/terrortown/gamemode/shared/hud_elements/base_elements/pure_skin_element.lua
+++ b/gamemodes/terrortown/gamemode/shared/hud_elements/base_elements/pure_skin_element.lua
@@ -62,7 +62,7 @@ if CLIENT then
 
 		-- draw text
 		if t then
-			draw.AdvancedText(t, "PureSkinBar", x + 14, y + h/2 - 1, util.GetDefaultColor(c), TEXT_ALIGN_LEFT, TEXT_ALIGN_CENTER, true, s)
+			draw.AdvancedText(t, "PureSkinBar", x + 14, y + h * 0.5 - 1, util.GetDefaultColor(c), TEXT_ALIGN_LEFT, TEXT_ALIGN_CENTER, true, s)
 		end
 	end
 


### PR DESCRIPTION
I noticed, that the text positioning in a pure_skin bar is not really consistent at different screen resolutions.
This has caused problems especially with a new HUD element, but it is also noticeable in the player info panel. 
I have tested this at various screen resolutions between 720p and 3000x2000, and it seems to be positioned consistently with the proposed change. 
It also looks good with the Vampire and Bodyguard role. But I have not tested more than that.

![comparison - text in pure_skin bar](https://user-images.githubusercontent.com/32761604/123665746-dc41cc80-d838-11eb-80be-113dd368b0ae.png)
This is at 1080p and 2560x1600.
