### PR TITLE
Hot-Reloading: Fixed data persistency on hotreload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 - Updated Japense translation (by @westooooo)
 - Fixed text positioning in pure_skin bar (by @LukasMandok)
+- Fixed data being not persistent after hot reloading
+  - HUDs are now still available
+  - ttt2net keeps its data
+  - bindings are not lost on reload
 
 ### Changed
 - Revise and additions simplified Chinese (by @TEGTianFan)

--- a/gamemodes/terrortown/gamemode/client/cl_main.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_main.lua
@@ -225,6 +225,12 @@ function GM:InitPostEntity()
 	items.MigrateLegacyItems()
 	items.OnLoaded()
 
+	-- load all HUDs
+	huds.OnLoaded()
+
+	-- load all HUD elements
+	hudelements.OnLoaded()
+
 	HUDManager.LoadAllHUDS()
 	HUDManager.SetHUD()
 
@@ -333,6 +339,16 @@ function GM:OnReloaded()
 	---
 	-- @realm shared
 	hook.Run("TTT2BaseRoleInit")
+
+	-- load all HUDs
+	huds.OnLoaded()
+
+	-- load all HUD elements
+	hudelements.OnLoaded()
+
+	-- re-request the HUD to be loaded
+	HUDManager.LoadAllHUDS()
+	HUDManager.SetHUD()
 
 	-- rebuild menues on game reload
 	vguihandler.Rebuild()

--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -419,6 +419,12 @@ function GM:InitPostEntity()
 	items.MigrateLegacyItems()
 	items.OnLoaded()
 
+	-- load all HUDs
+	huds.OnLoaded()
+
+	-- load all HUD elements
+	hudelements.OnLoaded()
+
 	InitDefaultEquipment()
 
 	local itms = items.GetList()
@@ -1478,6 +1484,12 @@ end
 function GM:OnReloaded()
 	-- load all roles
 	roles.OnLoaded()
+
+	-- load all HUDs
+	huds.OnLoaded()
+
+	-- load all HUD elements
+	hudelements.OnLoaded()
 
 	---
 	-- @realm shared

--- a/gamemodes/terrortown/gamemode/server/sv_network_sync.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_network_sync.lua
@@ -19,16 +19,16 @@
 -- Only send to clients, that already requested a full state update,
 -- which indirectly shows that they are ready to receive and are not
 -- loading the gamemode anymore.
-local initialized_clients = {}
+ttt2net.initializedClients = ttt2net.initializedClients or {}
 
 -- The meta data table to store information about the type of the data (used to correctly send the data)
-local data_store_metadata = {}
+ttt2net.dataStoreMetadata = ttt2net.dataStoreMetadata or {}
 
 -- The general value storage
-local data_store = {}
+ttt2net.dataStore = ttt2net.dataStore or {}
 
 -- The registered nwvars to sync with their path
-local data_synced_nwvars = {}
+ttt2net.dataSyncedNWVars = ttt2net.dataSyncedNWVars or {}
 
 -- Register network message names
 util.AddNetworkString(ttt2net.NETMSG_META_UPDATE)
@@ -56,7 +56,7 @@ local function SyncNWVarWithPath(path, meta, nwent, nwkey)
 		tmpPath = table.Copy(path)
 	end
 
-	local metadata = meta or table.GetWithPath(data_store_metadata, tmpPath)
+	local metadata = meta or table.GetWithPath(ttt2net.dataStoreMetadata, tmpPath)
 	local value = ttt2net.Get(tmpPath)
 
 	if metadata.type == "int" then
@@ -113,16 +113,16 @@ function ttt2net.SetMetaData(path, metadata)
 	end
 
 	-- Retrieve the stored metadata
-	local storedMetaData = table.GetWithPath(data_store_metadata, tmpPath)
+	local storedMetaData = table.GetWithPath(ttt2net.dataStoreMetadata, tmpPath)
 
 	-- If the metadata is already stored, do nothing
 	if ttt2net.NetworkMetaDataTableEqual(storedMetaData, metadata) then return end
 
 	-- Insert data to metadata table
-	table.SetWithPath(data_store_metadata, tmpPath, metadata)
+	table.SetWithPath(ttt2net.dataStoreMetadata, tmpPath, metadata)
 
 	-- Set value of the data field to nil
-	table.SetWithPath(data_store, tmpPath, nil)
+	table.SetWithPath(ttt2net.dataStore, tmpPath, nil)
 
 	-- Sync new meta information to all clients that are already connected and received a full state!
 	ttt2net.SendMetaDataUpdate(tmpPath)
@@ -203,7 +203,7 @@ function ttt2net.Set(path, meta, value, client)
 		tmpPath = table.Copy(path)
 	end
 
-	local metadata = meta or table.GetWithPath(data_store_metadata, tmpPath)
+	local metadata = meta or table.GetWithPath(ttt2net.dataStoreMetadata, tmpPath)
 
 	assert(metadata, "[TTT2NET] Set() called but no metadata entry or metadata parameter found!")
 
@@ -214,10 +214,10 @@ function ttt2net.Set(path, meta, value, client)
 	tmpPath[#tmpPath + 1] = clientId or "default"
 
 	-- Skip if the value is already present or nil
-	if table.GetWithPath(data_store, tmpPath) == value then return end
+	if table.GetWithPath(ttt2net.dataStore, tmpPath) == value then return end
 
 	-- Save the value
-	table.SetWithPath(data_store, tmpPath, value)
+	table.SetWithPath(ttt2net.dataStore, tmpPath, value)
 
 	-- Remove last key eg. "default" or the player id, as this does not belong to the base path
 	tmpPath[#tmpPath] = nil
@@ -235,7 +235,7 @@ function ttt2net.Set(path, meta, value, client)
 	assert(IsEntity(ent), "[TTT2NET] Set() used on a path with an invalid entity!")
 
 	-- Get all registered nwvars
-	local nwvars = table.GetWithPath(data_synced_nwvars, tmpPath) or {}
+	local nwvars = table.GetWithPath(ttt2net.dataSyncedNWVars, tmpPath) or {}
 
 	for i = 1, #nwvars do
 		SyncNWVarWithPath(tmpPath, metadata, ent, nwvars[i])
@@ -259,11 +259,11 @@ function ttt2net.RemoveOverrides(path)
 		tmpPath = table.Copy(path)
 	end
 
-	local currentDataTable = data_store
+	local currentDataTable = ttt2net.dataStore
 
 	if currentDataTable == nil then return end
 
-	-- Traverse the path in the data_store table.
+	-- Traverse the path in the ttt2net.dataStore table.
 	-- This will be done until the second last table is reached, so we still have a reference to the parent table.
 	for i = 1, (#tmpPath - 1) do
 		currentDataTable = currentDataTable[tmpPath[i]]
@@ -370,7 +370,7 @@ function ttt2net.Get(path, client)
 	-- Add the identifier for the default value for all clients or the clientId if specified
 	tmpPath[#tmpPath + 1] = clientId or "default"
 
-	return table.GetWithPath(data_store, tmpPath)
+	return table.GetWithPath(ttt2net.dataStore, tmpPath)
 end
 
 ---
@@ -401,12 +401,12 @@ function ttt2net.GetWithOverride(path, client)
 	defaultPath[#defaultPath + 1] = "default"
 
 	-- Get the overwrite value if available
-	local overrideValue = table.GetWithPath(data_store, overridePath)
+	local overrideValue = table.GetWithPath(ttt2net.dataStore, overridePath)
 
 	if overrideValue ~= nil then
 		return overrideValue
 	else
-		return table.GetWithPath(data_store, defaultPath)
+		return table.GetWithPath(ttt2net.dataStore, defaultPath)
 	end
 end
 
@@ -518,13 +518,13 @@ end
 function ttt2net.Debug()
 	print("[TTT2NET] Debug:")
 	print("Initialized clients:")
-	PrintTable(initialized_clients)
+	PrintTable(ttt2net.initializedClients)
 	print("Synced NWVars:")
-	PrintTable(data_synced_nwvars)
+	PrintTable(ttt2net.dataSyncedNWVars)
 	print("Meta data table:")
-	PrintTable(data_store_metadata)
+	PrintTable(ttt2net.dataStoreMetadata)
 	print("Data store table:")
-	PrintTable(data_store)
+	PrintTable(ttt2net.dataStore)
 end
 
 ---
@@ -544,7 +544,7 @@ function ttt2net.SendMetaDataUpdate(path)
 	end
 
 	-- Check for a metadata entry
-	local metadata = table.GetWithPath(data_store_metadata, tmpPath)
+	local metadata = table.GetWithPath(ttt2net.dataStoreMetadata, tmpPath)
 
 	-- Write meta data
 	net.Start(ttt2net.NETMSG_META_UPDATE)
@@ -552,7 +552,7 @@ function ttt2net.SendMetaDataUpdate(path)
 	ttt2net.NetWritePath(tmpPath)
 	ttt2net.NetWriteMetaData(metadata)
 
-	net.Send(initialized_clients)
+	net.Send(ttt2net.initializedClients)
 end
 
 ---
@@ -594,13 +594,13 @@ end
 function ttt2net.ResetClient(client)
 	assert(IsEntity(client), "[TTT2NET] ResetClient() client is not a valid Entity!")
 
-	table.RemoveByValue(initialized_clients, client)
+	table.RemoveByValue(ttt2net.initializedClients, client)
 
 	-- Clear up the player specific data table
 	ttt2net.SetMetaDataOnPlayer(nil, nil, client)
 
 	-- Clear up all left over overrides
-	ttt2net.RemoveOverridesForClient(client, data_store_metadata)
+	ttt2net.RemoveOverridesForClient(client, ttt2net.dataStoreMetadata)
 end
 
 ---
@@ -620,14 +620,14 @@ function ttt2net.SendDataUpdate(path, client)
 	end
 
 	-- Check for a valid metadata entry
-	local metadata = table.GetWithPath(data_store_metadata, tmpPath)
+	local metadata = table.GetWithPath(ttt2net.dataStoreMetadata, tmpPath)
 
 	assert(metadata, "[TTT2NET] SendDataUpdate(): Metadata table is not initialized for this path.")
 
 	-- Only send to the client (or table of clients) that was specified or the already initialized clients
 	-- This will check if client is a table or a single client and format it to a table and otherwise use
-	-- the initialized_clients list.
-	local receivers = istable(client) and client or client and { client } or initialized_clients
+	-- the ttt2net.initializedClients list.
+	local receivers = istable(client) and client or client and { client } or ttt2net.initializedClients
 
 	-- For each receiver send the data
 	for i = 1, #receivers do
@@ -687,21 +687,21 @@ end
 -- @realm server
 function ttt2net.SendFullStateUpdate(client)
 	-- Wrap the given receivers to a table
-	local receivers = istable(client) and client or client and { client } or initialized_clients
+	local receivers = istable(client) and client or client and { client } or ttt2net.initializedClients
 
 	-- For each receiver create the custom data table with respect to the override values and send it
 	for i = 1, #receivers do
 		local receiver = receivers[i]
 		local data = {
-			meta = data_store_metadata,
-			data = ttt2net.DataTableWithOverrides(receiver, data_store_metadata)
+			meta = ttt2net.dataStoreMetadata,
+			data = ttt2net.DataTableWithOverrides(receiver, ttt2net.dataStoreMetadata)
 		}
 
 		net.SendStream(ttt2net.NET_STREAM_FULL_STATE_UPDATE, data, receiver)
 
 		-- Set the client as initialized (so it will receive future data updates)
-		if not table.HasValue(initialized_clients, receiver) then
-			initialized_clients[#initialized_clients + 1] = receiver
+		if not table.HasValue(ttt2net.initializedClients, receiver) then
+			ttt2net.initializedClients[#ttt2net.initializedClients + 1] = receiver
 		end
 	end
 end
@@ -818,7 +818,7 @@ function ttt2net.SyncWithNWVar(path, meta, nwent, nwkey)
 	table.insert(tmpPath, 1, "players")
 	table.insert(tmpPath, 2, nwent:EntIndex())
 
-	local metadata = meta or table.GetWithPath(data_store_metadata, tmpPath)
+	local metadata = meta or table.GetWithPath(ttt2net.dataStoreMetadata, tmpPath)
 
 	assert(metadata, "[TTT2NET] SyncWithNWVar() called but no metadata entry or metadata parameter found!")
 
@@ -846,14 +846,14 @@ function ttt2net.SyncWithNWVar(path, meta, nwent, nwkey)
 	ttt2net.Set(tmpPath, metadata, curval)
 
 	-- Get all registered nwvars
-	local nwvars = table.GetWithPath(data_synced_nwvars, tmpPath) or {}
+	local nwvars = table.GetWithPath(ttt2net.dataSyncedNWVars, tmpPath) or {}
 
 	-- Add the nwkey to the registered nwvars on this path
 	if not table.HasValue(nwvars, nwkey) then
 		nwvars[#nwvars + 1] = nwkey
 	end
 
-	table.SetWithPath(data_synced_nwvars, tmpPath, nwvars)
+	table.SetWithPath(ttt2net.dataSyncedNWVars, tmpPath, nwvars)
 end
 
 ---

--- a/gamemodes/terrortown/gamemode/shared/hud_elements/tttminiscoreboard/pure_skin_miniscoreboard.lua
+++ b/gamemodes/terrortown/gamemode/shared/hud_elements/tttminiscoreboard/pure_skin_miniscoreboard.lua
@@ -23,7 +23,7 @@ local const_defaults = {
 	minsize = {w = 0, h = 0}
 }
 
-local plysList = plysList
+local plysList = {}
 
 local function SortMiniscoreboardFunc(a, b)
 	if not a:OnceFound() then

--- a/gamemodes/terrortown/gamemode/shared/hud_elements/tttminiscoreboard/pure_skin_miniscoreboard.lua
+++ b/gamemodes/terrortown/gamemode/shared/hud_elements/tttminiscoreboard/pure_skin_miniscoreboard.lua
@@ -23,7 +23,7 @@ local const_defaults = {
 	minsize = {w = 0, h = 0}
 }
 
-local plysList = plysList or {}
+local plysList = plysList
 
 local function SortMiniscoreboardFunc(a, b)
 	if not a:OnceFound() then

--- a/gamemodes/terrortown/gamemode/shared/sh_main.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_main.lua
@@ -26,12 +26,6 @@ function GM:TTT2Initialize()
 	-- @realm shared
 	hook.Run("TTT2BaseRoleInit")
 
-	-- load all HUDs
-	huds.OnLoaded()
-
-	-- load all HUD elements
-	hudelements.OnLoaded()
-
 	DefaultEquipment = GetDefaultEquipment()
 end
 

--- a/gamemodes/terrortown/gamemode/shared/sh_network_sync.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_network_sync.lua
@@ -3,7 +3,7 @@
 -- @author saibotk
 -- @module ttt2net
 
-ttt2net = {}
+ttt2net = ttt2net or {}
 
 -- Network message name constants
 ttt2net.NETMSG_META_UPDATE = "TTT2_NET_META_UPDATE"

--- a/lua/ttt2/libraries/bind.lua
+++ b/lua/ttt2/libraries/bind.lua
@@ -21,7 +21,7 @@ local WasPressed = {}
 bind = bind or {}
 
 bind.bindings = bind.bindings or {}
-bind.registry = bind.redistry or {}
+bind.registry = bind.registry or {}
 bind.settingsBindings = bind.settingsBindings or {}
 bind.settingsBindingsCategories = bind.settingsBindingsCategories or {
 	"header_bindings_ttt2",


### PR DESCRIPTION
Fixed hotreloading for
- TTT2NET
- HUDs
- Bindings

Based on [this article](https://wiki.facepunch.com/gmod/Auto_Refresh) I reworked the way data is stored. This way (I verified this) data is persistent over hot reloading. For HUDs I decided against this approach because in my opinion HUDs should refresh on reload so the user sees their change (i.e. the language system blocks data reloading which is annoying imo). Therefore I added a simple reload in `GM:OnReloaded`.

Additionally I cleaned up the bindings library a bit.