### PR TITLE
Revive: Prevent spectators about to revive from gathering player info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ### Changed
 - Revise and additions simplified Chinese (by @TEGTianFan)
+- Prevent spectators from gathering info on players if they're about to revive (by @AaronMcKenney)
 
 ## [v0.9.2b](https://github.com/TTT-2/TTT2/tree/v0.9.2b) (2021-06-20)
 

--- a/gamemodes/terrortown/gamemode/server/sv_player.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player.lua
@@ -362,7 +362,10 @@ function GM:KeyPress(ply, key)
 	if not ply:IsSpec() or ply:GetRagdollSpec() then return end
 
 	-- Do not allow the spectator to gather information if they're about to revive.
-	if ply:IsReviving() then return end
+	if ply:IsReviving() then
+		LANG.Msg(ply, "spec_about_to_revive", nil, MSG_MSTACK_WARN)
+		return
+	end
 
 	if ply.propspec then
 		return PROPSPEC.Key(ply, key)
@@ -488,7 +491,10 @@ local function SpecUseKey(ply, cmd, arg)
 	if not IsValid(ply) or not ply:IsSpec() then return end
 
 	-- Do not allow the spectator to gather information if they're about to revive.
-	if ply:IsReviving() then return end
+	if ply:IsReviving() then
+		LANG.Msg(ply, "spec_about_to_revive", nil, MSG_MSTACK_WARN)
+		return
+	end
 
 	-- longer range than normal use
 	local tr = util.QuickTrace(ply:GetShootPos(), ply:GetAimVector() * 128, ply)

--- a/gamemodes/terrortown/gamemode/server/sv_player.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player.lua
@@ -364,6 +364,7 @@ function GM:KeyPress(ply, key)
 	-- Do not allow the spectator to gather information if they're about to revive.
 	if ply:IsReviving() then
 		LANG.Msg(ply, "spec_about_to_revive", nil, MSG_MSTACK_WARN)
+
 		return
 	end
 
@@ -493,6 +494,7 @@ local function SpecUseKey(ply, cmd, arg)
 	-- Do not allow the spectator to gather information if they're about to revive.
 	if ply:IsReviving() then
 		LANG.Msg(ply, "spec_about_to_revive", nil, MSG_MSTACK_WARN)
+
 		return
 	end
 

--- a/gamemodes/terrortown/gamemode/server/sv_player.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player.lua
@@ -361,6 +361,9 @@ function GM:KeyPress(ply, key)
 	-- Spectator keys
 	if not ply:IsSpec() or ply:GetRagdollSpec() then return end
 
+	-- Do not allow the spectator to gather information if they're about to revive.
+	if ply:IsReviving() then return end
+
 	if ply.propspec then
 		return PROPSPEC.Key(ply, key)
 	end
@@ -483,6 +486,9 @@ end
 -- fun. Hence on the client we override +use for specs and use this instead.
 local function SpecUseKey(ply, cmd, arg)
 	if not IsValid(ply) or not ply:IsSpec() then return end
+
+	-- Do not allow the spectator to gather information if they're about to revive.
+	if ply:IsReviving() then return end
 
 	-- longer range than normal use
 	local tr = util.QuickTrace(ply:GetShootPos(), ply:GetAimVector() * 128, ply)

--- a/lua/terrortown/lang/de.lua
+++ b/lua/terrortown/lang/de.lua
@@ -1408,3 +1408,6 @@ L.xfer_team_indicator = "Team"
 
 -- 2021-06-25
 L.searchbar_default_placeholder = "Durchsuche Liste..."
+
+-- 2021-07-11
+--L.spec_about_to_revive = "Spectating is limited during revival period."

--- a/lua/terrortown/lang/en.lua
+++ b/lua/terrortown/lang/en.lua
@@ -1409,3 +1409,6 @@ L.xfer_team_indicator = "Team"
 
 -- 2021-06-25
 L.searchbar_default_placeholder = "Search in list..."
+
+-- 2021-07-11
+L.spec_about_to_revive = "Spectating is limited during revival period."

--- a/lua/terrortown/lang/es.lua
+++ b/lua/terrortown/lang/es.lua
@@ -1408,3 +1408,6 @@ L.desc_event_kill_other_using = "{victim} ({vrole} / {vteam}) fue asesinado por 
 
 -- 2021-06-25
 --L.searchbar_default_placeholder = "Search in list..."
+
+-- 2021-07-11
+--L.spec_about_to_revive = "Spectating is limited during revival period."

--- a/lua/terrortown/lang/fr.lua
+++ b/lua/terrortown/lang/fr.lua
@@ -1420,3 +1420,6 @@ L.karma_unknown_tooltip = "Inconnu"
 
 -- 2021-06-25
 --L.searchbar_default_placeholder = "Search in list..."
+
+-- 2021-07-11
+--L.spec_about_to_revive = "Spectating is limited during revival period."

--- a/lua/terrortown/lang/it.lua
+++ b/lua/terrortown/lang/it.lua
@@ -1418,3 +1418,6 @@ L.desc_event_kill_other_using = "{victim} ({vrole} / {vteam}) è stata ucciso da
 
 -- 2021-06-25
 --L.searchbar_default_placeholder = "Search in list..."
+
+-- 2021-07-11
+--L.spec_about_to_revive = "Spectating is limited during revival period."

--- a/lua/terrortown/lang/ja.lua
+++ b/lua/terrortown/lang/ja.lua
@@ -1409,3 +1409,6 @@ L.xfer_team_indicator = "陣営"
 
 -- 2021-06-25
 --L.searchbar_default_placeholder = "Search in list..."
+
+-- 2021-07-11
+--L.spec_about_to_revive = "Spectating is limited during revival period."

--- a/lua/terrortown/lang/pl.lua
+++ b/lua/terrortown/lang/pl.lua
@@ -1418,3 +1418,6 @@ L.none = "Brak Roli"
 
 -- 2021-06-25
 --L.searchbar_default_placeholder = "Search in list..."
+
+-- 2021-07-11
+--L.spec_about_to_revive = "Spectating is limited during revival period."

--- a/lua/terrortown/lang/ru.lua
+++ b/lua/terrortown/lang/ru.lua
@@ -1418,3 +1418,6 @@ L.desc_event_kill_other_using = "{victim} ({vrole} / {vteam}) был убит {a
 
 -- 2021-06-25
 --L.searchbar_default_placeholder = "Search in list..."
+
+-- 2021-07-11
+--L.spec_about_to_revive = "Spectating is limited during revival period."

--- a/lua/terrortown/lang/zh_hans.lua
+++ b/lua/terrortown/lang/zh_hans.lua
@@ -1417,3 +1417,6 @@ L.xfer_team_indicator = "阵营"
 
 -- 2021-06-25
 L.searchbar_default_placeholder = "在列表中搜索..."
+
+-- 2021-07-11
+--L.spec_about_to_revive = "Spectating is limited during revival period."

--- a/lua/terrortown/lang/zh_tw.lua
+++ b/lua/terrortown/lang/zh_tw.lua
@@ -1417,3 +1417,6 @@ L.xfer_team_indicator = "陣營"
 
 -- 2021-06-25
 L.searchbar_default_placeholder = "在列表中搜索..."
+
+-- 2021-07-11
+--L.spec_about_to_revive = "Spectating is limited during revival period."


### PR DESCRIPTION
This code change was made for reviving roles such as Pharaoh, Occultist, and Cursed. Each of these roles are likely to revive after death, but not immediately. During that 10 or so seconds they can browse the roles of other players, which they shouldn't know since they're about to re-enter play.

So this change prevents that. While the revive timer is going, the spectator can move around, but can no longer enter first-person view of an alive player to see their role, or look at unidentified corpses.