### PR TITLE
Hotreload: Weapon hotreloading fix and persistent data across reloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Add Traditional Chinese Translation (by @TEGTianFan)
 - Added a searchbar to submenus
 - Added full-sized icons to the equipment-editor
+- Hotreload functionality for weapons, they are now fully compatible to TTT2 after hotreload
+- Added experimental `SWEP.HotReloadableKeys` a list of strings to weapons, that makes data saved with `weapons.GetStored()` persistent across hotreloads
 
 ### Fixed
 
@@ -21,6 +23,11 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ### Changed
 - Revise and additions simplified Chinese (by @TEGTianFan)
 - Prevent spectators from gathering info on players if they're about to revive (by @AaronMcKenney)
+
+### Internal Breaking Changes
+- Removed first argument of `GetEquipmentBase(data, equipment)`, it only takes the equipment as argument now `GetEquipmentBase(equipment)` and generally merges it with `EquipMenuData`
+- Added equipment as argument to `InitDefaultEquipmentForRole(roleData)`, it now only initializes the given equipment not all `InitDefaultEquipmentForRole(roleData, equipment)`
+- Added equipment as argument to `CleanUpDefaultCanBuyIndices()`, it now only initializes the given equipment not all `CleanUpDefaultCanBuyIndices(equipment)`
 
 ## [v0.9.2b](https://github.com/TTT-2/TTT2/tree/v0.9.2b) (2021-06-20)
 

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -85,6 +85,10 @@ SWEP.AllowDrop = true
 -- Set to true if weapon kills silently (no death scream)
 SWEP.IsSilent = false
 
+-- Set Keys like {"HeadshotMultiplier","Weight"} if you want the data to be persistent after hotreloads
+-- Empty it before a hotreload to reset data after a hotreload, otherwise this data keep persisting until you do a map reload or restart your server
+SWEP.HotReloadableKeys = {}
+
 -- If this weapon should be given to players upon spawning, set a table of the
 -- roles this should happen for here
 --	SWEP.InLoadoutFor = {ROLE_TRAITOR, ROLE_DETECTIVE, ROLE_INNOCENT}

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -85,8 +85,9 @@ SWEP.AllowDrop = true
 -- Set to true if weapon kills silently (no death scream)
 SWEP.IsSilent = false
 
--- Set Keys like {"HeadshotMultiplier","Weight"} if you want the data to be persistent after hotreloads
+-- Set Keys like { "HeadshotMultiplier", "Weight", { "Primary", "Recoil" }, { "Secondary", "Ammo" } } if you want the data to be persistent after hotreloads
 -- Empty it before a hotreload to reset data after a hotreload, otherwise this data keep persisting until you do a map reload or restart your server
+-- Can be useful if you have multiple instances, that rely on global variables stored via weapons.GetStored()
 SWEP.HotReloadableKeys = {}
 
 -- If this weapon should be given to players upon spawning, set a table of the

--- a/gamemodes/terrortown/gamemode/client/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_equip.lua
@@ -1104,23 +1104,27 @@ function GM:OnContextMenuOpen()
 	end
 end
 
+function TTT2CacheEquipMaterials(item)
+	--if there is no material or model, the item should probably not be available in the shop
+	if item.material and item.material ~= "vgui/ttt/icon_id" then
+		item.ttt2_cached_material = Material(item.material)
+		if item.ttt2_cached_material:IsError() then
+			-- Setting fallback material
+			item.ttt2_cached_material = fallback_mat
+		end
+	elseif item.model and item.model ~= "models/weapons/w_bugbait.mdl" then
+		--do not use fallback mat and use model instead
+		item.ttt2_cached_material = nil
+		item.ttt2_cached_model = model
+	end
+end
+
 -- Preload materials for the shop
 hook.Add("PostInitPostEntity", "TTT2CacheEquipMaterials", function()
 	local itms = ShopEditor.GetEquipmentForRoleAll()
 
 	for _, item in pairs(itms) do
-		--if there is no material or model, the item should probably not be available in the shop
-		if item.material and item.material ~= "vgui/ttt/icon_id" then
-			item.ttt2_cached_material = Material(item.material)
-			if item.ttt2_cached_material:IsError() then
-				-- Setting fallback material
-				item.ttt2_cached_material = fallback_mat
-			end
-		elseif item.model and item.model ~= "models/weapons/w_bugbait.mdl" then
-			--do not use fallback mat and use model instead
-			item.ttt2_cached_material = nil
-			item.ttt2_cached_model = model
-		end
+		TTT2CacheEquipMaterials(item)
 	end
 end)
 

--- a/gamemodes/terrortown/gamemode/client/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_equip.lua
@@ -1104,6 +1104,10 @@ function GM:OnContextMenuOpen()
 	end
 end
 
+---
+-- Caches the material or model
+-- @param table item
+-- @realm client
 function TTT2CacheEquipMaterials(item)
 	--if there is no material or model, the item should probably not be available in the shop
 	if item.material and item.material ~= "vgui/ttt/icon_id" then

--- a/gamemodes/terrortown/gamemode/client/cl_main.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_main.lua
@@ -286,7 +286,7 @@ function GM:InitPostEntity()
 
 	net.Start("TTT2SyncShopsWithServer")
 	net.SendToServer()
-	isShopFallbackInitialized = true
+	TTT2ShopFallbackInitialized = true
 
 	net.Start("TTT_Spectate")
 	net.WriteBool(GetConVar("ttt_spectator_mode"):GetBool())

--- a/gamemodes/terrortown/gamemode/client/cl_main.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_main.lua
@@ -259,9 +259,6 @@ function GM:InitPostEntity()
 		-- Insert data into role fallback tables
 		InitDefaultEquipment(eq)
 
-		/*ShopEditor.InitDefaultData(eq) -- init normal weapons equipment
-		CreateEquipment(eq) -- init weapons*/
-
 		eq.CanBuy = {} -- reset normal weapons equipment
 	end
 

--- a/gamemodes/terrortown/gamemode/client/cl_main.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_main.lua
@@ -234,32 +234,35 @@ function GM:InitPostEntity()
 	HUDManager.LoadAllHUDS()
 	HUDManager.SetHUD()
 
-	InitDefaultEquipment()
 
 	local itms = items.GetList()
 
 	-- load items
 	for i = 1, #itms do
-		local itm = itms[i]
+		local eq = itms[i]
 
-		ShopEditor.InitDefaultData(itm) -- initialize the default data
-		CreateEquipment(itm) -- init items
+		InitDefaultEquipment(eq)
+		ShopEditor.InitDefaultData(eq) -- initialize the default data
+		CreateEquipment(eq) -- init items
 
-		itm.CanBuy = {} -- reset normal items equipment
+		eq.CanBuy = {} -- reset normal items equipment
 
-		itm:Initialize()
+		eq:Initialize()
 	end
 
 	local sweps = weapons.GetList()
 
 	-- load sweps
 	for i = 1, #sweps do
-		local wep = sweps[i]
+		local eq = sweps[i]
 
-		ShopEditor.InitDefaultData(wep) -- init normal weapons equipment
-		CreateEquipment(wep) -- init weapons
+		-- Insert data into role fallback tables
+		InitDefaultEquipment(eq)
 
-		wep.CanBuy = {} -- reset normal weapons equipment
+		/*ShopEditor.InitDefaultData(eq) -- init normal weapons equipment
+		CreateEquipment(eq) -- init weapons*/
+
+		eq.CanBuy = {} -- reset normal weapons equipment
 	end
 
 	local roleList = roles.GetList()
@@ -286,6 +289,7 @@ function GM:InitPostEntity()
 
 	net.Start("TTT2SyncShopsWithServer")
 	net.SendToServer()
+	isShopFallbackInitialized = true
 
 	net.Start("TTT_Spectate")
 	net.WriteBool(GetConVar("ttt_spectator_mode"):GetBool())

--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -505,7 +505,7 @@ function GM:InitPostEntity()
 	LoadShopsEquipment()
 
 	MsgN("[TTT2][INFO] Shops initialized...")
-	isShopFallbackInitialized = true
+	TTT2ShopFallbackInitialized = true
 
 	WEPS.ForcePrecache()
 

--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -461,21 +461,6 @@ function GM:InitPostEntity()
 		-- Insert data into role fallback tables
 		InitDefaultEquipment(eq)
 
-		/*ShopEditor.InitDefaultData(eq)
-
-		if isSqlTableCreated then
-			local name = GetEquipmentFileName(WEPS.GetClass(eq))
-			local loaded, changed = sql.Load("ttt2_items", name, eq, ShopEditor.savingKeys)
-
-			if not loaded then
-				sql.Init("ttt2_items", name, eq, ShopEditor.savingKeys)
-			elseif changed then
-				CHANGED_EQUIPMENT[#CHANGED_EQUIPMENT + 1] = {name, eq}
-			end
-		end
-
-		CreateEquipment(eq) -- init weapons*/
-
 		eq.CanBuy = {} -- reset normal weapons equipment
 	end
 

--- a/gamemodes/terrortown/gamemode/shared/sh_equip_items.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_equip_items.lua
@@ -937,7 +937,7 @@ local function ResetDefaultEquipmentForRole(roleData, eq)
 
 			if counter == i then continue end
 
-			-- Replace skipped equipments with higher indeces
+			-- Replace skipped equipments with higher indices
 			tbl[counter] = tbl[i]
 		end
 

--- a/gamemodes/terrortown/gamemode/shared/sh_equip_items.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_equip_items.lua
@@ -58,10 +58,10 @@ EquipmentItems = EquipmentItems or setmetatable(
 ---
 -- Adds all needed parameters for TTT2
 -- @param string name The classname this equipment shall have
--- @param table eq Equipment, that you add the KeyValues to
+-- @param table eq Equipment, that you add the keyvalues to
 -- @internal
 -- @realm shared
-function AddStandardKeyValues(eq, name)
+function AddEquipmentKeyValues(eq, name)
 	local data = eq.EquipMenuData or {}
 
 	local tbl = {
@@ -112,7 +112,7 @@ function GetEquipmentBase(eq)
 		return
 	end
 
-	AddStandardKeyValues(eq, name)
+	AddEquipmentKeyValues(eq, name)
 
 	return eq
 end

--- a/gamemodes/terrortown/gamemode/shared/sh_equip_items.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_equip_items.lua
@@ -60,7 +60,7 @@ EquipmentItems = EquipmentItems or setmetatable(
 -- @param string name The classname this equipment shall have
 -- @param table eq Equipment, that you add the KeyValues to
 -- @internal
--- @real shared
+-- @realm shared
 function AddStandardKeyValues(eq, name)
 	local data = eq.EquipMenuData or {}
 

--- a/gamemodes/terrortown/gamemode/shared/sh_equip_items.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_equip_items.lua
@@ -281,7 +281,7 @@ if CLIENT then
 
 				if not v or not v.id then continue end
 
-				v.custom = not table.HasValue(DefaultEquipment[fallback], v.id) -- TODO
+				v.custom = not table.HasValue(DefaultEquipment[fallback], v.id)
 			end
 
 			Equipment[fallback] = tbl
@@ -841,7 +841,7 @@ local function InitDefaultEquipmentForRole(roleData, eq)
 
 	-- mark custom equipment
 	if base and base.id then
-		base.custom = not table.HasValue(DefaultEquipment[roleData.index], base.id) -- TODO
+		base.custom = not table.HasValue(DefaultEquipment[roleData.index], base.id)
 	end
 
 	roleData.fallbackTable = tbl
@@ -947,7 +947,7 @@ local function ResetDefaultEquipmentForRole(roleData, eq)
 
 	-- mark custom equipment
 	if base and base.id then
-		base.custom = not table.HasValue(DefaultEquipment[roleData.index], base.id) -- TODO
+		base.custom = not table.HasValue(DefaultEquipment[roleData.index], base.id)
 	end
 
 	roleData.fallbackTable = tbl
@@ -1208,7 +1208,7 @@ else -- CLIENT
 
 		-- mark custom items
 		if toadd and toadd.id then
-			toadd.custom = not table.HasValue(DefaultEquipment[subrole], toadd.id) -- TODO
+			toadd.custom = not table.HasValue(DefaultEquipment[subrole], toadd.id)
 		end
 
 		Equipment[subrole] = Equipment[subrole] or {}

--- a/gamemodes/terrortown/gamemode/shared/sh_equip_items.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_equip_items.lua
@@ -930,17 +930,23 @@ local function ResetDefaultEquipmentForRole(roleData, eq)
 		local counter = 0
 
 		for i = 1, tblSize do
+			-- Skip the equipment that should be removed
 			if tbl[i].id == base.id then continue end
 
 			counter = counter + 1
+
+			if counter == i then continue end
+
+			-- Replace skipped equipments with higher indeces
 			tbl[counter] = tbl[i]
 		end
 
 		local diff = tblSize - counter
 
+		-- Remove last table entries
 		if diff > 0 then
-			for i = 1, diff do
-				table.remove(tbl)
+			for i = 0, diff - 1 do
+				table.remove(tbl, tblSize - i)
 			end
 		end
 	end

--- a/gamemodes/terrortown/gamemode/shared/sh_equip_items.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_equip_items.lua
@@ -55,6 +55,12 @@ EquipmentItems = EquipmentItems or setmetatable(
 	}
 )
 
+---
+-- Adds all needed parameters for TTT2
+-- @param string name The classname this equipment shall have
+-- @param table eq Equipment, that you add the KeyValues to
+-- @internal
+-- @real shared
 function AddStandardKeyValues(eq, name)
 	local data = eq.EquipMenuData or {}
 
@@ -818,6 +824,8 @@ end
 
 ---
 -- Initializes the default equipment for a role
+-- @param roleData roleData Role you initialize for
+-- @param table eq Equipment you initialize
 -- @internal
 -- @realm shared
 local function InitDefaultEquipmentForRole(roleData, eq)
@@ -844,6 +852,10 @@ end
 -- A table with structure tbl[key] = value is turned into tbl[value] = value by this function.
 -- This allows you to easily access the table using the value as an index.
 -- @warning This function is destructive! If you want to preserve the table, you have to copy it first.
+-- @param table tbl Table you want values transformed to keys
+-- @internal
+-- @realm shared
+-- @local
 local function ValueToKey(tbl)
 	local tmp = tmp or {}
 
@@ -858,11 +870,13 @@ local function ValueToKey(tbl)
 end
 
 ---
--- Cleans up the structure of the CanBuy table of all weapons and items.
+-- Cleans up the structure of the CanBuy table of the given equipment.
 -- After calling this, all keys will be equal to their value. This allows access in O(1) rather than O(n).
 -- table.HasValue is still supported, but please just check if the key is not nil instead.
+-- @param table eq Equipment you clean the buy indices from
 -- @internal
 -- @realm shared
+-- @local
 local function CleanUpDefaultCanBuyIndices(eq)
 	eq.CanBuy = eq.CanBuy or {}
 
@@ -871,6 +885,7 @@ end
 
 ---
 -- Initializes the default equipment for traitors and detectives
+-- @param table eq Equipment you initialize
 -- @internal
 -- @realm shared
 function InitDefaultEquipment(eq)
@@ -881,6 +896,8 @@ end
 
 ---
 -- Resets the default equipment for a role
+-- @param roleData roleData Role you reset for
+-- @param table eq Equipment you reset
 -- @internal
 -- @realm shared
 local function ResetDefaultEquipmentForRole(roleData, eq)
@@ -901,6 +918,7 @@ local function ResetDefaultEquipmentForRole(roleData, eq)
 		for i = 1, tblSize do
 			if tbl[i].id == base.id then
 				tableHasValue = true
+
 				break
 			end
 		end
@@ -912,9 +930,7 @@ local function ResetDefaultEquipmentForRole(roleData, eq)
 		local counter = 0
 
 		for i = 1, tblSize do
-			if tbl[i].id == base.id then
-				continue
-			end
+			if tbl[i].id == base.id then continue end
 
 			counter = counter + 1
 			tbl[counter] = tbl[i]
@@ -940,6 +956,7 @@ end
 ---
 -- Resets the default equipment for traitors and detectives
 -- After a hotreload this is necessary for example in case the default values changed
+-- @param table eq Equipment you initialize
 -- @internal
 -- @realm shared
 function ResetDefaultEquipment(eq)

--- a/gamemodes/terrortown/gamemode/shared/sh_init.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_init.lua
@@ -124,7 +124,6 @@ SHOP_DISABLED = "DISABLED"
 SHOP_UNSET = "UNSET"
 
 -- if you add roles that can shop, modify DefaultEquipment at the end of this file
--- TODO combine DefaultEquipment[x] and GetRoles()[x] !
 
 -- just compatibality functions
 

--- a/gamemodes/terrortown/gamemode/shared/sh_main.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_main.lua
@@ -10,14 +10,14 @@ local MAX_DROWN_TIME = 8
 
 local sneakSpeedSquared = math.pow(150, 2)
 
-isShopFallbackInitialized = false
+TTT2ShopFallbackInitialized = false
 
 ---
 -- Initializes the equipment with necessary data for ttt2
 -- @internal
 -- @realm shared
 local function TTT2PreRegisterSWEP(equipment, name)
-	if isShopFallbackInitialized then
+	if TTT2ShopFallbackInitialized then
 		MsgN("[TTT2] Trying to hotreload ",  name, " .")
 	end
 
@@ -25,7 +25,7 @@ local function TTT2PreRegisterSWEP(equipment, name)
 	AddEquipmentKeyValues(equipment, name)
 	ShopEditor.InitDefaultData(equipment)
 
-	if isShopFallbackInitialized then
+	if TTT2ShopFallbackInitialized then
 		local oldSWEP = weapons.GetStored(name)
 
 		-- Keep custom changed data from the old SWEP if hotReloadableKeys are given
@@ -92,7 +92,7 @@ local function TTT2PreRegisterSWEP(equipment, name)
 		elseif changed then
 			local counter = #CHANGED_EQUIPMENT + 1
 
-			if isShopFallbackInitialized then
+			if TTT2ShopFallbackInitialized then
 				for i = 1, #CHANGED_EQUIPMENT do
 					if CHANGED_EQUIPMENT[i][1] == name then
 						counter = i
@@ -106,7 +106,7 @@ local function TTT2PreRegisterSWEP(equipment, name)
 		end
 	end
 
-	if not isShopFallbackInitialized then return end
+	if not TTT2ShopFallbackInitialized then return end
 
 	-- initialize fallback shops
 	InitFallbackShops()

--- a/gamemodes/terrortown/gamemode/shared/sh_main.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_main.lua
@@ -51,6 +51,7 @@ local function TTT2PreRegisterSWEP(equipment, name)
 				for _, key in pairs(keys) do
 					if not isstring(key) or not oldKeyField then
 						continueOuterLoop = true
+
 						break
 					end
 
@@ -65,6 +66,7 @@ local function TTT2PreRegisterSWEP(equipment, name)
 						eqKeyField[key] = {}
 					elseif counter == #keys then
 						saveKey = key
+
 						break
 					end
 
@@ -83,32 +85,28 @@ local function TTT2PreRegisterSWEP(equipment, name)
 	end
 
 	if SERVER and sql.CreateSqlTable("ttt2_items", ShopEditor.savingKeys) then
-		if name == "weapon_ttt_demonicsheep" then print("3") end
 		local loaded, changed = sql.Load("ttt2_items", name, equipment, ShopEditor.savingKeys)
 
 		if not loaded then
-			if name == "weapon_ttt_demonicsheep" then print("4") end
 			sql.Init("ttt2_items", name, equipment, ShopEditor.savingKeys)
 		elseif changed then
-			if name == "weapon_ttt_demonicsheep" then print("5") end
 			local counter = #CHANGED_EQUIPMENT + 1
 
 			if isShopFallbackInitialized then
-				if name == "weapon_ttt_demonicsheep" then print("6") end
 				for i = 1, #CHANGED_EQUIPMENT do
 					if CHANGED_EQUIPMENT[i][1] == name then
 						counter = i
+
 						break
 					end
 				end
 			end
+
 			CHANGED_EQUIPMENT[counter] = {name, equipment}
 		end
 	end
 
 	if not isShopFallbackInitialized then return end
-
-	if name == "weapon_ttt_demonicsheep" then print("7") end
 
 	-- initialize fallback shops
 	InitFallbackShops()

--- a/gamemodes/terrortown/gamemode/shared/sh_main.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_main.lua
@@ -22,7 +22,7 @@ local function TTT2PreRegisterSWEP(equipment, name)
 	end
 
 	-- Initialize Equipment
-	AddStandardKeyValues(equipment, name)
+	AddEquipmentKeyValues(equipment, name)
 	ShopEditor.InitDefaultData(equipment)
 
 	if isShopFallbackInitialized then


### PR DESCRIPTION
This fixes the hotreloading problems with ttt2 missing certain key-values like .id or ttt2_cached_material.
It also cleans up the old code and reduces number of loops for weapons.GetList().

As a bonus I added the possibility to add HotReloadableKeys as a list of strings to make data saved via weapons.GetStored() inside the original SWEP-files to be persistent across hotreloads, if you need some variables to keep on counting.

As this was a deep going fix, I'd appreciate some tests and am open for critics as it might be that I dont see clear on this matter anymore 😄 To see how the weapons get registered and the hook "PreRegisterSWEP" gets ran look into garrysmod files directly under \garrysmod\lua\includes\modules\weapons.lua