### PR TITLE
Weapon spawn rework breaker

### DIFF
--- a/gamemodes/terrortown/gamemode/shared/sh_main.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_main.lua
@@ -29,7 +29,7 @@ local function TTT2PreRegisterSWEP(equipment, name)
 		local oldSWEP = weapons.GetStored(name)
 
 		-- Keep custom changed data from the old SWEP if hotReloadableKeys are given
-		if #equipment.HotReloadableKeys > 0 and oldSWEP then
+		if istable(equipment.HotReloadableKeys) and #equipment.HotReloadableKeys > 0 and oldSWEP then
 			MsgN("[TTT2] Hotreloading ",  #equipment.HotReloadableKeys, " given Keys from old SWEP-file.")
 
 			for _, keys in pairs(equipment.HotReloadableKeys) do

--- a/materials/vgui/ttt/tid/tid_big_ammo_deagle.vmt
+++ b/materials/vgui/ttt/tid/tid_big_ammo_deagle.vmt
@@ -7,4 +7,5 @@
 	"$translucent" 1
 	"$vertexalpha" 1
 	"$vertexcolor" 1
+	"$ignorez" 1
 }

--- a/materials/vgui/ttt/tid/tid_big_ammo_mac10.vmt
+++ b/materials/vgui/ttt/tid/tid_big_ammo_mac10.vmt
@@ -7,4 +7,5 @@
 	"$translucent" 1
 	"$vertexalpha" 1
 	"$vertexcolor" 1
+	"$ignorez" 1
 }

--- a/materials/vgui/ttt/tid/tid_big_ammo_pistol.vmt
+++ b/materials/vgui/ttt/tid/tid_big_ammo_pistol.vmt
@@ -7,4 +7,5 @@
 	"$translucent" 1
 	"$vertexalpha" 1
 	"$vertexcolor" 1
+	"$ignorez" 1
 }

--- a/materials/vgui/ttt/tid/tid_big_ammo_random.vmt
+++ b/materials/vgui/ttt/tid/tid_big_ammo_random.vmt
@@ -7,4 +7,5 @@
 	"$translucent" 1
 	"$vertexalpha" 1
 	"$vertexcolor" 1
+	"$ignorez" 1
 }

--- a/materials/vgui/ttt/tid/tid_big_ammo_rifle.vmt
+++ b/materials/vgui/ttt/tid/tid_big_ammo_rifle.vmt
@@ -7,4 +7,5 @@
 	"$translucent" 1
 	"$vertexalpha" 1
 	"$vertexcolor" 1
+	"$ignorez" 1
 }

--- a/materials/vgui/ttt/tid/tid_big_ammo_shotgun.vmt
+++ b/materials/vgui/ttt/tid/tid_big_ammo_shotgun.vmt
@@ -7,4 +7,5 @@
 	"$translucent" 1
 	"$vertexalpha" 1
 	"$vertexcolor" 1
+	"$ignorez" 1
 }

--- a/materials/vgui/ttt/tid/tid_big_player.vmt
+++ b/materials/vgui/ttt/tid/tid_big_player.vmt
@@ -7,4 +7,5 @@
 	"$translucent" 1
 	"$vertexalpha" 1
 	"$vertexcolor" 1
+	"$ignorez" 1
 }

--- a/materials/vgui/ttt/tid/tid_big_weapon_assault.vmt
+++ b/materials/vgui/ttt/tid/tid_big_weapon_assault.vmt
@@ -7,4 +7,5 @@
 	"$translucent" 1
 	"$vertexalpha" 1
 	"$vertexcolor" 1
+ 	"$ignorez" 1
 }

--- a/materials/vgui/ttt/tid/tid_big_weapon_melee.vmt
+++ b/materials/vgui/ttt/tid/tid_big_weapon_melee.vmt
@@ -7,4 +7,5 @@
 	"$translucent" 1
 	"$vertexalpha" 1
 	"$vertexcolor" 1
+ 	"$ignorez" 1
 }

--- a/materials/vgui/ttt/tid/tid_big_weapon_nade.vmt
+++ b/materials/vgui/ttt/tid/tid_big_weapon_nade.vmt
@@ -7,4 +7,5 @@
 	"$translucent" 1
 	"$vertexalpha" 1
 	"$vertexcolor" 1
+	"$ignorez" 1
 }

--- a/materials/vgui/ttt/tid/tid_big_weapon_pistol.vmt
+++ b/materials/vgui/ttt/tid/tid_big_weapon_pistol.vmt
@@ -7,4 +7,5 @@
 	"$translucent" 1
 	"$vertexalpha" 1
 	"$vertexcolor" 1
+	"$ignorez" 1
 }

--- a/materials/vgui/ttt/tid/tid_big_weapon_random.vmt
+++ b/materials/vgui/ttt/tid/tid_big_weapon_random.vmt
@@ -7,4 +7,5 @@
 	"$translucent" 1
 	"$vertexalpha" 1
 	"$vertexcolor" 1
+	"$ignorez" 1
 }

--- a/materials/vgui/ttt/tid/tid_big_weapon_shotgun.vmt
+++ b/materials/vgui/ttt/tid/tid_big_weapon_shotgun.vmt
@@ -7,4 +7,5 @@
 	"$translucent" 1
 	"$vertexalpha" 1
 	"$vertexcolor" 1
+	"$ignorez" 1
 }

--- a/materials/vgui/ttt/tid/tid_big_weapon_sniper.vmt
+++ b/materials/vgui/ttt/tid/tid_big_weapon_sniper.vmt
@@ -7,4 +7,5 @@
 	"$translucent" 1
 	"$vertexalpha" 1
 	"$vertexcolor" 1
+	"$ignorez" 1
 }

--- a/materials/vgui/ttt/tid/tid_big_weapon_special.vmt
+++ b/materials/vgui/ttt/tid/tid_big_weapon_special.vmt
@@ -7,4 +7,5 @@
 	"$translucent" 1
 	"$vertexalpha" 1
 	"$vertexcolor" 1
+	"$ignorez" 1
 }


### PR DESCRIPTION
Apparently materials drawn in WEAPON:RenderScreen need an additional $ignorez parameter to be properly drawn
https://wiki.facepunch.com/gmod/WEAPON:RenderScreen
https://developer.valvesoftware.com/wiki/$ignorez

A GIF to show all icons.
https://gyazo.com/c6232577957bc84fc910179d88bf59a1

Also fixed a little hotreloading bug, when no keys are defined.

Not gonna merge it directly, so you can see the changes.