### PR TITLE
Weapons: Weapon spawn rework Fix 3D-Positioning

### DIFF
--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_spawneditor.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_spawneditor.lua
@@ -383,7 +383,7 @@ if CLIENT then
 
 			-- find limits for top and bottom
 			local traceLimitUpper = util.TraceLine({
-				start = posBase,
+				start = posBase + trace.HitNormal,
 				endpos = posBase + Vector(0, 0, maxEditDistance),
 				mask = MASK_PLAYERSOLID_BRUSHONLY
 			})
@@ -392,7 +392,7 @@ if CLIENT then
 			previewData.normalLimitUpper = traceLimitUpper.HitNormal
 
 			local traceLimitLower = util.TraceLine({
-				start = posBase,
+				start = posBase + trace.HitNormal,
 				endpos = posBase - Vector(0, 0, maxEditDistance),
 				mask = MASK_PLAYERSOLID_BRUSHONLY
 			})
@@ -409,7 +409,7 @@ if CLIENT then
 			local distance2d = posGround:Distance(posBase)
 			local distance3d = posEye:Distance(posBase)
 
-			local angle = EyeAngles().p / 180 * mathPi -- angle in rad
+			local angle = LocalPlayer():EyeAngles().p / 180 * mathPi -- angle in rad
 			local diff = distance2d * mathTan(angle)
 
 			local currentPos = Vector(posBase.x, posBase.y, posEye.z - diff)

--- a/gamemodes/terrortown/gamemode/shared/sh_main.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_main.lua
@@ -29,7 +29,7 @@ local function TTT2PreRegisterSWEP(equipment, name)
 		local oldSWEP = weapons.GetStored(name)
 
 		-- Keep custom changed data from the old SWEP if hotReloadableKeys are given
-		if #equipment.HotReloadableKeys > 0 and oldSWEP then
+		if istable(equipment.HotReloadableKeys) and #equipment.HotReloadableKeys > 0 and oldSWEP then
 			MsgN("[TTT2] Hotreloading ",  #equipment.HotReloadableKeys, " given Keys from old SWEP-file.")
 
 			for _, keys in pairs(equipment.HotReloadableKeys) do

--- a/materials/vgui/ttt/tid/tid_big_ammo_deagle.vmt
+++ b/materials/vgui/ttt/tid/tid_big_ammo_deagle.vmt
@@ -7,4 +7,5 @@
 	"$translucent" 1
 	"$vertexalpha" 1
 	"$vertexcolor" 1
+	"$ignorez" 1
 }

--- a/materials/vgui/ttt/tid/tid_big_ammo_mac10.vmt
+++ b/materials/vgui/ttt/tid/tid_big_ammo_mac10.vmt
@@ -7,4 +7,5 @@
 	"$translucent" 1
 	"$vertexalpha" 1
 	"$vertexcolor" 1
+	"$ignorez" 1
 }

--- a/materials/vgui/ttt/tid/tid_big_ammo_pistol.vmt
+++ b/materials/vgui/ttt/tid/tid_big_ammo_pistol.vmt
@@ -7,4 +7,5 @@
 	"$translucent" 1
 	"$vertexalpha" 1
 	"$vertexcolor" 1
+	"$ignorez" 1
 }

--- a/materials/vgui/ttt/tid/tid_big_ammo_random.vmt
+++ b/materials/vgui/ttt/tid/tid_big_ammo_random.vmt
@@ -7,4 +7,5 @@
 	"$translucent" 1
 	"$vertexalpha" 1
 	"$vertexcolor" 1
+	"$ignorez" 1
 }

--- a/materials/vgui/ttt/tid/tid_big_ammo_rifle.vmt
+++ b/materials/vgui/ttt/tid/tid_big_ammo_rifle.vmt
@@ -7,4 +7,5 @@
 	"$translucent" 1
 	"$vertexalpha" 1
 	"$vertexcolor" 1
+	"$ignorez" 1
 }

--- a/materials/vgui/ttt/tid/tid_big_ammo_shotgun.vmt
+++ b/materials/vgui/ttt/tid/tid_big_ammo_shotgun.vmt
@@ -7,4 +7,5 @@
 	"$translucent" 1
 	"$vertexalpha" 1
 	"$vertexcolor" 1
+	"$ignorez" 1
 }

--- a/materials/vgui/ttt/tid/tid_big_player.vmt
+++ b/materials/vgui/ttt/tid/tid_big_player.vmt
@@ -7,4 +7,5 @@
 	"$translucent" 1
 	"$vertexalpha" 1
 	"$vertexcolor" 1
+	"$ignorez" 1
 }

--- a/materials/vgui/ttt/tid/tid_big_weapon_assault.vmt
+++ b/materials/vgui/ttt/tid/tid_big_weapon_assault.vmt
@@ -7,4 +7,5 @@
 	"$translucent" 1
 	"$vertexalpha" 1
 	"$vertexcolor" 1
+ 	"$ignorez" 1
 }

--- a/materials/vgui/ttt/tid/tid_big_weapon_melee.vmt
+++ b/materials/vgui/ttt/tid/tid_big_weapon_melee.vmt
@@ -7,4 +7,5 @@
 	"$translucent" 1
 	"$vertexalpha" 1
 	"$vertexcolor" 1
+ 	"$ignorez" 1
 }

--- a/materials/vgui/ttt/tid/tid_big_weapon_nade.vmt
+++ b/materials/vgui/ttt/tid/tid_big_weapon_nade.vmt
@@ -7,4 +7,5 @@
 	"$translucent" 1
 	"$vertexalpha" 1
 	"$vertexcolor" 1
+	"$ignorez" 1
 }

--- a/materials/vgui/ttt/tid/tid_big_weapon_pistol.vmt
+++ b/materials/vgui/ttt/tid/tid_big_weapon_pistol.vmt
@@ -7,4 +7,5 @@
 	"$translucent" 1
 	"$vertexalpha" 1
 	"$vertexcolor" 1
+	"$ignorez" 1
 }

--- a/materials/vgui/ttt/tid/tid_big_weapon_random.vmt
+++ b/materials/vgui/ttt/tid/tid_big_weapon_random.vmt
@@ -7,4 +7,5 @@
 	"$translucent" 1
 	"$vertexalpha" 1
 	"$vertexcolor" 1
+	"$ignorez" 1
 }

--- a/materials/vgui/ttt/tid/tid_big_weapon_shotgun.vmt
+++ b/materials/vgui/ttt/tid/tid_big_weapon_shotgun.vmt
@@ -7,4 +7,5 @@
 	"$translucent" 1
 	"$vertexalpha" 1
 	"$vertexcolor" 1
+	"$ignorez" 1
 }

--- a/materials/vgui/ttt/tid/tid_big_weapon_sniper.vmt
+++ b/materials/vgui/ttt/tid/tid_big_weapon_sniper.vmt
@@ -7,4 +7,5 @@
 	"$translucent" 1
 	"$vertexalpha" 1
 	"$vertexcolor" 1
+	"$ignorez" 1
 }

--- a/materials/vgui/ttt/tid/tid_big_weapon_special.vmt
+++ b/materials/vgui/ttt/tid/tid_big_weapon_special.vmt
@@ -7,4 +7,5 @@
 	"$translucent" 1
 	"$vertexalpha" 1
 	"$vertexcolor" 1
+	"$ignorez" 1
 }


### PR DESCRIPTION
Apparently outside of render Hooks the global EyeAngles() is unreliable. It worked on Tim's Pc but not on mine. Don't really know why.
https://wiki.facepunch.com/gmod/Global.EyeAngles

Also let the traces start a bit outside of the walls to be safe not to hit the same spot again.