### PR TITLE
Role function: Changed HasSpecialRole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ### Changed
 - Revise and additions simplified Chinese (by @TEGTianFan)
 - Prevent spectators from gathering info on players if they're about to revive (by @AaronMcKenney)
+- ROLE_NONE does not count as a special role anymore (by @TheNickSkater)
 
 ### Internal Breaking Changes
 - Removed first argument of `GetEquipmentBase(data, equipment)`, it only takes the equipment as argument now `GetEquipmentBase(equipment)` and generally merges it with `EquipMenuData`

--- a/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
@@ -442,11 +442,11 @@ plymeta.IsDetective = plymeta.GetDetective
 
 ---
 -- Checks whether a @{Player} has a special @{ROLE}.
--- @note This just returns <code>false</code> if the @{Player} is an Innocent!
+-- @note This just returns <code>false</code> if the @{Player} is an Innocent or has no role!
 -- @return boolean Returns true if the player has a special role
 -- @realm shared
 function plymeta:HasSpecialRole()
-	return self:GetSubRole() ~= ROLE_INNOCENT
+	return self:GetSubRole() ~= ROLE_INNOCENT and self:GetSubRole() ~= ROLE_NONE
 end
 
 ---


### PR DESCRIPTION
Changed the "IsSpecial" or "HasSpecialRole" function to also return "false" if the player has "ROLE_NONE".
This also fixes an issue with the Clairvoyant role.