### PR TITLE
Revival: Add Block Modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ## Unreleased
 
+### Changed
+
+- Change blocking revival mode from `true`/`false` to
+  - `REVIVAL_BLOCK_NONE`: don't block the winning condition during the revival process [default, previously `nil`/`false`]
+  - `REVIVAL_BLOCK_COUNT_AS_ALIVE`: only block the winning condition, if the player being alive would change the outcome [previously `true`]
+  - `REVIVAL_BLOCK_UNTIL_ALIVE`: block the winning condition until the revival process is ended
+  - the old arguments still work, they are automaticvally converted
+
 ## [v0.10.3b](https://github.com/TTT-2/TTT2/tree/v0.10.3b) (2021-10-29)
 
 ### Fixed

--- a/gamemodes/terrortown/gamemode/client/cl_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_player_ext.lua
@@ -246,8 +246,8 @@ net.Receive("TTT2RevivalUpdate_IsReviving", function()
 	LocalPlayer().isReviving = net.ReadBool()
 end)
 
-net.Receive("TTT2RevivalUpdate_IsBlockingRevival", function()
-	LocalPlayer().isBlockingRevival = net.ReadBool()
+net.Receive("TTT2RevivalUpdate_RevivalBlockMode", function()
+	LocalPlayer().revivalBlockMode = net.ReadReadUInt(2)
 end)
 
 net.Receive("TTT2RevivalUpdate_RevivalStartTime", function()

--- a/gamemodes/terrortown/gamemode/client/cl_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_player_ext.lua
@@ -247,7 +247,7 @@ net.Receive("TTT2RevivalUpdate_IsReviving", function()
 end)
 
 net.Receive("TTT2RevivalUpdate_RevivalBlockMode", function()
-	LocalPlayer().revivalBlockMode = net.ReadReadUInt(2)
+	LocalPlayer().revivalBlockMode = net.ReadUInt(REVIVAL_BITS)
 end)
 
 net.Receive("TTT2RevivalUpdate_RevivalStartTime", function()

--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -1487,6 +1487,8 @@ end
 ---
 -- Can be used to modify the table of teams with alive players. This hook is
 -- used in the default win condition.
+-- @note A dead player that is revived is counted as alive as well if the revival mode
+-- ist set to blocking mode.
 -- @param table alives The table of teams which have at least one player still alive
 -- @hook
 -- @realm server
@@ -1535,34 +1537,39 @@ function GM:TTTCheckForWin()
 	end
 
 	if self.MapWin ~= WIN_NONE then -- a role wins
-		local mw = self.MapWin
+		local mapWin = self.MapWin
 
 		self.MapWin = WIN_NONE
 
-		return mw
+		return mapWin
 	end
 
-	local alive = {}
+	local aliveTeams = {}
 	local plys = player.GetAll()
 
 	for i = 1, #plys do
-		local v = plys[i]
-		local tm = v:GetTeam()
+		local ply = plys[i]
+		local team = ply:GetTeam()
 
-		if (v:IsTerror() or v:IsBlockingRevival()) and not v:GetSubRoleData().preventWin and tm ~= TEAM_NONE then
-			alive[#alive + 1] = tm
+		if (ply:IsTerror() or ply:IsBlockingRevival()) and not ply:GetSubRoleData().preventWin and team ~= TEAM_NONE then
+			aliveTeams[#aliveTeams + 1] = team
+		end
+
+		-- special case: The revival blocks the round end
+		if ply:GetRevivalBlockMode() == REVIVAL_BLOCK_UNTIL_ALIVE then
+			return WIN_NONE
 		end
 	end
 
 	---
 	-- @realm server
-	hook.Run("TTT2ModifyWinningAlives", alive)
+	hook.Run("TTT2ModifyWinningAlives", aliveTeams)
 
 	local checkedTeams = {}
 	local b = 0
 
-	for i = 1, #alive do
-		local team = alive[i]
+	for i = 1, #aliveTeams do
+		local team = aliveTeams[i]
 
 		if team == TEAM_NONE then continue end
 
@@ -1581,7 +1588,7 @@ function GM:TTTCheckForWin()
 	if b > 1 then -- if >= 2 teams alive: no one wins
 		return WIN_NONE -- early out
 	elseif b == 1 then -- just 1 team is alive
-		return alive[1]
+		return aliveTeams[1]
 	else -- rare case: nobody is alive, e.g. because of an explosion
 		return TEAM_NONE -- none_win
 	end

--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -22,7 +22,7 @@ util.AddNetworkString("TTT2SetPlayerReady")
 util.AddNetworkString("TTT2SetRevivalReason")
 util.AddNetworkString("TTT2RevivalStopped")
 util.AddNetworkString("TTT2RevivalUpdate_IsReviving")
-util.AddNetworkString("TTT2RevivalUpdate_IsBlockingRevival")
+util.AddNetworkString("TTT2RevivalUpdate_RevivalBlockMode")
 util.AddNetworkString("TTT2RevivalUpdate_RevivalStartTime")
 util.AddNetworkString("TTT2RevivalUpdate_RevivalDuration")
 
@@ -806,7 +806,7 @@ end
 -- @param[opt] function OnRevive The @{function} that should be run if the @{Player} revives
 -- @param[opt] function DoCheck An additional checking @{function}
 -- @param[default=false] boolean needsCorpse Whether the dead @{Player} @{CORPSE} is needed
--- @param[default=false] boolean blockRound Stops the round from ending if this is set to true until the player is alive again
+-- @param[default=REVIVAL_BLOCK_NONE] number blockRound Stops the round from ending if this is set to someting other than 0
 -- @param[opt] function OnFail This @{function} is called if the revive fails
 -- @param[opt] Vector spawnPos The position where the player should be spawned, accounts for minor obstacles
 -- @param[opt] Angle spawnEyeAngle The eye angles of the revived players
@@ -818,8 +818,20 @@ function plymeta:Revive(delay, OnRevive, DoCheck, needsCorpse, blockRound, OnFai
 
 	delay = delay or 3
 
+	-- compatible mode for block round
+	if isbool(blockRound) then
+		MsgN("[DEPRECATION WARNING]: You should use the REVIVAL_BLOCK enum here.")
+		debug.Trace()
+	end
+
+	if blockRound == nil or blockRound == false then
+		blockRound = REVIVAL_BLOCK_NONE
+	elseif blockRound == true then
+		blockRound = REVIVAL_BLOCK_COUNT_AS_ALIVE
+	end
+
 	self:SetReviving(true)
-	self:SetBlockingRevival(blockRound)
+	self:SetRevivalBlockMode(blockRound)
 	self:SetRevivalStartTime(CurTime())
 	self:SetRevivalDuration(delay)
 
@@ -829,7 +841,7 @@ function plymeta:Revive(delay, OnRevive, DoCheck, needsCorpse, blockRound, OnFai
 		if not IsValid(self) then return end
 
 		self:SetReviving(false)
-		self:SetBlockingRevival(false)
+		self:SetRevivalBlockMode(REVIVAL_BLOCK_NONE)
 		self:SendRevivalReason(nil)
 
 		if not isfunction(DoCheck) or DoCheck(self) then
@@ -903,7 +915,7 @@ function plymeta:CancelRevival(failMessage, silent)
 	if not self:IsReviving() then return end
 
 	self:SetReviving(false)
-	self:SetBlockingRevival(false)
+	self:SetRevivalBlockMode(REVIVAL_BLOCK_NONE)
 	self:SendRevivalReason(nil)
 
 	timer.Remove("TTT2RevivePlayer" .. self:EntIndex())
@@ -933,18 +945,18 @@ end
 
 ---
 -- Sets the blocking revival state.
--- @param[default=false] boolean isBlockingRevival The blocking revival state
+-- @param[default=REVIVAL_BLOCK_NONE] number revivalBlockMode The blocking revival state
 -- @internal
 -- @realm server
-function plymeta:SetBlockingRevival(isBlockingRevival)
-	isBlockingRevival = isBlockingRevival or false
+function plymeta:SetRevivalBlockMode(revivalBlockMode)
+	revivalBlockMode = revivalBlockMode or REVIVAL_BLOCK_NONE
 
-	if self.isBlockingRevival == isBlockingRevival then return end
+	if self.revivalBlockMode == revivalBlockMode then return end
 
-	self.isBlockingRevival = isBlockingRevival
+	self.revivalBlockMode = revivalBlockMode
 
-	net.Start("TTT2RevivalUpdate_IsBlockingRevival")
-	net.WriteBool(self.isBlockingRevival)
+	net.Start("TTT2RevivalUpdate_RevivalBlockMode")
+	net.WriteUInt(self.revivalBlockMode, 2)
 	net.Send(self)
 end
 

--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -956,7 +956,7 @@ function plymeta:SetRevivalBlockMode(revivalBlockMode)
 	self.revivalBlockMode = revivalBlockMode
 
 	net.Start("TTT2RevivalUpdate_RevivalBlockMode")
-	net.WriteUInt(self.revivalBlockMode, 2)
+	net.WriteUInt(self.revivalBlockMode, REVIVAL_BITS)
 	net.Send(self)
 end
 

--- a/gamemodes/terrortown/gamemode/shared/sh_init.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_init.lua
@@ -126,6 +126,8 @@ REVIVAL_BLOCK_COUNT_AS_ALIVE = 1
 -- block the winning condition until the revival process is ended
 REVIVAL_BLOCK_UNTIL_ALIVE = 2
 
+REVIVAL_BITS = 2
+
 -- if you add roles that can shop, modify DefaultEquipment at the end of this file
 
 -- just compatibality functions

--- a/gamemodes/terrortown/gamemode/shared/sh_init.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_init.lua
@@ -119,6 +119,13 @@ ACTIVEROLES = ACTIVEROLES or {}
 SHOP_DISABLED = "DISABLED"
 SHOP_UNSET = "UNSET"
 
+-- don't block the winning condition during the revival process
+REVIVAL_BLOCK_NONE = 0
+-- only block the winning condition, if the player being alive would change the outcome
+REVIVAL_BLOCK_COUNT_AS_ALIVE = 1
+-- block the winning condition until the revival process is ended
+REVIVAL_BLOCK_UNTIL_ALIVE = 2
+
 -- if you add roles that can shop, modify DefaultEquipment at the end of this file
 
 -- just compatibality functions

--- a/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
@@ -1048,7 +1048,15 @@ end
 -- @return boolean The blocking status
 -- @realm shared
 function plymeta:IsBlockingRevival()
-	return self.isBlockingRevival or false
+	return self.revivalBlockMode and self.revivalBlockMode > REVIVAL_BLOCK_NONE
+end
+
+---
+-- Returns the blocking mode of the ongoing revival.
+-- @return number The blocking mode
+-- @realm shared
+function plymeta:GetRevivalBlockMode()
+	return self.revivalBlockMode or REVIVAL_BLOCK_NONE
 end
 
 ---


### PR DESCRIPTION
Change blocking revival mode from `true`/`false` to
  - `REVIVAL_BLOCK_NONE`: don't block the winning condition during the revival process [default, previously `nil`/`false`]
  - `REVIVAL_BLOCK_COUNT_AS_ALIVE`: only block the winning condition, if the player being alive would change the outcome [previously `true`]
  - `REVIVAL_BLOCK_UNTIL_ALIVE`: block the winning condition until the revival process is ended
  - the old arguments still work, they are automaticvally converted