### PR TITLE
Role Enhancement: Called Policing Role Hook and Added Docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 - Fixed that every policing player could be called to a corpse, this is now again restricted to alive only players
 - Fixed inconsistency between `.disabledTeamChatRecv` and `.disabledTeamChatRec`
-- Fixed non-public policing roles havin hats and therefore confirming them
+- Fixed non-public policing roles having hats and therefore confirming them
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ## Unreleased
 
+### Added
+
+- Added the hook `GM:TTT2CalledPolicingRole` that is called after all policing role players were called to a corpse
+
+### Fixed
+
+- Fixed that every policing player could be called to a corpse, this is now again restricted to alive only players
+- Fixed inconsistency between `.disabledTeamChatRecv` and ``.disabledTeamChatRec`
+- Fixed non-public policing roles havin hats and therefore confirming them
+
+### Changed
+
+- All public policing roles now appear as detectives in the chat
+
 ## [v0.10.3b](https://github.com/TTT-2/TTT2/tree/v0.10.3b) (2021-10-29)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ### Fixed
 
 - Fixed that every policing player could be called to a corpse, this is now again restricted to alive only players
-- Fixed inconsistency between `.disabledTeamChatRecv` and ``.disabledTeamChatRec`
+- Fixed inconsistency between `.disabledTeamChatRecv` and `.disabledTeamChatRec`
 - Fixed non-public policing roles havin hats and therefore confirming them
 
 ### Changed

--- a/gamemodes/terrortown/gamemode/client/cl_chat.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_chat.lua
@@ -113,7 +113,14 @@ function GM:OnPlayerChat(ply, text, teamChat, isDead)
 		return BaseClass.OnPlayerChat(self, ply, text, teamChat, isDead)
 	end
 
-	if ply:IsActiveRole(ROLE_DETECTIVE) then
+	local plyRoleData = ply:GetSubRoleData()
+
+	-- send detective-like message if role is public policing role
+	-- note: while it seems like is not nessecary to check if the role is public because
+	-- only a public role is synced, this is still checked here to make sure it works
+	-- well with revivals. A non-public role won't be counted as public policing role
+	-- if they were revived and their role is known.
+	if ply:IsActive() and plyRoleData.isPolicingRole and plyRoleData.isPublicRole then
 		AddDetectiveText(ply, text)
 
 		return true

--- a/gamemodes/terrortown/gamemode/server/sv_corpse.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_corpse.lua
@@ -235,7 +235,7 @@ local function ttt_call_detective(ply, cmd, args)
 	if IsValid(rag) and rag:GetPos():Distance(ply:GetPos()) < 128 then
 		if CORPSE.GetFound(rag, false) then
 			local plyTable = util.GetFilteredPlayers(function(p)
-				return p:GetSubRoleData().isPolicingRole
+				return p:GetSubRoleData().isPolicingRole and p:IsTerror()
 			end)
 
 			---
@@ -248,6 +248,10 @@ local function ttt_call_detective(ply, cmd, args)
 			net.Send(plyTable)
 
 			LANG.MsgAll("body_call", {player = ply:Nick(), victim = CORPSE.GetPlayerNick(rag, "someone")}, MSG_CHAT_PLAIN)
+
+			---
+			-- @realm server
+			hook.Run("TTT2CalledPolicingRole", plyTable, ply, rag, CORPSE.GetPlayer(rag))
 		else
 			LANG.Msg(ply, "body_call_error")
 		end
@@ -690,6 +694,20 @@ hook.Add("ShouldCollide", "TTT2RagdollCollide", function(ent1, ent2)
 end)
 
 ---
+-- This hook is called after the policing players were called to a ragdoll.
+-- @note If you want to modify the called players, use the
+-- @{GM:TTT2ModifyCorpseCallRadarRecipients} hook.
+-- @param table policingPlys An indexed table of the players that are called to the corpse
+-- @param Player finder The player that called the policing players
+-- @param Entity ragdoll The body of the dead player
+-- @param Player deadply The dead player
+-- @hook.
+-- @realm server
+function GM:TTT2CalledPolicingRole(policingPlys, finder, ragdoll, deadply)
+
+end
+
+---
 -- Checks whether a @{Player} is able to identify a @{CORPSE}.
 -- @note removed boolean "was_traitor". Team is available with `corpse.was_team`
 -- @param Player ply The player that tries to identify the corpse
@@ -759,7 +777,7 @@ end
 -- Checks whether a @{Player} is able to search a @{CORPSE} based on their position.
 -- The search opens a popup for the searching player with all of the player information.
 -- @note removed last param is_traitor -> accessable with `corpse.was_team`
--- @param Player ply The player that tries to 
+-- @param Player ply The player that tries to
 -- @param Entity rag The ragdoll tgat should be searched
 -- @param boolean isCovert Is the search hidden
 -- @param boolean isLongRange Is the search performed from a long range

--- a/gamemodes/terrortown/gamemode/server/sv_corpse.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_corpse.lua
@@ -701,7 +701,7 @@ end)
 -- @param Player finder The player that called the policing players
 -- @param Entity ragdoll The body of the dead player
 -- @param Player deadply The dead player
--- @hook.
+-- @hook
 -- @realm server
 function GM:TTT2CalledPolicingRole(policingPlys, finder, ragdoll, deadply)
 

--- a/gamemodes/terrortown/gamemode/server/sv_corpse.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_corpse.lua
@@ -777,8 +777,8 @@ end
 -- Checks whether a @{Player} is able to search a @{CORPSE} based on their position.
 -- The search opens a popup for the searching player with all of the player information.
 -- @note removed last param is_traitor -> accessable with `corpse.was_team`
--- @param Player ply The player that tries to
--- @param Entity rag The ragdoll tgat should be searched
+-- @param Player ply The player that tries to search the corpse
+-- @param Entity rag The ragdoll that should be searched
 -- @param boolean isCovert Is the search hidden
 -- @param boolean isLongRange Is the search performed from a long range
 -- @return[default=true] boolean Return false to block search

--- a/gamemodes/terrortown/gamemode/server/sv_gamemsg.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_gamemsg.lua
@@ -76,22 +76,22 @@ end
 
 -- Teamchat
 local function RoleChatMsg(sender, msg)
-	local senderIsSpectator = sender:GetTeam()
+	local senderTeam = sender:GetTeam()
 	local senderRoleData = sender:GetSubRoleData()
 
-	if senderIsSpectator == TEAM_NONE
+	if senderTeam == TEAM_NONE
 		or senderRoleData.unknownTeam
 		or senderRoleData.disabledTeamChat
-		or TEAMS[senderIsSpectator].alone
+		or TEAMS[senderTeam].alone
 		---
 		-- @realm server
-		or hook.Run("TTT2AvoidTeamChat", sender, senderIsSpectator, msg) == false
+		or hook.Run("TTT2AvoidTeamChat", sender, senderTeam, msg) == false
 	then return end
 
 	net.Start("TTT_RoleChat")
 	net.WriteEntity(sender)
 	net.WriteString(msg)
-	net.Send(GetTeamChatFilter(senderIsSpectator))
+	net.Send(GetTeamChatFilter(senderTeam))
 end
 
 ---

--- a/gamemodes/terrortown/gamemode/server/sv_gamemsg.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_gamemsg.lua
@@ -133,33 +133,33 @@ end
 ---
 -- Returns a list of filtered @{Player}s by the team.
 -- @param string team
--- @param boolean alive_only
+-- @param boolean aliveOnly
 -- @return table
 -- @realm server
-function GetTeamFilter(team, alive_only)
+function GetTeamFilter(team, aliveOnly)
 	return GetPlayerFilter(function(p)
-		return team ~= TEAM_NONE and not TEAMS[team].alone and p:GetTeam() == team and not p:GetSubRoleData().unknownTeam and (not alive_only or p:IsTerror())
+		return team ~= TEAM_NONE and not TEAMS[team].alone and p:GetTeam() == team and not p:GetSubRoleData().unknownTeam and (not aliveOnly or p:IsTerror())
 	end)
 end
 
 ---
 -- Returns a list of all @{Players} of the Innocent team.
--- @param boolean alive_only
+-- @param boolean aliveOnly
 -- @return table
 -- @realm server
 -- @see GetTeamFilter
-function GetInnocentFilter(alive_only)
-	return GetTeamFilter(TEAM_INNOCENT, alive_only)
+function GetInnocentFilter(aliveOnly)
+	return GetTeamFilter(TEAM_INNOCENT, aliveOnly)
 end
 
 ---
 -- Returns a list of all @{Players} of the Traitor team.
--- @param boolean alive_only
+-- @param boolean aliveOnly
 -- @return table
 -- @realm server
 -- @see GetTeamFilter
-function GetTraitorFilter(alive_only)
-	return GetTeamFilter(TEAM_TRAITOR, alive_only)
+function GetTraitorFilter(aliveOnly)
+	return GetTeamFilter(TEAM_TRAITOR, aliveOnly)
 end
 
 ---
@@ -167,45 +167,45 @@ end
 -- @note If a BaseRole is given, this will return true for all its SubRoles.
 -- If you just want to filter for a specific SubRole, use @{GetSubRoleFilter} instead
 -- @param number subrole
--- @param boolean alive_only
+-- @param boolean aliveOnly
 -- @return table
 -- @realm server
 -- @see Player:IsRole
-function GetRoleFilter(subrole, alive_only)
+function GetRoleFilter(subrole, aliveOnly)
 	return GetPlayerFilter(function(p)
-		return p:IsRole(subrole) and (not alive_only or p:IsTerror())
+		return p:IsRole(subrole) and (not aliveOnly or p:IsTerror())
 	end)
 end
 
 ---
 -- Returns a list of filtered @{Player}s by the @{ROLE}'s SubRole index.
 -- @param number subrole
--- @param boolean alive_only
+-- @param boolean aliveOnly
 -- @return table
 -- @realm server
-function GetSubRoleFilter(subrole, alive_only)
+function GetSubRoleFilter(subrole, aliveOnly)
 	return GetPlayerFilter(function(p)
-		return p:GetSubRole() == subrole and (not alive_only or p:IsTerror())
+		return p:GetSubRole() == subrole and (not aliveOnly or p:IsTerror())
 	end)
 end
 
 ---
 -- Returns a list of all @{Players} of the Detective @{ROLE}'s index.
--- @param boolean alive_only
+-- @param boolean aliveOnly
 -- @return table
 -- @realm server
 -- @see GetRoleFilter
-function GetDetectiveFilter(alive_only)
-	return GetRoleFilter(ROLE_DETECTIVE, alive_only)
+function GetDetectiveFilter(aliveOnly)
+	return GetRoleFilter(ROLE_DETECTIVE, aliveOnly)
 end
 
 ---
 -- Returns a list of all @{Players} of a specific @{ROLE}'s index that are able to chat.
 -- @param number subrole
--- @param boolean alive_only
+-- @param boolean aliveOnly
 -- @return table
 -- @realm server
-function GetRoleChatFilter(subrole, alive_only)
+function GetRoleChatFilter(subrole, aliveOnly)
 	if roles.GetByIndex(subrole).disabledTeamChat then
 		return {}
 	end
@@ -213,17 +213,17 @@ function GetRoleChatFilter(subrole, alive_only)
 	return GetPlayerFilter(function(p)
 		return p:IsRole(subrole)
 			and not p:GetSubRoleData().v
-			and (not alive_only or p:IsTerror())
+			and (not aliveOnly or p:IsTerror())
 	end)
 end
 
 ---
 -- Returns a list of all @{Players} of a specific team that are able to chat.
 -- @param string team
--- @param boolean alive_only
+-- @param boolean aliveOnly
 -- @return table
 -- @realm server
-function GetTeamChatFilter(team, alive_only)
+function GetTeamChatFilter(team, aliveOnly)
 	return GetPlayerFilter(function(ply)
 		local plyRoleData = ply:GetSubRoleData()
 
@@ -232,7 +232,7 @@ function GetTeamChatFilter(team, alive_only)
 			and ply:GetTeam() == team
 			and not plyRoleData.unknownTeam
 			and not plyRoleData.disabledTeamChatRecv
-			and (not alive_only or ply:IsTerror())
+			and (not aliveOnly or ply:IsTerror())
 	end)
 end
 
@@ -240,12 +240,12 @@ end
 -- Returns a list of filtered @{Player}s.
 -- This filters the team members of a given @{Player}
 -- @param Player ply
--- @param boolean alive_only
+-- @param boolean aliveOnly
 -- @return table
 -- @realm server
-function GetTeamMemberFilter(ply, alive_only)
+function GetTeamMemberFilter(ply, aliveOnly)
 	return GetPlayerFilter(function(p)
-		return p:IsInTeam(ply) and (not alive_only or p:IsTerror())
+		return p:IsInTeam(ply) and (not aliveOnly or p:IsTerror())
 	end)
 end
 
@@ -527,11 +527,11 @@ end
 -- Whether or not the @{Player} can receive the chat message.
 -- @param Player reader The @{Player} who can receive chat
 -- @param Player sender The @{Player} who sends the text message
--- @param boolean isenderIsSpectator Are they trying to use the team chat
+-- @param boolean isTeam Are they trying to use the team chat
 -- @return[default=true] boolean Return true if the reader should be able to see the message of the sender, false if they shouldn't
 -- @hook
 -- @realm server
-function GM:TTT2CanSeeChat(reader, sender, isenderIsSpectator)
+function GM:TTT2CanSeeChat(reader, sender, isTeam)
 	return true
 end
 

--- a/gamemodes/terrortown/gamemode/server/sv_gamemsg.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_gamemsg.lua
@@ -212,7 +212,7 @@ function GetRoleChatFilter(subrole, aliveOnly)
 
 	return GetPlayerFilter(function(p)
 		return p:IsRole(subrole)
-			and not p:GetSubRoleData().v
+			and not p:GetSubRoleData().disabledTeamChatRecv
 			and (not aliveOnly or p:IsTerror())
 	end)
 end

--- a/gamemodes/terrortown/gamemode/server/sv_networking.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_networking.lua
@@ -223,7 +223,7 @@ function SendFullStateUpdate()
 			if not roleDataSyncTo.unknownTeam and teamSyncFrom == teamSyncTo
 				or plySyncFrom:RoleKnown() -- TODO rework
 				or table.HasValue(roleDataSyncFrom.visibleForTeam, teamSyncTo)
-				or roleDataSyncTo.networkRoles and table.HasValue(roleDataSyncTo.networkRoles, roleDataSyncFrom)
+				or table.HasValue(roleDataSyncTo.networkRoles, roleDataSyncFrom)
 				or roleDataSyncFrom.isPublicRole
 				or plySyncTo == plySyncFrom
 			then
@@ -317,7 +317,7 @@ local function ttt_request_rolelist(plySyncTo)
 			if not roleDataSyncTo.unknownTeam and plySyncFrom:GetTeam() == team
 				or plySyncFrom:RoleKnown() -- TODO rework
 				or table.HasValue(roleDataSyncFrom.visibleForTeam, plySyncTo:GetTeam())
-				or roleDataSyncTo.networkRoles and table.HasValue(roleDataSyncTo.networkRoles, roleDataSyncFrom)
+				or table.HasValue(roleDataSyncTo.networkRoles, roleDataSyncFrom)
 				or roleDataSyncFrom.isPublicRole
 				or plySyncTo == plySyncFrom
 			then

--- a/gamemodes/terrortown/gamemode/server/sv_weaponry.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_weaponry.lua
@@ -413,8 +413,13 @@ function GM:PlayerLoadout(ply, isRespawn)
 
 	playermodels.RemovePlayerHat(ply)
 	playermodels.ApplyPlayerHat(ply, function(p)
-		return ply:IsActive() and ply:GetSubRoleData().isPolicingRole
-			and cv_ttt_detective_hats:GetBool() and playermodels.PlayerCanHaveHat(ply)
+		local plyRoleData = ply:GetSubRoleData()
+
+		return ply:IsActive()
+			and plyRoleData.isPolicingRole
+			and plyRoleData.isPublicRole
+			and cv_ttt_detective_hats:GetBool()
+			and playermodels.PlayerCanHaveHat(ply)
 	end)
 
 	if not HasLoadoutWeapons(ply) then

--- a/lua/terrortown/entities/roles/ttt_role_base/shared.lua
+++ b/lua/terrortown/entities/roles/ttt_role_base/shared.lua
@@ -84,15 +84,19 @@ ROLE.conVarData = {
 -- selection process.
 ROLE.notSelectable = false
 
--- This variable can be used to add roles that can see the role of the
+-- This variable can be used to add teams that can see the role of the
 -- player with the role defined in this file. While this table can be updated
 -- on runtime, it is strongly advised against. Use custom hook based
 -- syncing for specific syncing.
 ROLE.visibleForTeam = {}
 
+-- This variable can be used to add roles that can can be seen by the role
+-- defined in this file.
+ROLE.networkRoles = {}
+
 -- If set to true, this role doesn't know about their teammates. A normal innocent
 -- for example knows that they are in team innocent, but doesn't know who else is.
--- If set to false, this player knows about the role of all their teamm ates.
+-- If set to false, this player knows about the role of all their team mates.
 ROLE.unknownTeam = false
 
 -- This can be used to force prevent picking up credits from corpses. Keep in mind
@@ -120,6 +124,17 @@ ROLE.isPublicRole = false
 -- A policing role is a role that works like a detective. They can be called to
 -- a corpse and evil roles can be rewarded more points for them being killed.
 ROLE.isPolicingRole = false
+
+-- If this is set to true, the role is unable to send messages in the team chat. If this is
+-- set to false, it still could mean that the player is unable to use the team chat. If the
+-- role flag `.unknownTeam` is set, the team chat can't be used either.
+ROLE.disabledTeamChat = false
+
+-- If this is set to true, the geiven role is unable to receive team chat messages.
+ROLE.disabledTeamChatRecv = false
+
+-- By setting this to true, the role is unable to write in the general chat.
+ROLE.disabledGeneralChat = false
 
 ---
 -- This function is called before initializing a @{ROLE}, but after all


### PR DESCRIPTION
- all public policing roles now appear as detectives in the chat
- fixed that every policing player could be called to a corpse, this is now again restricted to alive only players
- added the hook `GM:TTT2CalledPolicingRole` that is called after all policing role players were called to a corpse
- fixed inconsistency between `.disabledTeamChatRecv` and `.disabledTeamChatRec`
- fixed non-public policing roles having hats and therefore confirming them
- small cole and docs cleanup