### PR TITLE
Weapon Spawn: Fix late random weapon spawns on maps like kakariko

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed that every policing player could be called to a corpse, this is now again restricted to alive only players
 - Fixed inconsistency between `.disabledTeamChatRecv` and `.disabledTeamChatRec`
 - Fixed non-public policing roles having hats and therefore confirming them
+- Fixed triggered spawns on Maps like 'ttt_lttp_kakariko_a5' with the vases and 'ttt_mc_jondome' with the chests
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed that every policing player could be called to a corpse, this is now again restricted to alive only players
 - Fixed inconsistency between `.disabledTeamChatRecv` and `.disabledTeamChatRec`
 - Fixed non-public policing roles having hats and therefore confirming them
-- Fixed triggered spawns on Maps like 'ttt_lttp_kakariko_a5' with the vases and 'ttt_mc_jondome' with the chests
+- Fixed triggered spawns on maps like 'ttt_lttp_kakariko_a5' with the vases and 'ttt_mc_jondome' with the chests
 
 ### Changed
 

--- a/gamemodes/terrortown/entities/entities/ttt_random_ammo.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_random_ammo.lua
@@ -5,3 +5,9 @@
 
 ENT.Type = "point"
 ENT.Base = "base_point"
+
+function ENT:Initialize()
+	if entspawn.IsDirectRandomSpawnEnabled() then
+		entspawn.SpawnRandomAmmo(self)
+	end
+end

--- a/gamemodes/terrortown/entities/entities/ttt_random_ammo.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_random_ammo.lua
@@ -6,8 +6,12 @@
 ENT.Type = "point"
 ENT.Base = "base_point"
 
+---
+-- @note Only used to forceSpawn ammo after map cleanup 
+-- otherwise these entities are only used to mark the spots for random ammo spawns
+-- @realm shared
 function ENT:Initialize()
-	if entspawn.IsDirectRandomSpawnEnabled() then
+	if entspawn.IsForcedRandomSpawnEnabled() then
 		entspawn.SpawnRandomAmmo(self)
 	end
 end

--- a/gamemodes/terrortown/entities/entities/ttt_random_weapon.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_random_weapon.lua
@@ -17,3 +17,9 @@ function ENT:KeyValue(key, value)
 		self.autoAmmoAmount = tonumber(value)
 	end
 end
+
+function ENT:Initialize()
+	if entspawn.IsDirectRandomSpawnEnabled() then
+		entspawn.SpawnRandomWeapon(self)
+	end
+end

--- a/gamemodes/terrortown/entities/entities/ttt_random_weapon.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_random_weapon.lua
@@ -18,8 +18,12 @@ function ENT:KeyValue(key, value)
 	end
 end
 
+---
+-- @note Only used to forceSpawn weapons after map cleanup 
+-- otherwise these entities are only used to mark the spots for random weapon spawns
+-- @realm shared
 function ENT:Initialize()
-	if entspawn.IsDirectRandomSpawnEnabled() then
+	if entspawn.IsForcedRandomSpawnEnabled() then
 		entspawn.SpawnRandomWeapon(self)
 	end
 end

--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -886,7 +886,7 @@ function GM:PreCleanupMap()
 	entityOutputs.CleanUp()
 
 	-- While cleaning up the map, disable random weapons directly spawning
-	entspawn.EnableDirectRandomSpawn(false)
+	entspawn.EnableForcedRandomSpawn(false)
 end
 
 ---
@@ -905,7 +905,7 @@ function GM:PostCleanupMap()
 	-- After map cleanup enable 'env_entity_maker'-entities to force spawn random weapons and ammo
 	-- This is necessary for maps like 'ttt_lttp_kakariko_a5', that only initialize 'ttt_random_weapon'-entities
 	-- after destroying vases and were therefore not affected by our entspawn-system
-	entspawn.EnableDirectRandomSpawn(true)
+	entspawn.EnableForcedRandomSpawn(true)
 	---
 	-- @realm server
 	hook.Run("TTT2PostCleanupMap")

--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -884,6 +884,9 @@ function GM:PreCleanupMap()
 	ents.TTT.FixParentedPreCleanup()
 
 	entityOutputs.CleanUp()
+
+	-- While cleaning up the map, disable random weapons directly spawning
+	entspawn.EnableDirectRandomSpawn(false)
 end
 
 ---
@@ -898,6 +901,11 @@ function GM:PostCleanupMap()
 	entityOutputs.SetUp()
 
 	entspawn.HandleSpawns()
+
+	-- After map cleanup enable 'env_entity_maker'-entities to force spawn random weapons and ammo
+	-- This is necessary for maps like 'ttt_lttp_kakariko_a5', that only initialize 'ttt_random_weapon'-entities
+	-- after destroying vases and were therefore not affected by our entspawn-system
+	entspawn.EnableDirectRandomSpawn(true)
 	---
 	-- @realm server
 	hook.Run("TTT2PostCleanupMap")

--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -886,7 +886,7 @@ function GM:PreCleanupMap()
 	entityOutputs.CleanUp()
 
 	-- While cleaning up the map, disable random weapons directly spawning
-	entspawn.EnableForcedRandomSpawn(false)
+	entspawn.SetForcedRandomSpawn(false)
 end
 
 ---
@@ -905,7 +905,7 @@ function GM:PostCleanupMap()
 	-- After map cleanup enable 'env_entity_maker'-entities to force spawn random weapons and ammo
 	-- This is necessary for maps like 'ttt_lttp_kakariko_a5', that only initialize 'ttt_random_weapon'-entities
 	-- after destroying vases and were therefore not affected by our entspawn-system
-	entspawn.EnableForcedRandomSpawn(true)
+	entspawn.SetForcedRandomSpawn(true)
 	---
 	-- @realm server
 	hook.Run("TTT2PostCleanupMap")

--- a/lua/ttt2/libraries/entspawn.lua
+++ b/lua/ttt2/libraries/entspawn.lua
@@ -17,7 +17,47 @@ local mathMin = math.min
 local timerCreate = timer.Create
 local timerRemove = timer.Remove
 
+local allowDirectRandomSpawn = false
+
 entspawn = entspawn or {}
+
+function entspawn.EnableDirectRandomSpawn(enable)
+	allowDirectRandomSpawn = enable
+end
+
+function entspawn.IsDirectRandomSpawnEnabled()
+	return allowDirectRandomSpawn
+end
+
+function entspawn.SpawnRandomWeapon(ent)
+	local spawns = {
+		[SPAWN_TYPE_WEAPON] = {
+			[1] = {
+				pos = ent:GetPos(),
+				ang = ent:GetAngles(),
+				ammo = ent.autoAmmoAmount or 0
+				}
+			}
+		}
+
+	local wepsForTypes, weps = WEPS.GetWeaponsForSpawnTypes()
+	entspawn.SpawnEntities(spawns, wepsForTypes, weps, WEAPON_TYPE_RANDOM)
+end
+
+function entspawn.SpawnRandomAmmo(ent)
+	local spawns = {
+		[SPAWN_TYPE_AMMO] = {
+			[1] = {
+				pos = ent:GetPos(),
+				ang = ent:GetAngles(),
+				ammo = ent.autoAmmoAmount or 0
+				}
+			}
+		}
+
+	local ammoForTypes, ammo = WEPS.GetAmmoForSpawnTypes()
+	entspawn.SpawnEntities(spawns, ammoForTypes, ammo, AMMO_TYPE_RANDOM)
+end
 
 local function RemoveEntities(entTable, spawnTable, spawnType)
 	local useDefaultSpawns = not entspawnscript.ShouldUseCustomSpawns()

--- a/lua/ttt2/libraries/entspawn.lua
+++ b/lua/ttt2/libraries/entspawn.lua
@@ -25,7 +25,7 @@ entspawn = entspawn or {}
 -- Enable or disable forced random spawns for 'env_entity_maker' spawning non available
 -- random spawns at map start.
 -- @note see: https://developer.valvesoftware.com/wiki/Env_entity_maker
--- @param bool enable The state to set it to
+-- @param bool enable The state to set it to.
 -- @realm server
 function entspawn.SetForcedRandomSpawn(enable)
 	allowForcedRandomSpawn = enable

--- a/lua/ttt2/libraries/entspawn.lua
+++ b/lua/ttt2/libraries/entspawn.lua
@@ -22,8 +22,9 @@ local allowForcedRandomSpawn = false
 entspawn = entspawn or {}
 
 ---
--- Enable or disable forced random spawns for 'env_entity_maker' 'https://developer.valvesoftware.com/wiki/Env_entity_maker'
--- spawning non available random spawns at map start
+-- Enable or disable forced random spawns for 'env_entity_maker' spawning non available
+-- random spawns at map start.
+-- @note see: https://developer.valvesoftware.com/wiki/Env_entity_maker
 -- @param bool enable The state to set it to
 -- @realm server
 function entspawn.SetForcedRandomSpawn(enable)
@@ -31,7 +32,7 @@ function entspawn.SetForcedRandomSpawn(enable)
 end
 
 ---
--- To check if forced random spawns are available
+-- To check if forced random spawns are available.
 -- @return bool if forced random spawns are enabled
 -- @realm server
 function entspawn.IsForcedRandomSpawnEnabled()
@@ -39,7 +40,7 @@ function entspawn.IsForcedRandomSpawnEnabled()
 end
 
 ---
--- Spawns a random weapon with the given data of the random spawn entity
+-- Spawns a random weapon with the given data of the random spawn entity.
 -- @param Entity ent the entity holding the random weapon data
 -- @realm server
 function entspawn.SpawnRandomWeapon(ent)
@@ -58,7 +59,7 @@ function entspawn.SpawnRandomWeapon(ent)
 end
 
 ---
--- Spawns a random ammo box with the given data of the random spawn entity
+-- Spawns a random ammo box with the given data of the random spawn entity.
 -- @param Entity ent the entity holding the random ammo data
 -- @realm server
 function entspawn.SpawnRandomAmmo(ent)

--- a/lua/ttt2/libraries/entspawn.lua
+++ b/lua/ttt2/libraries/entspawn.lua
@@ -26,7 +26,7 @@ entspawn = entspawn or {}
 -- spawning non available random spawns at map start
 -- @param bool enable The state to set it to
 -- @realm server
-function entspawn.EnableForcedRandomSpawn(enable)
+function entspawn.SetForcedRandomSpawn(enable)
 	allowForcedRandomSpawn = enable
 end
 

--- a/lua/ttt2/libraries/entspawn.lua
+++ b/lua/ttt2/libraries/entspawn.lua
@@ -17,18 +17,31 @@ local mathMin = math.min
 local timerCreate = timer.Create
 local timerRemove = timer.Remove
 
-local allowDirectRandomSpawn = false
+local allowForcedRandomSpawn = false
 
 entspawn = entspawn or {}
 
-function entspawn.EnableDirectRandomSpawn(enable)
-	allowDirectRandomSpawn = enable
+---
+-- Enable or disable forced random spawns for 'env_entity_maker' 'https://developer.valvesoftware.com/wiki/Env_entity_maker'
+-- spawning non available random spawns at map start
+-- @param bool enable The state to set it to
+-- @realm server
+function entspawn.EnableForcedRandomSpawn(enable)
+	allowForcedRandomSpawn = enable
 end
 
-function entspawn.IsDirectRandomSpawnEnabled()
-	return allowDirectRandomSpawn
+---
+-- To check if forced random spawns are available
+-- @return bool if forced random spawns are enabled
+-- @realm server
+function entspawn.IsForcedRandomSpawnEnabled()
+	return allowForcedRandomSpawn
 end
 
+---
+-- Spawns a random weapon with the given data of the random spawn entity
+-- @param Entity ent the entity holding the random weapon data
+-- @realm server
 function entspawn.SpawnRandomWeapon(ent)
 	local spawns = {
 		[SPAWN_TYPE_WEAPON] = {
@@ -44,13 +57,17 @@ function entspawn.SpawnRandomWeapon(ent)
 	entspawn.SpawnEntities(spawns, wepsForTypes, weps, WEAPON_TYPE_RANDOM)
 end
 
+---
+-- Spawns a random ammo box with the given data of the random spawn entity
+-- @param Entity ent the entity holding the random ammo data
+-- @realm server
 function entspawn.SpawnRandomAmmo(ent)
 	local spawns = {
 		[SPAWN_TYPE_AMMO] = {
 			[1] = {
 				pos = ent:GetPos(),
 				ang = ent:GetAngles(),
-				ammo = ent.autoAmmoAmount or 0
+				ammo = 1
 				}
 			}
 		}


### PR DESCRIPTION
Maps like
- Kakariko https://steamcommunity.com/sharedfiles/filedetails/?id=118937144
- Mc Jondome https://steamcommunity.com/sharedfiles/filedetails/?id=322655757

have spawns through an env_entity_maker https://developer.valvesoftware.com/wiki/Env_entity_maker, which disables the random spawns entity on map initialization and only activates them when a trigger is activated. 
On Kakariko its destroying the vases, on jondome the using of chests.

As we delete all random spawn entities on mapcleanup and make a manual call to spawn, we removed the spawning of weapons inside the initialization, which made those maps not working correctly.
Now we set a boolean after the cleanup and allow those later appearing instances to spawn weapons again, but still going over spawn type system.