### PR TITLE
Roleselection: Fix available baseroles calculation by considering maxPlys when filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed inconsistency between `.disabledTeamChatRecv` and `.disabledTeamChatRec`
 - Fixed non-public policing roles having hats and therefore confirming them
 - Fixed triggered spawns on maps like 'ttt_lttp_kakariko_a5' with the vases and 'ttt_mc_jondome' with the chests
+- Fixed roleselection layering with base roles to ensure layer order is considered correctly when selecting roles
 
 ### Changed
 

--- a/gamemodes/terrortown/gamemode/server/sv_roleselection.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_roleselection.lua
@@ -409,7 +409,14 @@ function roleselection.GetSelectableRolesList(maxPlys, rolesAmountList)
 
 	-- first of all, we need to select the baseroles. Otherwise, we would select subroles that never gonna be choosen because if the missing baserole
 	for i = 1, availableBaseRolesAmount do
-		if currentlyAvailableRolesAmount >= maxPlys or maxRoles and maxRoles <= curRoles or maxBaseroles and maxBaseroles <= curBaseroles or #availableBaseRolesTbl < 1 then break end -- if the limit is reached or no available roles left (could happen if removing available roles that weren't already selected in layered "or"-tables), stop selection
+		-- if the limit is reached or no available roles left (could happen if removing available roles that weren't already selected in layered "or"-tables), stop selection
+		if currentlyAvailableRolesAmount >= maxPlys
+		    or maxRoles and maxRoles <= curRoles
+			or maxBaseroles and maxBaseroles <= curBaseroles
+			or #availableBaseRolesTbl < 1
+		then
+			break
+		end
 
 		-- the selected role
 		local subrole = nil

--- a/gamemodes/terrortown/gamemode/server/sv_roleselection.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_roleselection.lua
@@ -411,7 +411,7 @@ function roleselection.GetSelectableRolesList(maxPlys, rolesAmountList)
 	for i = 1, availableBaseRolesAmount do
 		-- if the limit is reached or no available roles left (could happen if removing available roles that weren't already selected in layered "or"-tables), stop selection
 		if currentlyAvailableRolesAmount >= maxPlys
-		    or maxRoles and maxRoles <= curRoles
+	    	or maxRoles and maxRoles <= curRoles
 			or maxBaseroles and maxBaseroles <= curBaseroles
 			or #availableBaseRolesTbl < 1
 		then

--- a/gamemodes/terrortown/gamemode/server/sv_roleselection.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_roleselection.lua
@@ -411,7 +411,7 @@ function roleselection.GetSelectableRolesList(maxPlys, rolesAmountList)
 	for i = 1, availableBaseRolesAmount do
 		-- if the limit is reached or no available roles left (could happen if removing available roles that weren't already selected in layered "or"-tables), stop selection
 		if currentlyAvailableRolesAmount >= maxPlys
-	    	or maxRoles and maxRoles <= curRoles
+			or maxRoles and maxRoles <= curRoles
 			or maxBaseroles and maxBaseroles <= curBaseroles
 			or #availableBaseRolesTbl < 1
 		then

--- a/gamemodes/terrortown/gamemode/server/sv_roleselection.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_roleselection.lua
@@ -405,9 +405,11 @@ function roleselection.GetSelectableRolesList(maxPlys, rolesAmountList)
 		ROLE_INNOCENT
 	}
 
+	local currentlyAvailableRolesAmount = rolesAmountList[ROLE_TRAITOR] + rolesAmountList[ROLE_INNOCENT]
+
 	-- first of all, we need to select the baseroles. Otherwise, we would select subroles that never gonna be choosen because if the missing baserole
 	for i = 1, availableBaseRolesAmount do
-		if maxRoles and maxRoles <= curRoles or maxBaseroles and maxBaseroles <= curBaseroles or #availableBaseRolesTbl < 1 then break end -- if the limit is reached or no available roles left (could happen if removing available roles that weren't already selected in layered "or"-tables), stop selection
+		if currentlyAvailableRolesAmount >= maxPlys or maxRoles and maxRoles <= curRoles or maxBaseroles and maxBaseroles <= curBaseroles or #availableBaseRolesTbl < 1 then break end -- if the limit is reached or no available roles left (could happen if removing available roles that weren't already selected in layered "or"-tables), stop selection
 
 		-- the selected role
 		local subrole = nil
@@ -439,11 +441,14 @@ function roleselection.GetSelectableRolesList(maxPlys, rolesAmountList)
 			table.remove(availableBaseRolesTbl, rnd) -- selected subrole shouldn't get selected multiple times
 		end
 
-		selectableRoles[subrole] = rolesAmountList[subrole]
+		local amountForThisRole = math.min(rolesAmountList[subrole], maxPlys - currentlyAvailableRolesAmount)
+
+		selectableRoles[subrole] = amountForThisRole
 		baseroleLoopTbl[#baseroleLoopTbl + 1] = subrole
 
 		curRoles = curRoles + 1
 		curBaseroles = curBaseroles + 1
+		currentlyAvailableRolesAmount = currentlyAvailableRolesAmount + amountForThisRole
 	end
 
 	local layeredSubRolesTbl = table.Copy(roleselection.subroleLayers) -- layered roles list, the order defines the pick order. Just one role per layer is picked. Before a role is picked, the given layer is cleared (checked if the given roles are still selectable). Insert a table as a "or" list
@@ -612,7 +617,7 @@ local function SelectForcedRoles(plys, selectableRoles)
 		end
 	end
 
-	local selectedForcedRoles = GetHardForcedBaseRoles() -- this gets the hardforced amount of baseroles that are taken by subroles 
+	local selectedForcedRoles = GetHardForcedBaseRoles() -- this gets the hardforced amount of baseroles that are taken by subroles
 
 	for subrole, forcedPlys in pairs(transformed) do
 		local roleCount = selectableRoles[subrole]


### PR DESCRIPTION
This patch potentially corrects the filtering of available baseroles.
When the system goes through all layers for each baserole it does not consider the amount of players that can take the role and thus how many players can already be assigned to a role.
With the new condition it will now correctly stop adding baseroles to the final baserole selection table (marked as available), if the amount is equal to the player amount. This ensures that layering actually influences the availability of base roles and thus won't lead to weird issues further down.
The final role assignment also implicitly assumes that the actual selection of what roles appear is already made in the filtering of available roles. This should now work as intended.

This patch still needs testing and verification.