### PR TITLE
Items: Fix hotreload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed inconsistency between `.disabledTeamChatRecv` and `.disabledTeamChatRec`
 - Fixed non-public policing roles having hats and therefore confirming them
 - Fixed triggered spawns on maps like 'ttt_lttp_kakariko_a5' with the vases and 'ttt_mc_jondome' with the chests
+- Fixed hotreloading items
 
 ### Changed
 

--- a/gamemodes/terrortown/gamemode/client/cl_main.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_main.lua
@@ -235,22 +235,6 @@ function GM:InitPostEntity()
 	HUDManager.LoadAllHUDS()
 	HUDManager.SetHUD()
 
-
-	local itms = items.GetList()
-
-	-- load items
-	for i = 1, #itms do
-		local eq = itms[i]
-
-		InitDefaultEquipment(eq)
-		ShopEditor.InitDefaultData(eq) -- initialize the default data
-		CreateEquipment(eq) -- init items
-
-		eq.CanBuy = {} -- reset normal items equipment
-
-		eq:Initialize()
-	end
-
 	local sweps = weapons.GetList()
 
 	-- load sweps
@@ -258,7 +242,7 @@ function GM:InitPostEntity()
 		local eq = sweps[i]
 
 		-- Check if an equipment has an id or ignore it
-		-- @realm server		
+		-- @realm server
 		if not hook.Run("TTT2RegisterWeaponID", eq) then continue end
 
 		-- Insert data into role fallback tables
@@ -345,6 +329,9 @@ function GM:OnReloaded()
 	---
 	-- @realm shared
 	hook.Run("TTT2BaseRoleInit")
+
+	-- load all items
+	items.OnLoaded()
 
 	-- load all HUDs
 	huds.OnLoaded()

--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -427,34 +427,6 @@ function GM:InitPostEntity()
 	-- load all HUD elements
 	hudelements.OnLoaded()
 
-	local itms = items.GetList()
-
-	local isSqlTableCreated = sql.CreateSqlTable("ttt2_items", ShopEditor.savingKeys)
-
-	for i = 1, #itms do
-		local eq = itms[i]
-
-		InitDefaultEquipment(eq)
-		ShopEditor.InitDefaultData(eq)
-
-		if isSqlTableCreated then
-			local name = GetEquipmentFileName(WEPS.GetClass(eq))
-			local loaded, changed = sql.Load("ttt2_items", name, eq, ShopEditor.savingKeys)
-
-			if not loaded then
-				sql.Init("ttt2_items", name, eq, ShopEditor.savingKeys)
-			elseif changed then
-				CHANGED_EQUIPMENT[#CHANGED_EQUIPMENT + 1] = {name, eq}
-			end
-		end
-
-		CreateEquipment(eq) -- init items
-
-		eq.CanBuy = {} -- reset normal items equipment
-
-		eq:Initialize()
-	end
-
 	local sweps = weapons.GetList()
 
 	for i = 1, #sweps do
@@ -1367,6 +1339,9 @@ function GM:OnReloaded()
 
 	-- reload entity spawns from file
 	entspawnscript.OnLoaded()
+
+	-- load all items
+	items.OnLoaded()
 
 	-- load all HUDs
 	huds.OnLoaded()

--- a/lua/ttt2/libraries/items.lua
+++ b/lua/ttt2/libraries/items.lua
@@ -92,6 +92,30 @@ function items.OnLoaded()
 
 		baseclass.Set(k, newTable)
 	end
+
+	local isSqlTableCreated = SERVER and sql.CreateSqlTable("ttt2_items", ShopEditor.savingKeys)
+
+	for _, item in pairs(ItemList) do
+		InitDefaultEquipment(item)
+		ShopEditor.InitDefaultData(item) -- initialize the default data
+
+		if SERVER and isSqlTableCreated then
+			local name = GetEquipmentFileName(WEPS.GetClass(item))
+			local loaded, changed = sql.Load("ttt2_items", name, item, ShopEditor.savingKeys)
+
+			if not loaded then
+				sql.Init("ttt2_items", name, item, ShopEditor.savingKeys)
+			elseif changed then
+				CHANGED_EQUIPMENT[#CHANGED_EQUIPMENT + 1] = {name, item}
+			end
+		end
+
+		CreateEquipment(item) -- init items
+
+		item.CanBuy = {} -- reset normal items equipment
+
+		item:Initialize()
+	end
 end
 
 ---


### PR DESCRIPTION
This patch moves the initialization code specific to items into the items.OnLoaded() function and adds the call to the function to the OnReloaded hook as we do with all other things like huds etc.

This needs discussion, since im not particularly happy about such gamemode stuff / dependencies on those functions inside the items module. But on the other hand it really is a function that is tied to the gamemode.
Another idea would be to only move the ITEM:Initialize call to the items.OnLoaded() function and not touching the ShopEditor related initializations at all. 