### PR TITLE
Playermodels: Fixed Random Selection on Map Change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed non-public policing roles having hats and therefore confirming them
 - Fixed triggered spawns on maps like 'ttt_lttp_kakariko_a5' with the vases and 'ttt_mc_jondome' with the chests
 - Fixed roleselection layering with base roles to ensure layer order is considered correctly when selecting roles
-- Fixed hotreloading items-
-- Fixed random playermode selection on map change not working
+- Fixed hotreloading items
+- Fixed random playermodel selection on map change not working
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed non-public policing roles having hats and therefore confirming them
 - Fixed triggered spawns on maps like 'ttt_lttp_kakariko_a5' with the vases and 'ttt_mc_jondome' with the chests
 - Fixed roleselection layering with base roles to ensure layer order is considered correctly when selecting roles
-- Fixed hotreloading items
+- Fixed hotreloading items-
+- Fixed random playermode selection on map change not working
 
 ### Changed
 

--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -336,8 +336,6 @@ function GM:Initialize()
 
 	self.DamageLog = {}
 	self.LastRole = {}
-	self.playermodel = playermodels.GetRandomPlayerModel()
-	self.playercolor = COLOR_WHITE
 
 	-- Delay reading of cvars until config has definitely loaded
 	self.cvar_init = false
@@ -492,6 +490,10 @@ function GM:InitPostEntity()
 
 	-- initialize playermodel database
 	playermodels.Initialize()
+
+	-- set the default random playermodel
+	self.playermodel = playermodels.GetRandomPlayerModel()
+	self.playercolor = COLOR_WHITE
 
 	timer.Simple(0, function()
 		addonChecker.Check()
@@ -1352,6 +1354,10 @@ function GM:OnReloaded()
 	-- reload everything from the playermodels
 	playermodels.Initialize()
 	playermodels.StreamModelStateToSelectedClients()
+
+	-- set the default random playermodel
+	self.playermodel = playermodels.GetRandomPlayerModel()
+	self.playercolor = COLOR_WHITE
 
 	---
 	-- @realm shared


### PR DESCRIPTION
Currently the random playermodel selection on round change is broken. Moving the random selection until after the initialization fixes this.