### PR TITLE
Weapon Pickup: Fixed Flying Weapons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed roleselection layering with base roles to ensure layer order is considered correctly when selecting roles
 - Fixed hotreloading items
 - Fixed random playermodel selection on map change not working
+- Fixes weapon pickup sometimes causing floating weapons
+- Fixes weapon pickup sometimes failing if a weapon with the same class as a weapon in the invetory should be picked up
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed hotreloading items
 - Fixed random playermodel selection on map change not working
 - Fixes weapon pickup sometimes causing floating weapons
-- Fixes weapon pickup sometimes failing if a weapon with the same class as a weapon in the invetory should be picked up
+- Fixes weapon pickup sometimes failing if a weapon with the same class as a weapon in the inventory should be picked up
 
 ### Changed
 

--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -1255,7 +1255,6 @@ local plymeta_old_Give = plymeta.Give
 -- @realm server
 function plymeta:Give(weaponClassName, bNoAmmo)
 	self.forcedPickup = true
-	self.forcedGive = true
 
 	local wep = plymeta_old_Give(self, weaponClassName, bNoAmmo or false)
 
@@ -1263,7 +1262,6 @@ function plymeta:Give(weaponClassName, bNoAmmo)
 		if not IsValid(self) then return end
 
 		self.forcedPickup = false
-		self.forcedGive = false
 	end)
 
 	return wep
@@ -1296,11 +1294,15 @@ end
 -- @param boolean keepSelection If set to true the current selection is kept if not dropped
 -- @realm server
 function plymeta:SafeDropWeapon(wep, keepSelection)
-	if not self:CanSafeDropWeapon(wep) then return end
+	if not self:CanSafeDropWeapon(wep) then
+		return false
+	end
 
 	self:AnimPerformGesture(ACT_GMOD_GESTURE_ITEM_PLACE)
 
 	WEPS.DropNotifiedWeapon(self, wep, false, keepSelection)
+
+	return true
 end
 
 ---
@@ -1313,12 +1315,14 @@ end
 -- @realm server
 function plymeta:CanPickupWeapon(wep, forcePickup, dropBlockingWeapon)
 	self.forcedPickup = forcePickup
+	self.isPickupProbe = true
 
 	---
 	-- @realm server
 	local ret, errCode = hook.Run("PlayerCanPickupWeapon", self, wep, dropBlockingWeapon)
 
 	self.forcedPickup = false
+	self.isPickupProbe = false
 
 	return ret, errCode
 end
@@ -1393,11 +1397,7 @@ function plymeta:SafePickupWeapon(wep, ammoOnly, forcePickup, dropBlockingWeapon
 		-- Very very rarely happens but definitely breaks the weapon and should be avoided at all costs
 		if dropWeapon == wep then return end
 
-		timer.Simple(0, function()
-			if not IsValid(self) or not IsValid(dropWeapon) then return end
-
-			self:SafeDropWeapon(dropWeapon, true)
-		end)
+		if not self:SafeDropWeapon(dropWeapon, true) then return end
 
 		-- set flag to new weapon that is used to autoselect it later on
 		shouldAutoSelect = shouldAutoSelect or isActiveWeapon

--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -1292,6 +1292,7 @@ end
 -- Called to drop a weapon in a safe manner (e.g. preparing and space-check).
 -- @param Weapon wep The weapon that should be dropped
 -- @param boolean keepSelection If set to true the current selection is kept if not dropped
+-- @return boolean Returns if this weapon is dropped
 -- @realm server
 function plymeta:SafeDropWeapon(wep, keepSelection)
 	if not self:CanSafeDropWeapon(wep) then
@@ -1315,14 +1316,12 @@ end
 -- @realm server
 function plymeta:CanPickupWeapon(wep, forcePickup, dropBlockingWeapon)
 	self.forcedPickup = forcePickup
-	self.isPickupProbe = true
 
 	---
 	-- @realm server
-	local ret, errCode = hook.Run("PlayerCanPickupWeapon", self, wep, dropBlockingWeapon)
+	local ret, errCode = hook.Run("PlayerCanPickupWeapon", self, wep, dropBlockingWeapon, true)
 
 	self.forcedPickup = false
-	self.isPickupProbe = false
 
 	return ret, errCode
 end

--- a/gamemodes/terrortown/gamemode/server/sv_weaponry.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_weaponry.lua
@@ -29,7 +29,7 @@ local cv_ttt_detective_hats = CreateConVar("ttt_detective_hats", "0", {FCVAR_NOT
 -- @param Player ply The @{Player} attempting to pick up the @{Weapon}
 -- @param Weapon wep The @{Weapon} entity in question
 -- @param[opt] number dropBlockingWeapon should the weapon stored in the same slot be dropped
--- @param[opt] boolean isPickupProble Set this to true to mark this hook run as probe
+-- @param[opt] boolean isPickupProbe Set this to true to mark this hook run as probe
 -- @return boolean Allowed pick up or not
 -- @return number errorCode
 -- 1 - Player is spectator

--- a/gamemodes/terrortown/gamemode/server/sv_weaponry.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_weaponry.lua
@@ -28,7 +28,8 @@ local cv_ttt_detective_hats = CreateConVar("ttt_detective_hats", "0", {FCVAR_NOT
 -- @note Prevent @{Player}s from picking up multiple @{Weapon}s of the same type etc
 -- @param Player ply The @{Player} attempting to pick up the @{Weapon}
 -- @param Weapon wep The @{Weapon} entity in question
--- @param nil|number dropBlockingWeapon should the weapon stored in the same slot be dropped
+-- @param[opt] number dropBlockingWeapon should the weapon stored in the same slot be dropped
+-- @param[opt] boolean isPickupProble Set this to true to mark this hook run as probe
 -- @return boolean Allowed pick up or not
 -- @return number errorCode
 -- 1 - Player is spectator
@@ -40,7 +41,7 @@ local cv_ttt_detective_hats = CreateConVar("ttt_detective_hats", "0", {FCVAR_NOT
 -- @realm server
 -- @ref https://wiki.facepunch.com/gmod/GM:PlayerCanPickupWeapon
 -- @local
-function GM:PlayerCanPickupWeapon(ply, wep, dropBlockingWeapon)
+function GM:PlayerCanPickupWeapon(ply, wep, dropBlockingWeapon, isPickupProbe)
 	if not IsValid(wep) or not IsValid(ply) then return end
 
 	-- spectators are not allowed to pickup weapons
@@ -80,7 +81,7 @@ function GM:PlayerCanPickupWeapon(ply, wep, dropBlockingWeapon)
 
 	-- make sure that the weapon is moved to the player if it should be automatically picked
 	-- up; this however should not happen for manual pickup and/or hook probing
-	if cv_auto_pickup:GetBool() and not ply.forcedPickup and not ply.isPickupProbe then
+	if cv_auto_pickup:GetBool() and not ply.forcedPickup and not isPickupProbe then
 		local tr = util.TraceEntity({
 			start = wep:GetPos(),
 			endpos = ply:GetShootPos(),

--- a/gamemodes/terrortown/gamemode/server/sv_weaponry.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_weaponry.lua
@@ -80,7 +80,7 @@ function GM:PlayerCanPickupWeapon(ply, wep, dropBlockingWeapon)
 
 	-- make sure that the weapon is moved to the player if it should be automatically picked
 	-- up; this however should not happen for manual pickup and/or hook probing
-	if cv_auto_pickup:GetBool() and not ply.forcedGive and not ply.isPickupProbe then
+	if cv_auto_pickup:GetBool() and not ply.forcedPickup and not ply.isPickupProbe then
 		local tr = util.TraceEntity({
 			start = wep:GetPos(),
 			endpos = ply:GetShootPos(),

--- a/gamemodes/terrortown/gamemode/server/sv_weaponry.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_weaponry.lua
@@ -58,7 +58,7 @@ function GM:PlayerCanPickupWeapon(ply, wep, dropBlockingWeapon)
 	-- block pickup when there is no slot free
 	-- exception: this hook is called to check if a player can pick up weapon while dropping
 	-- the current weapon
-	if not dropBlockingWeapon and not InventorySlotFree(ply, wep.Kind) and not ply.forcedGive then
+	if not dropBlockingWeapon and not InventorySlotFree(ply, wep.Kind) and not ply.forcedPickup then
 		return false, 3
 	end
 
@@ -78,15 +78,18 @@ function GM:PlayerCanPickupWeapon(ply, wep, dropBlockingWeapon)
 		return false, 6
 	end
 
-	-- Who knows what happens here?!
-	local tr = util.TraceEntity({
-		start = wep:GetPos(),
-		endpos = ply:GetShootPos(),
-		mask = MASK_SOLID
-	}, wep)
+	-- make sure that the weapon is moved to the player if it should be automatically picked
+	-- up; this however should not happen for manual pickup and/or hook probing
+	if cv_auto_pickup:GetBool() and not ply.forcedGive and not ply.isPickupProbe then
+		local tr = util.TraceEntity({
+			start = wep:GetPos(),
+			endpos = ply:GetShootPos(),
+			mask = MASK_SOLID
+		}, wep)
 
-	if tr.Fraction == 1.0 or tr.Entity == ply then
-		wep:SetPos(ply:GetShootPos())
+		if tr.Fraction == 1.0 or tr.Entity == ply then
+			wep:SetPos(ply:GetShootPos())
+		end
 	end
 
 	return true


### PR DESCRIPTION
This PR fixes #861 by moving the weapon teleportation code into a conditional check. It also removes the timer around the weapon drop. After some testing I came to the realization that the timer doesn't seem to make a difference. However it causes problems when switching between two weapons with the same class, because then the pickup fails since the weapon is dropped a tick later.
The solution here was to either add a single tick timer to the pickup function as well, or to remove the existing drop timer. I chose the latter here.