### PR TITLE
Overheadicons: Color icon based on role color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
   - voice drain rate is now no longer bound to Detectives but to all public policing roles
   - Karma multiplier is now no longer bound to Detectives but to all public policing roles
   - all non-innocent roles are now able to pin ragdolls if enabled (previous only Traitors could do this)
+- Overhead icons are now also either colored black or white depending on the role's color
 
 ### Breaking Changes
 

--- a/gamemodes/terrortown/gamemode/client/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_targetid.lua
@@ -118,7 +118,7 @@ function DrawOverheadRoleIcon(ply, ricon, rcolor)
 
 	-- draw icon
 	render.SetMaterial(ricon)
-	render.DrawQuadEasy(Vector(pos.x, pos.y, pos.z + 0.5), dir, 8, 8, COLOR_WHITE, 180)
+	render.DrawQuadEasy(Vector(pos.x, pos.y, pos.z + 0.5), dir, 8, 8, util.GetDefaultColor(rcolor), 180)
 
 	-- stop linear filter
 	render.PopFilterMag()


### PR DESCRIPTION
This patch adjusts the color of overhead icons to match the info box role icon. It will now select white / black depending on the role's color.

![image](https://user-images.githubusercontent.com/10776964/141694358-fab037d6-1ab2-4f4f-b997-decfb5fc8608.png)
