### PR TITLE
Role Agnostics: IsOmniscientRole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
   - equipment specific settings can be found in the 'edit equipment' menu
 - Added icon to the magneto stick
 - Added the function `AddToSettingsMenu` to both `SWEP` and `ITEM` to add settings to the equipment menu
+- Added the role flag `.isOmniscientRole`; if set to true the role is able to see missing in action players and the haste mode time
 
 ### Fixed
 

--- a/gamemodes/terrortown/gamemode/client/vgui/cl_sb_main.lua
+++ b/gamemodes/terrortown/gamemode/client/vgui/cl_sb_main.lua
@@ -79,8 +79,8 @@ function ScoreGroup(ply)
 
 			-- To terrorists, missing players show as alive
 			if client:IsSpec()
-			or client:IsActive() and client:GetTeam() == TEAM_TRAITOR
-			or GetRoundState() ~= ROUND_ACTIVE and client:IsTerror()
+				or client:IsActive() and client:GetSubRoleData().isOmniscientRole
+				or GetRoundState() ~= ROUND_ACTIVE and client:IsTerror()
 			then
 				return GROUP_NOTFOUND
 			else

--- a/gamemodes/terrortown/gamemode/shared/hud_elements/tttinfopanel/old_ttt_info.lua
+++ b/gamemodes/terrortown/gamemode/shared/hud_elements/tttinfopanel/old_ttt_info.lua
@@ -153,8 +153,8 @@ if CLIENT then
 			end
 
 			-- Draw round time
-			local is_haste = HasteMode() and round_state == ROUND_ACTIVE
-			local is_traitor = client:IsActive() and client:GetTeam() == TEAM_TRAITOR
+			local isHaste = HasteMode() and round_state == ROUND_ACTIVE
+			local isOmniscient = client:IsActive() and client:GetSubRoleData().isOmniscientRole
 			local endtime = GetGlobalFloat("ttt_round_end", 0) - CurTime()
 			local font = "TimeLeft"
 			local color = COLOR_WHITE
@@ -166,10 +166,10 @@ if CLIENT then
 
 			-- Time displays differently depending on whether haste mode is on,
 			-- whether the player is traitor or not, and whether it is overtime.
-			if is_haste then
+			if isHaste then
 				local hastetime = GetGlobalFloat("ttt_haste_end", 0) - CurTime()
 				if hastetime < 0 then
-					if not is_traitor or math.ceil(CurTime()) % 7 <= 2 then
+					if not isOmniscient or math.ceil(CurTime()) % 7 <= 2 then
 
 						-- innocent or blinking "overtime"
 						text = L.overtime
@@ -187,7 +187,7 @@ if CLIENT then
 					-- still in starting period
 					local t = hastetime
 
-					if is_traitor and math.ceil(CurTime()) % 6 < 2 then
+					if isOmniscient and math.ceil(CurTime()) % 6 < 2 then
 						t = endtime
 						color = COLOR_RED
 					end
@@ -201,7 +201,7 @@ if CLIENT then
 
 			self:ShadowedText(text, font, rx, ry, color, TEXT_ALIGN_CENTER)
 
-			if is_haste then
+			if isHaste then
 				draw.SimpleText(L.hastemode, "TabLarge", tmp, traitor_y - 8, COLOR_WHITE, TEXT_ALIGN_CENTER)
 			end
 		else

--- a/gamemodes/terrortown/gamemode/shared/hud_elements/tttroundinfo/pure_skin_roundinfo.lua
+++ b/gamemodes/terrortown/gamemode/shared/hud_elements/tttroundinfo/pure_skin_roundinfo.lua
@@ -61,8 +61,8 @@ if CLIENT then
 		-- draw haste / time
 		-- Draw round time
 
-		local is_haste = HasteMode() and round_state == ROUND_ACTIVE
-		local is_traitor = not client:IsActive() or client:GetTeam() == TEAM_TRAITOR
+		local isHaste = HasteMode() and round_state == ROUND_ACTIVE
+		local isOmniscient = not client:IsActive() or client:GetSubRoleData().isOmniscientRole
 		local endtime = GetGlobalFloat("ttt_round_end", 0) - CurTime()
 		local font = "PureSkinTimeLeft"
 		local color = util.GetDefaultColor(self.basecolor)
@@ -77,10 +77,10 @@ if CLIENT then
 
 		-- Time displays differently depending on whether haste mode is on,
 		-- whether the player is traitor or not, and whether it is overtime.
-		if is_haste then
+		if isHaste then
 			local hastetime = GetGlobalFloat("ttt_haste_end", 0) - CurTime()
 			if hastetime < 0 then
-				if not is_traitor or math.ceil(CurTime()) % 7 <= 2 then
+				if not isOmniscient or math.ceil(CurTime()) % 7 <= 2 then
 					-- innocent or blinking "overtime"
 					text = L.overtime
 					font = "PureSkinMSTACKMsg"
@@ -97,7 +97,7 @@ if CLIENT then
 				-- still in starting period
 				local t = hastetime
 
-				if is_traitor and math.ceil(CurTime()) % 6 < 2 then
+				if isOmniscient and math.ceil(CurTime()) % 6 < 2 then
 					t = endtime
 					color = COLOR_RED
 				end
@@ -113,7 +113,7 @@ if CLIENT then
 
 		draw.AdvancedText(text, font, rx, ry, color, TEXT_ALIGN_CENTER, vert_align_clock, true, self.scale)
 
-		if is_haste then
+		if isHaste then
 			draw.AdvancedText(L.hastemode, "PureSkinMSTACKMsg", tmpx, self.pos.y + self.pad, util.GetDefaultColor(self.basecolor), TEXT_ALIGN_CENTER, TEXT_ALIGN_TOP, true, self.scale)
 		end
 

--- a/lua/terrortown/entities/roles/traitor/shared.lua
+++ b/lua/terrortown/entities/roles/traitor/shared.lua
@@ -20,6 +20,8 @@ function ROLE:PreInitialize()
 	self.score.teamKillsMultiplier = -16
 	self.score.bodyFoundMuliplier = 0
 
+	self.isOmniscientRole = true
+
 	self.fallbackTable = {}
 
 	-- conVarData

--- a/lua/terrortown/entities/roles/ttt_role_base/shared.lua
+++ b/lua/terrortown/entities/roles/ttt_role_base/shared.lua
@@ -125,6 +125,10 @@ ROLE.isPublicRole = false
 -- a corpse and evil roles can be rewarded more points for them being killed.
 ROLE.isPolicingRole = false
 
+-- Omniscient roles are able to see missing in action players and therefore the haste
+-- mode timer as well. This is mostly traitor-like behaviour.
+ROLE.isOmniscientRole = false
+
 -- If this is set to true, the role is unable to send messages in the team chat. If this is
 -- set to false, it still could mean that the player is unable to use the team chat. If the
 -- role flag `.unknownTeam` is set, the team chat can't be used either.


### PR DESCRIPTION
This new role variable moves yet another traitor feature to the role base. If `isOmniscientRole` is set to true, the role is able to see the haste mode timer as well as missing in action players.