### PR TITLE
Overhead Icon: Made modifyable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Added icon to the magneto stick
 - Added the function `AddToSettingsMenu` to both `SWEP` and `ITEM` to add settings to the equipment menu
 - Added the role flag `.isOmniscientRole`; if set to true the role is able to see missing in action players and the haste mode time
+- Added `GM:TTT2ModifyOverheadIcon` to add, remove or modify the overhead icons of players
 
 ### Fixed
 

--- a/gamemodes/terrortown/gamemode/client/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_targetid.lua
@@ -182,7 +182,7 @@ function GM:PostDrawTranslucentRenderables(bDrawingDepth, bDrawingSkybox)
 		local shouldDraw, material, color = hook.Run("TTT2ModifyOverheadIcon", ply, shouldDrawDefault)
 
 		if shouldDraw == false
-			or not shouldDrawDefault and not material and not color
+			or not shouldDrawDefault and not (material and color)
 		then continue end
 
 		DrawOverheadRoleIcon(ply, material or rd.iconMaterial, color or ply:GetRoleColor())

--- a/gamemodes/terrortown/gamemode/client/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_targetid.lua
@@ -172,13 +172,18 @@ function GM:PostDrawTranslucentRenderables(bDrawingDepth, bDrawingSkybox)
 		local ply = plys[i]
 		local rd = ply:GetSubRoleData()
 
-		if ply:IsActive()
+		local shouldDrawDefault = ply:IsActive()
 			and ply:HasRole()
 			and (not client:IsActive() or ply:IsInTeam(client) or rd.isPublicRole)
 			and not rd.avoidTeamIcons
-		then
-			DrawOverheadRoleIcon(ply, rd.iconMaterial, ply:GetRoleColor())
-		end
+
+		local shouldDraw, material, color = hook.Run("TTT2ModifyOverheadIcon", ply, shouldDrawDefault)
+
+		if shouldDraw == false
+			or not shouldDrawDefault and not material and not color
+		then continue end
+
+		DrawOverheadRoleIcon(ply, material or rd.iconMaterial, color or ply:GetRoleColor())
 	end
 end
 
@@ -434,5 +439,18 @@ end
 -- @hook
 -- @realm client
 function GM:TTTModifyTargetTracedata(startpos, endpos)
+
+end
+
+---
+-- Can be used to modify, disable or add an overhead icon of a player.
+-- @param Player ply The player whose overhead icon should be modified
+-- @param boolean shouldDrawDefault Defines if the overhead icon would draw normally
+-- @return boolean Return false to prevent overhead icon draw
+-- @return Material The material for the overhead icon (normally the role icon)
+-- @return Color The color of the overhead icon backdrop
+-- @hook
+-- @realm client
+function GM:TTT2ModifyOverheadIcon(ply, shouldDrawDefault)
 
 end

--- a/gamemodes/terrortown/gamemode/client/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_targetid.lua
@@ -177,6 +177,8 @@ function GM:PostDrawTranslucentRenderables(bDrawingDepth, bDrawingSkybox)
 			and (not client:IsActive() or ply:IsInTeam(client) or rd.isPublicRole)
 			and not rd.avoidTeamIcons
 
+		---
+		-- @realm client
 		local shouldDraw, material, color = hook.Run("TTT2ModifyOverheadIcon", ply, shouldDrawDefault)
 
 		if shouldDraw == false


### PR DESCRIPTION
Added a hook to add, remove or modify the overhead icon:

```lua
---
-- Can be used to modify, disable or add an overhead icon of a player.
-- @param Player ply The player whose overhead icon should be modified
-- @param boolean shouldDrawDefault Defines if the overhead icon would draw normally
-- @return boolean Return false to prevent overhead icon draw
-- @return Material The material for the overhead icon (normally the role icon)
-- @return Color The color of the overhead icon backdrop
-- @hook
-- @realm client
function GM:TTT2ModifyOverheadIcon(ply, shouldDrawDefault)

end
```

Example usage in the identity desiguiser:
```lua
hook.Add("TTT2ModifyOverheadIcon", "ModifyDisguiserOHI", function(ply, shouldDrawDefault)
	if not ply:IsPlayer() or not ply:HasDisguiserTarget() then return end

	local client = LocalPlayer()
	local target = ply:GetDisguiserTarget()
	local rd = target:GetSubRoleData()

	local shouldShow = target:IsActive()
		and target:HasRole()
		and (not client:IsActive() or target:IsInTeam(client) or rd.isPublicRole)
		and not rd.avoidTeamIcons

	return shouldShow, target:GetSubRoleData().iconMaterial, target:GetRoleColor()
end)
```