### PR TITLE
Spawneditor: Fixed giving spawneditor when weapons are cached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ## Unreleased
 
+### Fixed
+
+- Fixed `ply:Give(weapon)` to work again, when weapons are cached, fixing the spawneditor to work again
+
 ## [v0.11.0b](https://github.com/TTT-2/TTT2/tree/v0.11.0b) (2021-11-15)
 
 ### Added

--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -1314,7 +1314,7 @@ end
 ---
 -- Returns whether or not a player can pick up a weapon
 -- @param Weapon wep The weapon object
--- @param nil|boolean forcePickup is there a forced pickup to ignore the cv_auto_pickup cvar
+-- @param nil|boolean forcePickup is there a forced pickup to ignore the cv_auto_pickup cvar?
 -- @param nil|boolean dropBlockingWeapon should the weapon stored in the same slot be dropped
 -- @return boolean return of the PlayerCanPickupWeapon hook
 -- @return number errorCode that appeared. For the error, give a look into the specific hook

--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -1254,11 +1254,16 @@ local plymeta_old_Give = plymeta.Give
 -- @return Weapon
 -- @realm server
 function plymeta:Give(weaponClassName, bNoAmmo)
+	-- ForcedPickup needs to be used to be able to ignore the cv_auto_pickup cvar
 	self.forcedPickup = true
+
+	-- ForcedGive needs to be used to give weapons when there are cached ones, e.g. in use with the spawneditor
+	self.forcedGive = true
 
 	local wep = plymeta_old_Give(self, weaponClassName, bNoAmmo or false)
 
 	self.forcedPickup = false
+	self.forcedGive = false
 
 	return wep
 end
@@ -1309,7 +1314,7 @@ end
 ---
 -- Returns whether or not a player can pick up a weapon
 -- @param Weapon wep The weapon object
--- @param nil|boolean forcePickup is there a forced pickup to ignore the cv_auto_pickup cvar?
+-- @param nil|boolean forcePickup is there a forced pickup to ignore the cv_auto_pickup cvar
 -- @param nil|boolean dropBlockingWeapon should the weapon stored in the same slot be dropped
 -- @return boolean return of the PlayerCanPickupWeapon hook
 -- @return number errorCode that appeared. For the error, give a look into the specific hook


### PR DESCRIPTION
We removed a flag, that was used for cached weapons. As the spawneditor is given after caching, we need the forcedGive flag.