### PR TITLE
Spawneditor: Fix too many steps (leading up to infinity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ### Fixed
 
 - Fixed `ply:Give(weapon)` to work again, when weapons are cached, fixing the spawneditor to work again
+- Fixed spawneditor not causing errors, when going through walls due to many steps
 
 ## [v0.11.0b](https://github.com/TTT-2/TTT2/tree/v0.11.0b) (2021-11-15)
 

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_spawneditor.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_spawneditor.lua
@@ -106,6 +106,7 @@ if CLIENT then
 	local mathPi = math.pi
 	local mathTan = math.tan
 	local mathMax = math.max
+	local mathMin = math.min
 	local ColorAlpha = ColorAlpha
 
 	local centerX = 0.5 * ScrW()
@@ -114,6 +115,7 @@ if CLIENT then
 	local tolerance = 32 * sphereRadius
 
 	local maxEditDistance = 1500
+	local maxSphereQualitySteps = 100
 	local distWalls = 7.5
 
 	local colorPreview = Color(255, 255, 255, 100)
@@ -179,7 +181,7 @@ if CLIENT then
 
 				if dist3d > maxEditDistance then continue end
 
-				local steps = mathMax(1, 4 + 750 / dist3d)
+				local steps = mathMin(maxSphereQualitySteps, mathMax(1, 4 + 750 / dist3d))
 
 				if not isHighlighted then
 					renderDrawSphere(
@@ -248,7 +250,7 @@ if CLIENT then
 			local id = proximitySpawn.id
 			local dist3d = proximitySpawn.dist3d
 			local color = colorSpawnTypes[spawnType]
-			local steps = mathMax(1, 4 + 750 / dist3d)
+			local steps = mathMin(maxSphereQualitySteps, mathMax(1, 4 + 750 / dist3d))
 
 			screenPos = proximitySpawn.screenPos
 
@@ -317,7 +319,7 @@ if CLIENT then
 			colorSphere = colorPreview
 		end
 
-		local steps = mathMax(1, 4 + 750 / previewData.distance3d)
+		local steps = mathMin(maxSphereQualitySteps, mathMax(1, 4 + 750 / previewData.distance3d))
 
 		renderDrawSphere(
 			previewData.currentPos,

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_spawneditor.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_spawneditor.lua
@@ -115,7 +115,7 @@ if CLIENT then
 	local tolerance = 32 * sphereRadius
 
 	local maxEditDistance = 1500
-	local maxSphereQualitySteps = 100
+	local maxSphereQualitySteps = 10
 	local distWalls = 7.5
 
 	local colorPreview = Color(255, 255, 255, 100)

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_spawneditor.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_spawneditor.lua
@@ -115,7 +115,6 @@ if CLIENT then
 	local tolerance = 32 * sphereRadius
 
 	local maxEditDistance = 1500
-	local maxSphereQualitySteps = 10
 	local distWalls = 7.5
 
 	local colorPreview = Color(255, 255, 255, 100)
@@ -137,6 +136,16 @@ if CLIENT then
 
 	local colorBasic = Color(255, 255, 255, 100)
 	local colorSelect = Color(255, 255, 255, 235)
+
+	local function GetSteps(distance3D)
+		if not isnumber(distance3D) then
+			return 10
+		end
+
+		-- Norm Steps to be the maximum 10 at 200 units and minimum of 5 at 400 units seems reasonable
+		-- Dont go below 5, as you wont recognize it as a sphere anymore
+		return mathMin(10, mathMax(5,  10 * 200 / distance3D))
+	end
 
 	local function IsHighlighted(pos, screenPos)
 		local localPlayer = LocalPlayer()
@@ -181,7 +190,7 @@ if CLIENT then
 
 				if dist3d > maxEditDistance then continue end
 
-				local steps = mathMin(maxSphereQualitySteps, mathMax(1, 4 + 750 / dist3d))
+				local steps = GetSteps(dist3d)
 
 				if not isHighlighted then
 					renderDrawSphere(
@@ -250,7 +259,7 @@ if CLIENT then
 			local id = proximitySpawn.id
 			local dist3d = proximitySpawn.dist3d
 			local color = colorSpawnTypes[spawnType]
-			local steps = mathMin(maxSphereQualitySteps, mathMax(1, 4 + 750 / dist3d))
+			local steps = GetSteps(dist3d)
 
 			screenPos = proximitySpawn.screenPos
 
@@ -319,7 +328,7 @@ if CLIENT then
 			colorSphere = colorPreview
 		end
 
-		local steps = mathMin(maxSphereQualitySteps, mathMax(1, 4 + 750 / previewData.distance3d))
+		local steps = GetSteps(dist3d)
 
 		renderDrawSphere(
 			previewData.currentPos,


### PR DESCRIPTION
It took some time, but after glitching through some walls it happened and I can confirm the error of #904 
I also then forced it to happen and that at least confirms my suspicion that drawSphere cant handle infinity.
```
previewData.distance3d = math.floor(previewData.distance3d)

if previewData.distance3d <= 0 then
	print(previewData.distance3d)
end
```

So this fix should handle that special case and also handle some framedrops, when being close to spheres. As this is an admin tool, I guess we dont need it to be super high fidelity. 🤔 
Opinions on only 10 steps shown in the picture on 2k resolution?
![grafik](https://user-images.githubusercontent.com/72046466/141980763-af8cad53-d6c5-43b8-a275-ed43003ace18.png)
