### PR TITLE
Karma: Added Multiplicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ## Unreleased
 
+### Added
+
+- Added four new Karma multipliers. They are applied **after** all other Karma calculations are done_
+  - `ROLE.karma.teamKillPenaltyMultiplier`: The multiplier that is used to calculate the Karma penalty for a team kill
+  - `ROLE.karma.teamHurtPenatlyMultiplier`: The multiplier that is used to calculate the Karma penalty for team damage
+  - `ROLE.karma.enemyKillBonusMultiplier`: The multiplier that is used to change the Karma given to the killer if a player from an enemy team is killed
+  - `ROLE.karma.enemyHurtBonusMulitplier`: The multiplier that is used to change the Karma given to the attacker if a player from an enemy team is damaged
+
 ### Fixed
 
 - Fixed `ply:Give(weapon)` to work again, when weapons are cached, fixing the spawneditor to work again

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 - Added four new Karma multipliers as role variables. They are applied **after** all other Karma calculations are done_
   - `ROLE.karma.teamKillPenaltyMultiplier`: The multiplier that is used to calculate the Karma penalty for a team kill
-  - `ROLE.karma.teamHurtPenatlyMultiplier`: The multiplier that is used to calculate the Karma penalty for team damage
+  - `ROLE.karma.teamHurtPenaltyMultiplier`: The multiplier that is used to calculate the Karma penalty for team damage
   - `ROLE.karma.enemyKillBonusMultiplier`: The multiplier that is used to calculate the Karma given to the killer if a player from an enemy team is killed
   - `ROLE.karma.enemyHurtBonusMultiplier`: The multiplier that is used to calculate the Karma given to the attacker if a player from an enemy team is damaged
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ### Added
 
-- Added four new Karma multipliers. They are applied **after** all other Karma calculations are done_
+- Added four new Karma multipliers as role variables. They are applied **after** all other Karma calculations are done_
   - `ROLE.karma.teamKillPenaltyMultiplier`: The multiplier that is used to calculate the Karma penalty for a team kill
   - `ROLE.karma.teamHurtPenatlyMultiplier`: The multiplier that is used to calculate the Karma penalty for team damage
   - `ROLE.karma.enemyKillBonusMultiplier`: The multiplier that is used to change the Karma given to the killer if a player from an enemy team is killed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Added four new Karma multipliers as role variables. They are applied **after** all other Karma calculations are done_
   - `ROLE.karma.teamKillPenaltyMultiplier`: The multiplier that is used to calculate the Karma penalty for a team kill
   - `ROLE.karma.teamHurtPenatlyMultiplier`: The multiplier that is used to calculate the Karma penalty for team damage
-  - `ROLE.karma.enemyKillBonusMultiplier`: The multiplier that is used to change the Karma given to the killer if a player from an enemy team is killed
-  - `ROLE.karma.enemyHurtBonusMulitplier`: The multiplier that is used to change the Karma given to the attacker if a player from an enemy team is damaged
+  - `ROLE.karma.enemyKillBonusMultiplier`: The multiplier that is used to calculate the Karma given to the killer if a player from an enemy team is killed
+  - `ROLE.karma.enemyHurtBonusMultiplier`: The multiplier that is used to calculate the Karma given to the attacker if a player from an enemy team is damaged
 
 ### Fixed
 

--- a/gamemodes/terrortown/gamemode/server/sv_karma.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_karma.lua
@@ -399,7 +399,7 @@ function KARMA.Hurt(attacker, victim, dmginfo)
 	else -- team hurts own team
 		if not victim:GetCleanRound() then return end
 
-		local multiplicator = WasAvoidable(attacker, victim, dmginfo) * attackerRoleData.teamHurtPenatlyMultiplier
+		local multiplicator = WasAvoidable(attacker, victim, dmginfo) * attackerRoleData.teamHurtPenaltyMultiplier
 		local penalty = KARMA.GetHurtPenalty(victim:GetLiveKarma(), hurt_amount) * multiplicator
 
 		KARMA.GivePenalty(attacker, penalty, victim, KARMA.reason[KARMA_TEAMHURT])

--- a/gamemodes/terrortown/gamemode/server/sv_karma.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_karma.lua
@@ -390,7 +390,7 @@ function KARMA.Hurt(attacker, victim, dmginfo)
 	-- team hurts another team
 	if not attacker:IsInTeam(victim) then
 		if attacker:GetSubRoleData().unknownTeam then
-			local reward = KARMA.GetHurtReward(hurt_amount) * attackerRoleData.enemyHurtBonusMulitplier
+			local reward = KARMA.GetHurtReward(hurt_amount) * attackerRoleData.enemyHurtBonusMultiplier
 
 			reward = KARMA.GiveReward(attacker, reward, KARMA.reason[KARMA_ENEMYHURT])
 

--- a/gamemodes/terrortown/gamemode/server/sv_karma.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_karma.lua
@@ -389,7 +389,7 @@ function KARMA.Hurt(attacker, victim, dmginfo)
 
 	-- team hurts another team
 	if not attacker:IsInTeam(victim) then
-		if attacker:GetSubRoleData().unknownTeam then
+		if attackerRoleData.unknownTeam then
 			local reward = KARMA.GetHurtReward(hurt_amount) * attackerRoleData.enemyHurtBonusMultiplier
 
 			reward = KARMA.GiveReward(attacker, reward, KARMA.reason[KARMA_ENEMYHURT])
@@ -428,7 +428,7 @@ function KARMA.Killed(attacker, victim, dmginfo)
 
 	-- team kills another team
 	if not attacker:IsInTeam(victim) then
-		if attacker:GetSubRoleData().unknownTeam then
+		if attackerRoleData.unknownTeam then
 			local reward = KARMA.GetKillReward() * attackerRoleData.enemyKillBonusMultiplier
 
 			reward = KARMA.GiveReward(attacker, reward, KARMA.reason[KARMA_ENEMYKILL])

--- a/gamemodes/terrortown/gamemode/server/sv_karma.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_karma.lua
@@ -399,7 +399,7 @@ function KARMA.Hurt(attacker, victim, dmginfo)
 	else -- team hurts own team
 		if not victim:GetCleanRound() then return end
 
-		local multiplicator = WasAvoidable(attacker, victim, dmginfo) * attackerRoleData.teamHurtBonusMulitplier
+		local multiplicator = WasAvoidable(attacker, victim, dmginfo) * attackerRoleData.teamHurtPenatlyMultiplier
 		local penalty = KARMA.GetHurtPenalty(victim:GetLiveKarma(), hurt_amount) * multiplicator
 
 		KARMA.GivePenalty(attacker, penalty, victim, KARMA.reason[KARMA_TEAMHURT])
@@ -438,7 +438,7 @@ function KARMA.Killed(attacker, victim, dmginfo)
 	else -- team kills own team
 		if not victim:GetCleanRound() then return end
 
-		local multiplicator = WasAvoidable(attacker, victim, dmginfo) * attackerRoleData.teamKillBonusMultiplier
+		local multiplicator = WasAvoidable(attacker, victim, dmginfo) * attackerRoleData.teamKillPenaltyMultiplier
 		local penalty = KARMA.GetKillPenalty(victim:GetLiveKarma()) * multiplicator
 
 		KARMA.GivePenalty(attacker, penalty, victim, KARMA.reason[KARMA_TEAMKILL])

--- a/gamemodes/terrortown/gamemode/server/sv_karma.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_karma.lua
@@ -374,24 +374,32 @@ end
 -- @param DamageInfo dmginfo
 -- @realm server
 function KARMA.Hurt(attacker, victim, dmginfo)
-	if attacker == victim or not IsValid(attacker) or not IsValid(victim) or not attacker:IsPlayer() or not victim:IsPlayer() or dmginfo:GetDamage() <= 0 then return end
+	if attacker == victim
+		or not IsValid(attacker)
+		or not IsValid(victim)
+		or not attacker:IsPlayer()
+		or not victim:IsPlayer()
+		or dmginfo:GetDamage() <= 0
+	then return end
 
 	-- Ignore excess damage
 	local hurt_amount = math.min(victim:Health(), dmginfo:GetDamage())
 
-	-- team kills another team
+	local attackerRoleData = attacker:GetSubRoleData()
+
+	-- team hurts another team
 	if not attacker:IsInTeam(victim) then
 		if attacker:GetSubRoleData().unknownTeam then
-			local reward = KARMA.GetHurtReward(hurt_amount)
+			local reward = KARMA.GetHurtReward(hurt_amount) * attackerRoleData.enemyHurtBonusMulitplier
 
 			reward = KARMA.GiveReward(attacker, reward, KARMA.reason[KARMA_ENEMYHURT])
 
 			print(Format("%s (%f) hurt %s (%f) and gets REWARDED %f", attacker:Nick(), attacker:GetLiveKarma(), victim:Nick(), victim:GetLiveKarma(), reward))
 		end
-	else -- team kills own team
+	else -- team hurts own team
 		if not victim:GetCleanRound() then return end
 
-		local multiplicator = WasAvoidable(attacker, victim, dmginfo)
+		local multiplicator = WasAvoidable(attacker, victim, dmginfo) * attackerRoleData.teamHurtBonusMulitplier
 		local penalty = KARMA.GetHurtPenalty(victim:GetLiveKarma(), hurt_amount) * multiplicator
 
 		KARMA.GivePenalty(attacker, penalty, victim, KARMA.reason[KARMA_TEAMHURT])
@@ -409,11 +417,19 @@ end
 -- @param DamageInfo dmginfo
 -- @realm server
 function KARMA.Killed(attacker, victim, dmginfo)
-	if attacker == victim or not IsValid(attacker) or not IsValid(victim) or not victim:IsPlayer() or not attacker:IsPlayer() then return end
+	if attacker == victim
+		or not IsValid(attacker)
+		or not IsValid(victim)
+		or not victim:IsPlayer()
+		or not attacker:IsPlayer()
+	then return end
 
-	if not attacker:IsInTeam(victim) then -- team kills another team
+	local attackerRoleData = attacker:GetSubRoleData()
+
+	-- team kills another team
+	if not attacker:IsInTeam(victim) then
 		if attacker:GetSubRoleData().unknownTeam then
-			local reward = KARMA.GetKillReward()
+			local reward = KARMA.GetKillReward() * attackerRoleData.enemyKillBonusMultiplier
 
 			reward = KARMA.GiveReward(attacker, reward, KARMA.reason[KARMA_ENEMYKILL])
 
@@ -422,7 +438,7 @@ function KARMA.Killed(attacker, victim, dmginfo)
 	else -- team kills own team
 		if not victim:GetCleanRound() then return end
 
-		local multiplicator = WasAvoidable(attacker, victim, dmginfo)
+		local multiplicator = WasAvoidable(attacker, victim, dmginfo) * attackerRoleData.teamKillBonusMultiplier
 		local penalty = KARMA.GetKillPenalty(victim:GetLiveKarma()) * multiplicator
 
 		KARMA.GivePenalty(attacker, penalty, victim, KARMA.reason[KARMA_TEAMKILL])

--- a/lua/terrortown/entities/roles/ttt_role_base/shared.lua
+++ b/lua/terrortown/entities/roles/ttt_role_base/shared.lua
@@ -40,9 +40,29 @@ ROLE.score = {
 	-- round ended with nobody winning, usually a negative number.
 	timelimitMultiplier = 0,
 
-	-- the amount of points gained by killing yourself. Should be a
+	-- The amount of points gained by killing yourself. Should be a
 	-- negative number for most roles.
 	suicideMultiplier = -1
+}
+
+ROLE.karma = {
+	-- The multiplier that is used to calculate the Karma penalty for a team kill.
+	-- Keep in mind that the game will increase the multiplier further if it was avoidable
+	-- like a kill on a public policing role.
+	teamKillPenaltyMultiplier = 1,
+
+	-- The multiplier that is used to calculate the Karma penalty for team damage.
+	-- Keep in mind that the game will increase the multiplier further if it was avoidable
+	-- like damage applied to a public policing role.
+	teamHurtPenalyMultiplier = 1,
+
+	-- The multiplier that is used to change the Karma given to the killer if a player
+	-- from an enemy team is killed.
+	enemyKillBonusMultiplier = 1,
+
+	-- The multiplier that is used to change the Karma given to the attacker if a player
+	-- from an enemy team is damaged.
+	enemyHurtBonusMulitplier = 1,
 }
 
 ROLE.conVarData = {

--- a/lua/terrortown/entities/roles/ttt_role_base/shared.lua
+++ b/lua/terrortown/entities/roles/ttt_role_base/shared.lua
@@ -54,7 +54,7 @@ ROLE.karma = {
 	-- The multiplier that is used to calculate the Karma penalty for team damage.
 	-- Keep in mind that the game will increase the multiplier further if it was avoidable
 	-- like damage applied to a public policing role.
-	teamHurtPenalyMultiplier = 1,
+	teamHurtPenatlyMultiplier = 1,
 
 	-- The multiplier that is used to change the Karma given to the killer if a player
 	-- from an enemy team is killed.

--- a/lua/terrortown/entities/roles/ttt_role_base/shared.lua
+++ b/lua/terrortown/entities/roles/ttt_role_base/shared.lua
@@ -54,7 +54,7 @@ ROLE.karma = {
 	-- The multiplier that is used to calculate the Karma penalty for team damage.
 	-- Keep in mind that the game will increase the multiplier further if it was avoidable
 	-- like damage applied to a public policing role.
-	teamHurtPenatlyMultiplier = 1,
+	teamHurtPenaltyMultiplier = 1,
 
 	-- The multiplier that is used to change the Karma given to the killer if a player
 	-- from an enemy team is killed.

--- a/lua/terrortown/entities/roles/ttt_role_base/shared.lua
+++ b/lua/terrortown/entities/roles/ttt_role_base/shared.lua
@@ -62,7 +62,7 @@ ROLE.karma = {
 
 	-- The multiplier that is used to change the Karma given to the attacker if a player
 	-- from an enemy team is damaged.
-	enemyHurtBonusMulitplier = 1,
+	enemyHurtBonusMultiplier = 1,
 }
 
 ROLE.conVarData = {


### PR DESCRIPTION
This is a very basic karma var system that could be extended in the future. We opted for this very simple approach, because it can always be extended at a later point. But a more in-depth system would need a whole system rework first.

The following vars have been added:
- `ROLE.karma.teamKillPenaltyMultiplier`: The multiplier that is used to calculate the Karma penalty for a team kill
- `ROLE.karma.teamHurtPenatlyMultiplier`: The multiplier that is used to calculate the Karma penalty for team damage
- `ROLE.karma.enemyKillBonusMultiplier`: The multiplier that is used to change the Karma given to the killer if a player from an enemy team is killed
- `ROLE.karma.enemyHurtBonusMultiplier`: The multiplier that is used to change the Karma given to the attacker if a player from an enemy team is damaged