### PR TITLE
Damage Overlay: Fix unscaled damage being shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 - Fixed `ply:Give(weapon)` to work again, when weapons are cached, fixing the spawneditor to work again
 - Fixed spawneditor not causing errors, when going through walls due to many steps
+- Fixed unchanged or unscaled damage being sent to the client, leading to a wrongly working damage-overlay
 
 ## [v0.11.0b](https://github.com/TTT-2/TTT2/tree/v0.11.0b) (2021-11-15)
 

--- a/gamemodes/terrortown/gamemode/server/sv_player.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player.lua
@@ -1296,7 +1296,7 @@ function GM:PlayerTakeDamage(ent, infl, att, amount, dmginfo)
 
 	-- send damage information to client
 	net.Start("ttt2_damage_received")
-	net.WriteFloat(amount)
+	net.WriteFloat(dmginfo:GetDamage())
 	net.Send(ent)
 end
 


### PR DESCRIPTION
As the amount of damage cant be changed in the hook, we use now the info from dmginfo:GetDamage() instead and therefore take everything that is scaled due to hooks and armor and Karma into account.

Warning: This is untested, but should work in theory!