### PR TITLE
Roles: Initial Traitor Button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 - Fixed `ply:Give(weapon)` to work again, when weapons are cached, fixing the spawneditor to work again
 - Fixed spawneditor not causing errors, when going through walls due to many steps
+- Set default traitor button variable back to 0
 
 ## [v0.11.0b](https://github.com/TTT-2/TTT2/tree/v0.11.0b) (2021-11-15)
 

--- a/lua/terrortown/entities/roles/ttt_role_base/shared.lua
+++ b/lua/terrortown/entities/roles/ttt_role_base/shared.lua
@@ -79,7 +79,7 @@ ROLE.conVarData = {
 	minKarma = 0,
 
 	-- Defines if the role has access to traitor buttons.
-	traitorButton = 1,
+	traitorButton = 0,
 
 	-- Sets the amount of credits the role is starting with.
 	credits = 0,


### PR DESCRIPTION
In a recent code refactoring I accidentally set the default of the traitor button variable to 1. I reset that to 0. This caused the reports that for new people innocents could access traitor buttons.