### PR TITLE
Equipment Editor: Fix showing cached variables instead of synced ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ## Unreleased
 
+### Fixed
+
+- Fixed Equipment-Editor not showing the current synced values, but the cached ones 
+
 ## [v0.11.2b](https://github.com/TTT-2/TTT2/tree/v0.11.2b) (2021-11-17)
 
 ### Fixed

--- a/lua/terrortown/menus/gamemode/equipment.lua
+++ b/lua/terrortown/menus/gamemode/equipment.lua
@@ -33,16 +33,9 @@ function CLGAMEMODEMENU:InitializeVirtualMenus()
 
 		counter = counter + 1
 
-		local isItem = items.IsItem(equipment)
-
-		-- Get inheritable version for weapons
-		if not isItem then
-			equipment = weapons.Get(WEPS.GetClass(equipment))
-		end
-
 		virtualSubmenus[counter] = tableCopy(equipmentMenuBase)
 		virtualSubmenus[counter].equipment = equipment
-		virtualSubmenus[counter].isItem = isItem
+		virtualSubmenus[counter].isItem = items.IsItem(equipment)
 		virtualSubmenus[counter].icon = equipment.ttt2_cached_material
 		virtualSubmenus[counter].iconFullSize = true
 	end

--- a/lua/terrortown/menus/gamemode/equipment/base_equipment.lua
+++ b/lua/terrortown/menus/gamemode/equipment/base_equipment.lua
@@ -100,6 +100,11 @@ function CLGAMEMODESUBMENU:Populate(parent)
 		masterRefs[key] = option
 	end
 
+	-- Get inheritable version for weapons to access inherited functions
+	if not self.isItem then
+		equipment = weapons.Get(WEPS.GetClass(equipment))
+	end
+
 	-- now add custom equipment settings
 	equipment:AddToSettingsMenu(parent)
 end


### PR DESCRIPTION
To have the inherited versions for the AddToSettingsMenu-function, we used the weapons.Get-function which cached an inherited copy of the original weapons table. But as synchronization only affects the original table not the copied cached one, we need to get it as late as possible.

I know that at this point we could also just check if the function is given, but I would rather have the option available to later patch in a default AddToSettingsMenu directly in the ttt_weaponbase.