### PR TITLE
Panel Dropdown: Added ServerConVar and reworked whole structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ## Unreleased
 
+### Added
+
+- Added possibility to manipulate serverside ConVars with Dropdowns
+  - Just add .serverConvar with the conVarName to the given data similar to .convar
+
 ## [v0.11.3b](https://github.com/TTT-2/TTT2/tree/v0.11.3b) (2021-11-18)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,20 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ### Added
 
-- Added possibility to manipulate serverside ConVars with Dropdowns
-  - Just add .serverConvar with the conVarName to the given data similar to .convar
+- Reworked our simplified Dropdowns MakePanel `PANEL:MakeComboBox(data)` version
+  - Added possibility to manipulate serverside ConVars with Dropdowns. Just add .serverConvar with the conVarName to the given data similar to .convar
+  - .serverConVar and .conVar are also supported
+  - data.choices can now be a table containing `{title, value, select, icon, additionalData}`
+  - data.selectValue is added, use it instead of data.selectName to choose the value you set
+  - data.selectTitle is added and shall replace data.selectName
+
+### Breaking Changes
+
+- Reworked Dropdowns Panel `DComboBoxTTT2` itself
+  - `PANEL:AddChoice(title, value, select, icon, data)` now uses the second argument as value string for setting convars, use the fifth argument for special data instead
+  - `PANEL:ChooseOption(value, index, ignoreConVar)` no longer chooses the displayed text, but the underlying value, which also sets conVars
+- Reworked our simplified Dropdowns MakePanel `PANEL:MakeComboBox(data)` version
+  - `data.OnChange(value, additionalData)` is now only called with the two important arguments, the value that e.g. convars are set and the additionalData 
 
 ## [v0.11.3b](https://github.com/TTT-2/TTT2/tree/v0.11.3b) (2021-11-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 - Reworked Dropdowns Panel `DComboBoxTTT2` itself
   - `PANEL:AddChoice(title, value, select, icon, data)` now uses the second argument as value string for setting convars, use the fifth argument for special data instead
-  - `PANEL:ChooseOption(value, index, ignoreConVar)` no longer chooses the displayed text, but the underlying value, which also sets conVars
+  - `PANEL:ChooseOption(title, index, ignoreConVar)` is deprecated and no longer chooses the displayed text, only per index
 - Reworked our simplified Dropdowns MakePanel `PANEL:MakeComboBox(data)` version
   - `data.OnChange(value, additionalData, comboBoxPanel)` is now called with the two important arguments at first. They are the value that e.g. convars are set, the additionalData and the Panel
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
   - `PANEL:AddChoice(title, value, select, icon, data)` now uses the second argument as value string for setting convars, use the fifth argument for special data instead
   - `PANEL:ChooseOption(value, index, ignoreConVar)` no longer chooses the displayed text, but the underlying value, which also sets conVars
 - Reworked our simplified Dropdowns MakePanel `PANEL:MakeComboBox(data)` version
-  - `data.OnChange(value, additionalData)` is now only called with the two important arguments, the value that e.g. convars are set and the additionalData 
+  - `data.OnChange(value, additionalData, comboBoxPanel)` is now called with the two important arguments at first. They are the value that e.g. convars are set, the additionalData and the Panel
 
 ## [v0.11.3b](https://github.com/TTT-2/TTT2/tree/v0.11.3b) (2021-11-18)
 

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcombobox_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcombobox_ttt2.lua
@@ -318,7 +318,7 @@ end
 
 ---
 -- @realm client
-function PANEl:CloseMenu()
+function PANEL:CloseMenu()
 	if IsValid(self.menu) then
 		self.menu:Remove()
 		self.menu = nil

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcombobox_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcombobox_ttt2.lua
@@ -336,13 +336,16 @@ function PANEL:SetValue(value, ignoreConVar)
 	self:ChooseOptionValue(value, ignoreConVar)
 end
 
+local convarTracker = 0
 ---
 -- @param Panel menu to set the value of
 -- @param string conVar name of the convar
 local function AddConVarChangeCallback(menu, conVar)
+	convarTracker = convarTracker % 1023 + 1
+
 	local function OnConVarChangeCallback(conVarName, oldValue, newValue)
 		if not IsValid(menu) then
-			cvars.RemoveChangeCallback(conVarName, "TTT2F1MenuConVarChangeCallback")
+			cvars.RemoveChangeCallback(conVarName, "TTT2F1MenuConVarChangeCallback" .. tostring(convarTracker))
 
 			return
 		end
@@ -350,7 +353,7 @@ local function AddConVarChangeCallback(menu, conVar)
 		menu:SetValue(newValue, true)
 	end
 
-	cvars.AddChangeCallback(conVar, OnConVarChangeCallback, "TTT2F1MenuConVarChangeCallback")
+	cvars.AddChangeCallback(conVar, OnConVarChangeCallback, "TTT2F1MenuConVarChangeCallback"  .. tostring(convarTracker))
 end
 
 ---

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcombobox_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcombobox_ttt2.lua
@@ -154,7 +154,7 @@ function PANEL:AddChoice(title, value, select, icon, data)
 	self.valueIndices[value] = index
 
 	if select then
-		self:ChooseOption(nil, index, true)
+		self:ChooseOptionID(index, true)
 	end
 
 	return index
@@ -333,7 +333,7 @@ end
 -- @param bool ignoreConVar To avoid endless loops, separated setting of convars and UI values
 -- @realm client
 function PANEL:SetValue(value, ignoreConVar)
-	self:ChooseOption(value, nil, ignoreConVar)
+	self:ChooseOptionValue(value, ignoreConVar)
 end
 
 ---

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcombobox_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcombobox_ttt2.lua
@@ -33,45 +33,69 @@ function PANEL:Init()
 	self:SetSortItems(true)
 
 	self:SetFont("DermaTTT2Text")
+
+	self.choices = {}
+	self.titleIndices = {}
+	self.valueIndices = {}
 end
 
 ---
 -- @realm client
 function PANEL:Clear()
 	self:SetText("")
+
 	self.choices = {}
-	self.data = {}
-	self.choiceIcons = {}
+	self.titleIndices = {}
+	self.valueIndices = {}
 	self.selected = nil
 
-	if self.menu then
-		self.menu:Remove()
-		self.menu = nil
-	end
+	self:CloseMenu()
 end
 
 ---
--- @param number id
+-- Gets the displayed Text if one is set, otherwise the value like in the original DComboBox
+-- @note this doesnt necessarily get the value used to set conVars, use `PANEL:GetOptionValue(index)` instead
+-- @param number index the option id
 -- @return string
 -- @realm client
-function PANEL:GetOptionText(id)
-	return self.choices[id]
+function PANEL:GetOptionText(index)
+	local choice = self.choices[index]
+
+	if not choice then return end
+
+	return choice.title or choice.value
 end
 
 ---
--- @param string name
+-- @param number index the option id
 -- @return number
 -- @realm client
-function PANEL:GetOptionId(name)
-	return table.KeyFromValue(self.choices, name) or 1
+function PANEL:GetOptionValue(index)
+	return self.choices[index].value
 end
 
 ---
--- @param number id
+-- @param number index the option id
 -- @return any
 -- @realm client
-function PANEL:GetOptionData(id)
-	return self.data[id]
+function PANEL:GetOptionData(index)
+	return self.choices[index].data
+end
+
+---
+-- @param string value
+-- @return number
+-- @realm client
+function PANEL:GetOptionId(value)
+	return self.valueIndices[value] or 1
+end
+
+---
+-- @param string title
+-- @return number
+-- @realm client
+function PANEL:GetOptionTitleId(title)
+	return self.titleIndices[title] or 1
 end
 
 ---
@@ -79,13 +103,18 @@ end
 -- @return any
 -- @realm client
 function PANEL:GetOptionTextByData(data)
-	for id, dat in pairs(self.data) do
-		if dat ~= data and dat ~= tonumber(data) then continue end
+	local choices = self.choices
+	local choicesSize = #choices
 
-		return self:GetOptionText(id)
+	for index = 1, choicesSize do
+		local choiceData = choices[index].data
+
+		if choiceData ~= data and choiceData ~= tonumber(data) then continue end
+
+		return self:GetOptionText(index)
 	end
 
-	return data
+	return
 end
 
 ---
@@ -97,33 +126,59 @@ function PANEL:PerformLayout()
 end
 
 ---
--- @param string value
--- @param number index
+-- Choose either value or index, title is set 
+-- @param[opt] string value
+-- @param[opt] number index the option id
+-- @param[default=false] bool ignoreConVar To avoid endless loops, separated setting of convars and UI values
 -- @realm client
-function PANEL:ChooseOption(value, index)
-	if self.menu then
-		self.menu:Remove()
-		self.menu = nil
+function PANEL:ChooseOption(value, index, ignoreConVar)
+	if not isstring(value) and not isnumber(index) then return end
+
+	if not index then
+		index = self:GetOptionId(value)
+
+		if not isnumber(index) then return end
 	end
 
-	self:SetText(value)
-
 	self.selected = index
-	self:OnSelect(index, value, self.data[index])
+
+	self:SetText(self:GetOptionText(index))
+	self:OnSelect(index, self:GetOptionValue(index), self:GetOptionData(index))
+
+	self:CloseMenu()
+
+	if ignoreConVar then return end
+
+	self:SetConVarValues(value)
 end
 
 ---
--- @param number index
+-- @param number index the option id
+-- @param[default=false] bool ignoreConVar To avoid endless loops, separated setting of convars and UI values
 -- @realm client
-function PANEL:ChooseOptionId(index)
-	self:ChooseOption(self:GetOptionText(index), index)
+function PANEL:ChooseOptionId(index, ignoreConVar)
+	self:ChooseOption(nil, index, ignoreConVar)
 end
 
 ---
--- @param string name
+-- @note this chooses the the set value like in the original DComboBox
+-- @param string value e.g. the value used to set conVars 
+-- @param[default=false] bool ignoreConVar To avoid endless loops, separated setting of convars and UI values
 -- @realm client
-function PANEL:ChooseOptionName(name)
-	self:ChooseOption(name, self:GetOptionId(name))
+function PANEL:ChooseOptionValue(value, ignoreConVar)
+	self:ChooseOption(value, nil, ignoreConVar)
+end
+
+---
+-- @note this chooses the displayed text rather than the set value like in the original DComboBox
+-- So use `PANEL:ChooseOptionValue` for the old behaviour
+-- @param string name the displayed text
+-- @param[default=false] bool ignoreConVar To avoid endless loops, separated setting of convars and UI values
+-- @realm client
+function PANEL:ChooseOptionName(name, ignoreConVar)
+	local index = self:GetOptionTitleId(name)
+
+	self:ChooseOption(nil, index, ignoreConVar)
 end
 
 ---
@@ -134,12 +189,15 @@ function PANEL:GetSelectedId()
 end
 
 ---
--- @return string
+-- @note this returns the set value not the displayed text, like in the combobox
+-- @warning the second return-argument is the additional data that is given not what was before the set value, which is now given in the first return argument
+-- @return string the set value
+-- @return any the additional data if given
 -- @realm client
 function PANEL:GetSelected()
 	if not self.selected then return end
 
-	return self:GetOptionText(self.selected), self:GetOptionData(self.selected)
+	return self:GetOptionValue(self.selected), self:GetOptionData(self.selected)
 end
 
 ---
@@ -152,30 +210,49 @@ function PANEL:OnSelect(index, value, data)
 end
 
 ---
+-- @param string title
 -- @param string value
--- @param any data
--- @param any select
+-- @param bool select
 -- @param string icon
+-- @param any data additional data that you might want to use
 -- @return number index
 -- @realm client
-function PANEL:AddChoice(value, data, select, icon)
-	local i = #self.choices + 1
+function PANEL:AddChoice(title, value, select, icon, data)
+	if not isstring(value) then
+		ErrorNoHalt("[TTT2] dcombobox_ttt2 AddChoice format changed to PANEL:AddChoice(title, value, select, icon, data)\n For any data use the last parameter, value has to be a string.\n")
 
-	self.choices[i] = value
-
-	if data then
-		self.data[i] = data
+		return
 	end
 
-	if icon then
-		self.choiceIcons[i] = icon
-	end
+	local index = #self.choices + 1
+
+	self.choices[index] = {
+		title = title,
+		value = value,
+		icon = icon,
+		data = data
+	}
+
+	-- Index tables for fast access
+	self.titleIndices[title] = index
+	self.valueIndices[value] = index
 
 	if select then
-		self:ChooseOption(value, i)
+		self:ChooseOption(nil, index, true)
 	end
 
-	return i
+	return index
+end
+
+---
+-- @return boolean
+-- @realm client
+function PANEL:DoClick()
+	if self:IsMenuOpen() then
+		self:CloseMenu()
+	end
+
+	self:OpenMenu()
 end
 
 ---
@@ -191,55 +268,45 @@ end
 function PANEL:OpenMenu(pControlOpener)
 	if pControlOpener and pControlOpener == self.TextEntry then return end
 
+	-- Do a table Copy if you want to sort items
+	local sortItems = self:GetSortItems()
+	local choices = sortItems and table.Copy(self.choices) or self.choices
+	local choicesSize = #choices
+
 	-- Don't do anything if there aren't any options..
-	if #self.choices == 0 then return end
+	if choicesSize == 0 then return end
 
 	-- If the menu still exists and hasn't been deleted
-	-- then just close it and don't open a new one.
-	if self.menu then
-		self.menu:Remove()
-		self.menu = nil
-	end
+	-- then just close it and open a new one.
+	self:CloseMenu()
 
 	self.menu = DermaMenu(false, self)
 
-	if self:GetSortItems() then
-		local sorted = {}
+	if sortItems then
+		-- Convert Gmod Strings 
+		for i = 1, choicesSize do
+			local choice = choices[i]
+			local title = choice.title
 
-		for i = 1, #self.choices do
-			local choice = self.choices[i]
-			local val = tostring(choice)
-
-			if string.len(val) > 1 and val:StartWith("#") then
-				val = language.GetPhrase(val:sub(2))
+			if string.len(title) > 1 and title:StartWith("#") then
+				title = language.GetPhrase(title:sub(2))
 			end
 
-			sorted[#sorted + 1] = {
-				id = i,
-				data = choice,
-				label = val
-			}
+			choice.title = title
 		end
 
-		for k, v in SortedPairsByMemberValue(sorted, "label") do
-			local option = self.menu:AddOption(v.data, function()
-				self:ChooseOption(v.data, v.id)
-			end)
+		-- Sort by title
+		table.SortByMember(choices, "title", true)
+	end
 
-			if self.choiceIcons[v.id] then
-				option:SetIcon(self.choiceIcons[v.id])
-			end
-		end
-	else
-		for i = 1, #self.choices do
-			local choice = self.choices[i]
-			local option = self.menu:AddOption(choice, function()
-				self:ChooseOption(choice, i)
-			end)
+	for index = 1, choicesSize do
+		local choice = choices[index]
+		local option = self.menu:AddOption(choice.title, function()
+			self:SetValue(choice.value, false)
+		end)
 
-			if self.choiceIcons[i] then
-				option:SetIcon(self.choiceIcons[i])
-			end
+		if choice.icon then
+			option:SetIcon(choice.icon)
 		end
 	end
 
@@ -251,48 +318,143 @@ end
 
 ---
 -- @realm client
-function PANEL:CloseMenu()
-	if not IsValid(self.menu) then return end
-
-	self.menu:Remove()
+function PANEl:CloseMenu()
+	if IsValid(self.menu) then
+		self.menu:Remove()
+		self.menu = nil
+	end
 end
 
 ---
+-- @warning this doesnt set the displayed text like before, but the value and selects an option
+-- @param string value
+-- @param bool ignoreConVar To avoid endless loops, separated setting of convars and UI values
 -- @realm client
-function PANEL:CheckConVarChanges()
-	if not self.m_strConVar then return end
-
-	local strValue = GetConVar(self.m_strConVar):GetString()
-
-	if self.m_strConVarValue == strValue then return end
-
-	self.m_strConVarValue = strValue
-
-	self:SetValue(self:GetOptionTextByData(self.m_strConVarValue))
+function PANEL:SetValue(value, ignoreConVar)
+	self:ChooseOption(value, nil, ignoreConVar)
 end
 
 ---
--- @ignore
-function PANEL:Think()
-	self:CheckConVarChanges()
-end
+-- @param Panel menu to set the value of
+-- @param string conVar name of the convar
+local function AddConVarChangeCallback(menu, conVar)
+	local function OnConVarChangeCallback(conVarName, oldValue, newValue)
+		if not IsValid(menu) then
+			cvars.RemoveChangeCallback(conVarName, "TTT2F1MenuConVarChangeCallback")
 
----
--- @param string strValue
--- @realm client
-function PANEL:SetValue(strValue)
-	self:SetText(strValue)
-end
+			return
+		end
 
----
--- @return boolean
--- @realm client
-function PANEL:DoClick()
-	if self:IsMenuOpen() then
-		return self:CloseMenu()
+		menu:SetValue(newValue, true)
 	end
 
-	self:OpenMenu()
+	cvars.AddChangeCallback(conVar, OnConVarChangeCallback, "TTT2F1MenuConVarChangeCallback")
 end
+
+---
+-- @param string conVarName
+-- @realm client
+function PANEL:SetConVar(conVarName)
+	if not ConVarExists(conVarName or "") then return end
+
+	local conVar = GetConVar(conVarName)
+	self.conVar = conVar
+
+	self:SetValue(conVar:GetString(), true)
+	self:SetDefaultValue(conVar:GetDefault())
+
+	AddConVarChangeCallback(self, conVarName)
+end
+
+---
+-- @param string conVarName
+-- @realm client
+function PANEL:SetServerConVar(conVarName)
+	if not conVarName or conVarName == "" then return end
+
+	self.serverConVar = conVarName
+
+	cvars.ServerConVarGetValue(conVarName, function (wasSuccess, value, default)
+		if wasSuccess then
+			self:SetValue(value, true)
+			self:SetDefaultValue(default)
+		end
+	end)
+
+	AddConVarChangeCallback(self, conVarName)
+end
+
+---
+-- @param string value
+-- @realm client
+function PANEL:SetConVarValues(value)
+	if self.conVar then
+		self.conVar:SetString(value)
+	end
+
+	if self.serverConVar then
+		cvars.ChangeServerConVar(self.serverConVar, value)
+	end
+end
+
+---
+-- @param string value
+-- @realm client
+function PANEL:SetDefaultValue(value)
+	local noDefault = true
+
+	if isstring(value) then
+		self.default = value
+		noDefault = false
+	else
+		self.default = nil
+	end
+
+	local reset = self:GetResetButton()
+
+	if ispanel(reset) then
+		reset.noDefault = noDefault
+	end
+end
+
+---
+-- @return number defaultValue
+-- @realm client
+function PANEL:GetDefaultValue()
+	return self.default
+end
+
+---
+-- @realm client
+function PANEL:ResetToDefaultValue()
+	local default = self:GetDefaultValue()
+
+	if not default then return end
+
+	self:SetValue(default, false)
+end
+
+---
+-- @param Panel reset
+-- @realm client
+function PANEL:SetResetButton(reset)
+	if not ispanel(reset) then return end
+
+	self.resetButton = reset
+
+	reset.DoClick = function(slf)
+		self:ResetToDefaultValue()
+	end
+
+	reset.noDefault = self.default == nil
+end
+
+---
+-- @return Panel reset
+-- @realm client
+function PANEL:GetResetButton()
+	return self.resetButton
+end
+
 
 derma.DefineControl("DComboBoxTTT2", "", PANEL, "DButtonTTT2")

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcombobox_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcombobox_ttt2.lua
@@ -168,7 +168,7 @@ function PANEL:ChooseOptionID(index, ignoreConVar)
 	local choices = self.choices
 
 	if index > #choices then
-		ErrorNoHalt("[TTT2] PANEL:ChooseOptionId failed, exceeding index size of choices.")
+		ErrorNoHalt("[TTT2] PANEL:ChooseOptionID failed, exceeding index size of choices.")
 
 		return
 	end
@@ -213,7 +213,7 @@ end
 -- @param number index the option id
 -- @param[default=false] bool ignoreConVar To avoid endless loops, separated setting of convars and UI values
 -- @realm client
--- @deprecated Giving titles is not possible anymore. Use `PANEL:ChooseOptionId` instead
+-- @deprecated Giving titles is not possible anymore. Use `PANEL:ChooseOptionID` instead
 function PANEL:ChooseOption(title, index, ignoreConVar)
 	self:ChooseOptionID(index, ignoreConVar)
 end
@@ -221,7 +221,7 @@ end
 ---
 -- @return number
 -- @realm client
-function PANEL:GetSelectedId()
+function PANEL:GetSelectedID()
 	return self.selected
 end
 

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcombobox_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcombobox_ttt2.lua
@@ -342,10 +342,11 @@ local convarTracker = 0
 -- @param string conVar name of the convar
 local function AddConVarChangeCallback(menu, conVar)
 	convarTracker = convarTracker % 1023 + 1
+	local myIdentifierString = "TTT2F1MenuConVarChangeCallback" .. tostring(convarTracker)
 
 	local function OnConVarChangeCallback(conVarName, oldValue, newValue)
 		if not IsValid(menu) then
-			cvars.RemoveChangeCallback(conVarName, "TTT2F1MenuConVarChangeCallback" .. tostring(convarTracker))
+			cvars.RemoveChangeCallback(conVarName, myIdentifierString)
 
 			return
 		end
@@ -353,7 +354,7 @@ local function AddConVarChangeCallback(menu, conVar)
 		menu:SetValue(newValue, true)
 	end
 
-	cvars.AddChangeCallback(conVar, OnConVarChangeCallback, "TTT2F1MenuConVarChangeCallback"  .. tostring(convarTracker))
+	cvars.AddChangeCallback(conVar, OnConVarChangeCallback, myIdentifierString)
 end
 
 ---

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcombobox_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcombobox_ttt2.lua
@@ -68,7 +68,7 @@ end
 
 ---
 -- @param number index the option id
--- @return number
+-- @return string/number a value that is indexable
 -- @realm client
 function PANEL:GetOptionValue(index)
 	return self.choices[index].value
@@ -83,7 +83,7 @@ function PANEL:GetOptionData(index)
 end
 
 ---
--- @param string value
+-- @param string/number value should be indexable
 -- @return number
 -- @realm client
 function PANEL:GetOptionId(value)
@@ -127,15 +127,15 @@ end
 
 ---
 -- @param string title
--- @param string value
+-- @param string/number value should be indexable
 -- @param bool select
 -- @param string icon
 -- @param any data additional data that you might want to use
 -- @return number index
 -- @realm client
 function PANEL:AddChoice(title, value, select, icon, data)
-	if not isstring(value) then
-		ErrorNoHalt("[TTT2] dcombobox_ttt2 AddChoice format changed to PANEL:AddChoice(title, value, select, icon, data)\n For any data use the last parameter, value has to be a string.\n")
+	if istable(value) then
+		ErrorNoHalt("[TTT2] dcombobox_ttt2 AddChoice format changed to PANEL:AddChoice(title, value, select, icon, data)\n For any table data use the last parameter.\n")
 
 		return
 	end
@@ -162,12 +162,12 @@ end
 
 ---
 -- Choose either value or index, title is set 
--- @param[opt] string value
+-- @param[opt] string/number value should be indexable
 -- @param[opt] number index the option id
 -- @param[default=false] bool ignoreConVar To avoid endless loops, separated setting of convars and UI values
 -- @realm client
 function PANEL:ChooseOption(value, index, ignoreConVar)
-	if not isstring(value) and not isnumber(index) then return end
+	if not value and not isnumber(index) then return end
 
 	if not index then
 		index = self:GetOptionId(value)
@@ -184,7 +184,7 @@ function PANEL:ChooseOption(value, index, ignoreConVar)
 
 	if ignoreConVar then return end
 
-	self:SetConVarValues(value)
+	self:SetConVarValues(tostring(value))
 end
 
 ---
@@ -197,7 +197,7 @@ end
 
 ---
 -- @note this chooses the the set value like in the original DComboBox
--- @param string value e.g. the value used to set conVars 
+-- @param string/number value should be indexable e.g. the value used to set conVars 
 -- @param[default=false] bool ignoreConVar To avoid endless loops, separated setting of convars and UI values
 -- @realm client
 function PANEL:ChooseOptionValue(value, ignoreConVar)
@@ -237,7 +237,7 @@ end
 
 ---
 -- @param number index
--- @param string value
+-- @param string/number value is indexable
 -- @param any data
 -- @realm client
 function PANEL:OnSelect(index, value, data)
@@ -327,7 +327,7 @@ end
 
 ---
 -- @warning this doesnt set the displayed text like before, but the value and selects an option
--- @param string value
+-- @param string/number value should be indexable
 -- @param bool ignoreConVar To avoid endless loops, separated setting of convars and UI values
 -- @realm client
 function PANEL:SetValue(value, ignoreConVar)

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcombobox_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcombobox_ttt2.lua
@@ -40,6 +40,14 @@ function PANEL:Init()
 end
 
 ---
+-- @ignore
+function PANEL:PerformLayout()
+	self.DropButton:SetSize(15, 15)
+	self.DropButton:AlignRight(4)
+	self.DropButton:CenterVertical()
+end
+
+---
 -- @realm client
 function PANEL:Clear()
 	self:SetText("")
@@ -86,7 +94,7 @@ end
 -- @param string/number value should be indexable
 -- @return number
 -- @realm client
-function PANEL:GetOptionId(value)
+function PANEL:GetOptionID(value)
 	return self.valueIndices[value] or 1
 end
 
@@ -94,7 +102,7 @@ end
 -- @param string title
 -- @return number
 -- @realm client
-function PANEL:GetOptionTitleId(title)
+function PANEL:GetOptionTitleID(title)
 	return self.titleIndices[title] or 1
 end
 
@@ -115,14 +123,6 @@ function PANEL:GetOptionTextByData(data)
 	end
 
 	return
-end
-
----
--- @ignore
-function PANEL:PerformLayout()
-	self.DropButton:SetSize(15, 15)
-	self.DropButton:AlignRight(4)
-	self.DropButton:CenterVertical()
 end
 
 ---
@@ -161,24 +161,25 @@ function PANEL:AddChoice(title, value, select, icon, data)
 end
 
 ---
--- Choose either value or index, title is set 
--- @param[opt] string/number value should be indexable
--- @param[opt] number index the option id
+-- @param number index the option id
 -- @param[default=false] bool ignoreConVar To avoid endless loops, separated setting of convars and UI values
 -- @realm client
-function PANEL:ChooseOption(value, index, ignoreConVar)
-	if not value and not isnumber(index) then return end
+function PANEL:ChooseOptionID(index, ignoreConVar)
+	local choices = self.choices
 
-	if not index then
-		index = self:GetOptionId(value)
+	if index > #choices then
+		ErrorNoHalt("[TTT2] PANEL:ChooseOptionId failed, exceeding index size of choices.")
 
-		if not isnumber(index) then return end
+		return
 	end
+
+	local choice = choices[index]
+	local value = choice.value
 
 	self.selected = index
 
-	self:SetText(self:GetOptionText(index))
-	self:OnSelect(index, self:GetOptionValue(index), self:GetOptionData(index))
+	self:SetText(choice.title)
+	self:OnSelect(index, value, choice.data)
 
 	self:CloseMenu()
 
@@ -188,20 +189,12 @@ function PANEL:ChooseOption(value, index, ignoreConVar)
 end
 
 ---
--- @param number index the option id
--- @param[default=false] bool ignoreConVar To avoid endless loops, separated setting of convars and UI values
--- @realm client
-function PANEL:ChooseOptionId(index, ignoreConVar)
-	self:ChooseOption(nil, index, ignoreConVar)
-end
-
----
 -- @note this chooses the the set value like in the original DComboBox
 -- @param string/number value should be indexable e.g. the value used to set conVars 
 -- @param[default=false] bool ignoreConVar To avoid endless loops, separated setting of convars and UI values
 -- @realm client
 function PANEL:ChooseOptionValue(value, ignoreConVar)
-	self:ChooseOption(value, nil, ignoreConVar)
+	self:ChooseOptionID(self:GetOptionID(value), ignoreConVar)
 end
 
 ---
@@ -211,9 +204,18 @@ end
 -- @param[default=false] bool ignoreConVar To avoid endless loops, separated setting of convars and UI values
 -- @realm client
 function PANEL:ChooseOptionName(name, ignoreConVar)
-	local index = self:GetOptionTitleId(name)
+	self:ChooseOptionID(self:GetOptionTitleID(name), ignoreConVar)
+end
 
-	self:ChooseOption(nil, index, ignoreConVar)
+---
+-- Choose option by index, title is not settable 
+-- @param[opt] string title is unused as it cant be set anymore
+-- @param number index the option id
+-- @param[default=false] bool ignoreConVar To avoid endless loops, separated setting of convars and UI values
+-- @realm client
+-- @deprecated Giving titles is not possible anymore. Use `PANEL:ChooseOptionId` instead
+function PANEL:ChooseOption(title, index, ignoreConVar)
+	self:ChooseOptionID(index, ignoreConVar)
 end
 
 ---

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcombobox_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcombobox_ttt2.lua
@@ -126,6 +126,41 @@ function PANEL:PerformLayout()
 end
 
 ---
+-- @param string title
+-- @param string value
+-- @param bool select
+-- @param string icon
+-- @param any data additional data that you might want to use
+-- @return number index
+-- @realm client
+function PANEL:AddChoice(title, value, select, icon, data)
+	if not isstring(value) then
+		ErrorNoHalt("[TTT2] dcombobox_ttt2 AddChoice format changed to PANEL:AddChoice(title, value, select, icon, data)\n For any data use the last parameter, value has to be a string.\n")
+
+		return
+	end
+
+	local index = #self.choices + 1
+
+	self.choices[index] = {
+		title = title,
+		value = value,
+		icon = icon,
+		data = data
+	}
+
+	-- Index tables for fast access
+	self.titleIndices[title] = index
+	self.valueIndices[value] = index
+
+	if select then
+		self:ChooseOption(nil, index, true)
+	end
+
+	return index
+end
+
+---
 -- Choose either value or index, title is set 
 -- @param[opt] string value
 -- @param[opt] number index the option id
@@ -207,41 +242,6 @@ end
 -- @realm client
 function PANEL:OnSelect(index, value, data)
 
-end
-
----
--- @param string title
--- @param string value
--- @param bool select
--- @param string icon
--- @param any data additional data that you might want to use
--- @return number index
--- @realm client
-function PANEL:AddChoice(title, value, select, icon, data)
-	if not isstring(value) then
-		ErrorNoHalt("[TTT2] dcombobox_ttt2 AddChoice format changed to PANEL:AddChoice(title, value, select, icon, data)\n For any data use the last parameter, value has to be a string.\n")
-
-		return
-	end
-
-	local index = #self.choices + 1
-
-	self.choices[index] = {
-		title = title,
-		value = value,
-		icon = icon,
-		data = data
-	}
-
-	-- Index tables for fast access
-	self.titleIndices[title] = index
-	self.valueIndices[value] = index
-
-	if select then
-		self:ChooseOption(nil, index, true)
-	end
-
-	return index
 end
 
 ---

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dform_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dform_ttt2.lua
@@ -230,6 +230,7 @@ end
 -- conVar, serverConVar, selectId or selectTitle or selectValue,
 -- function OnChange(value, additionalData), master = { function AddSlave(self, slave) }
 -- }
+-- @note If ConVars are used the values are always strings, so make sure, that you used strings for values, when setting up choices
 -- @return Panel The created combobox
 -- @return Panel The created label
 -- @realm client

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dform_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dform_ttt2.lua
@@ -228,7 +228,7 @@ end
 -- @note Structure of data = {
 -- label, default, choices = { [1] = {title, value, select, icon, additionalData}, [2] = ...},
 -- conVar, serverConVar, selectId or selectTitle or selectValue,
--- function OnChange(value, additionalData), master = { function AddSlave(self, slave) }
+-- function OnChange(value, additionalData, dropDownPanel), master = { function AddSlave(self, slave) }
 -- }
 -- @note If ConVars are used the values are always strings, so make sure, that you used strings for values, when setting up choices
 -- @return Panel The created combobox
@@ -283,7 +283,7 @@ function PANEL:MakeComboBox(data)
 
 	right.OnSelect = function(slf, index, value, additionalData)
 		if data and isfunction(data.OnChange) then
-			data.OnChange(value, additionalData)
+			data.OnChange(value, additionalData, slf)
 		end
 	end
 

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dform_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dform_ttt2.lua
@@ -271,7 +271,7 @@ function PANEL:MakeComboBox(data)
 	right:SetServerConVar(serverConVar)
 
 	-- Only choose an option, if no conVars are set
-	if not isstring(conVar) or not isstring(serverConVar) then
+	if not isstring(conVar) and not isstring(serverConVar) then
 		if data.selectId then
 			right:ChooseOptionId(data.selectId, true)
 		elseif data.selectName or data.selectTitle then

--- a/lua/terrortown/menus/gamemode/administration/hud.lua
+++ b/lua/terrortown/menus/gamemode/administration/hud.lua
@@ -28,7 +28,7 @@ function CLGAMEMODESUBMENU:Populate(parent)
 		choices = validHUDsDefault,
 		selectName = ttt2net.GetGlobal({"hud_manager", "defaultHUD"}) or "None",
 		default = "None",
-		OnChange = function(_, _, value)
+		OnChange = function(value)
 			net.Start("TTT2DefaultHUDRequest")
 			net.WriteString(value == "None" and "" or value)
 			net.SendToServer()
@@ -44,7 +44,7 @@ function CLGAMEMODESUBMENU:Populate(parent)
 		choices = validHUDsRestriction,
 		selectName = ttt2net.GetGlobal({"hud_manager", "forcedHUD"}) or "None",
 		default = "None",
-		OnChange = function(_, _, value)
+		OnChange = function(value)
 			net.Start("TTT2ForceHUDRequest")
 			net.WriteString(value == "None" and "" or value)
 			net.SendToServer()

--- a/lua/terrortown/menus/gamemode/appearance/hudswitcher.lua
+++ b/lua/terrortown/menus/gamemode/appearance/hudswitcher.lua
@@ -105,7 +105,7 @@ function CLGAMEMODESUBMENU:Populate(parent)
 		label = "label_hud_select",
 		choices = validHUDs,
 		selectName = currentHUDName,
-		OnChange = function(_, _, value)
+		OnChange = function(value)
 			HUDManager.SetHUD(value)
 		end,
 		default = ttt2net.GetGlobal({"hud_manager", "defaultHUD"})

--- a/lua/terrortown/menus/gamemode/appearance/vskin.lua
+++ b/lua/terrortown/menus/gamemode/appearance/vskin.lua
@@ -16,7 +16,7 @@ function CLGAMEMODESUBMENU:Populate(parent)
 		label = "label_vskin_select",
 		choices = vskin.GetVSkinList(),
 		selectName = vskin.GetVSkinName(),
-		OnChange = function(_, _, value)
+		OnChange = function(value)
 			vskin.SelectVSkin(value)
 		end,
 		default = vskin.GetDefaultVSkinName()

--- a/lua/terrortown/menus/gamemode/equipment/base_equipment.lua
+++ b/lua/terrortown/menus/gamemode/equipment/base_equipment.lua
@@ -59,8 +59,8 @@ function CLGAMEMODESUBMENU:Populate(parent)
 			if data.subtype == "enum" then
 				option = form:MakeComboBox({
 					label = name,
-					default = TryT(data.lookupNamesFunc(equipment.defaultValues[key])),
-					OnChange = function(_, _, _, enum)
+					default = equipment.defaultValues[key],
+					OnChange = function(enum)
 						net.Start("TTT2SESaveItem")
 						net.WriteString(equipment.id)
 						net.WriteUInt(1, ShopEditor.savingKeysBitCount or 16)

--- a/lua/terrortown/menus/gamemode/language/language.lua
+++ b/lua/terrortown/menus/gamemode/language/language.lua
@@ -26,9 +26,7 @@ function CLGAMEMODESUBMENU:Populate(parent)
 		convar = "ttt_language",
 		choices = choices,
 		OnChange = function(value)
-			if value == "auto" and GetActiveLanguageName() == "auto" then return end
-
-			if value == GetTranslatedLanguageName(GetActiveLanguageName()) then return end
+			if value == GetActiveLanguageName() then return end
 
 			vguihandler.InvalidateVSkin()
 			vguihandler.Rebuild()

--- a/lua/terrortown/menus/gamemode/language/language.lua
+++ b/lua/terrortown/menus/gamemode/language/language.lua
@@ -12,12 +12,21 @@ CLGAMEMODESUBMENU.title = "submenu_language_language_title"
 function CLGAMEMODESUBMENU:Populate(parent)
 	local form = vgui.CreateTTT2Form(parent, "header_language")
 
-	local dlang = form:MakeComboBox({
+	local choices = {}
+	local activeLanguageName = GetActiveLanguageName()
+
+	choices[1] = {title = TryT("lang_server_default"), value = "auto", select = activeLanguageName == "auto"}
+
+	for _, lang in pairs(LANG.GetLanguages()) do
+		choices[#choices + 1] = {title = GetTranslatedLanguageName(lang), value = lang, select =  activeLanguageName == lang}
+	end
+
+	form:MakeComboBox({
 		label = "label_language_set",
 		convar = "ttt_language",
-		OnChange = function(slf, index, value, rawdata)
-
-			if rawdata == "auto" and GetActiveLanguageName() == "auto" then return end
+		choices = choices,
+		OnChange = function(value)
+			if value == "auto" and GetActiveLanguageName() == "auto" then return end
 
 			if value == GetTranslatedLanguageName(GetActiveLanguageName()) then return end
 
@@ -26,21 +35,8 @@ function CLGAMEMODESUBMENU:Populate(parent)
 		end
 	})
 
-	-- since these are no simple strings, the choices have to be added manually
-	dlang:AddChoice(TryT("lang_server_default"), "auto", false)
-
-	for _, lang in pairs(LANG.GetLanguages()) do
-		dlang:AddChoice(GetTranslatedLanguageName(lang), lang, false)
-	end
-
-	if GetActiveLanguageName() == "auto" then
-		dlang:ChooseOptionName(TryT("lang_server_default"))
-	else
-		dlang:ChooseOptionName(GetTranslatedLanguageName(GetActiveLanguageName()))
-	end
-
 	form:MakeHelp({
 		label = "help_lang_info",
-		params = {coverage = math.Round(100 * LANG.GetDefaultCoverage(GetActiveLanguageName()), 1)}
+		params = {coverage = math.Round(100 * LANG.GetDefaultCoverage(activeLanguageName), 1)}
 	})
 end

--- a/lua/terrortown/menus/gamemode/shops/base_shops.lua
+++ b/lua/terrortown/menus/gamemode/shops/base_shops.lua
@@ -14,21 +14,21 @@ CLGAMEMODESUBMENU.priority = 0
 CLGAMEMODESUBMENU.title = ""
 
 function CLGAMEMODESUBMENU:Populate(parent)
-	local roleName = self.roleData.name
+	local myRoleName = self.roleData.name
 	local roleIndex = self.roleData.index
 
 	local form = vgui.CreateTTT2Form(parent, "header_shop_linker")
 
 	local shopLink = form:MakeComboBox({
 		label = "label_shop_linker_set",
-		OnChange = function(_, _, _, rawdata)
-			if ShopEditor.fallback[roleName] == rawdata.name then return end
+		OnChange = function(roleName)
+			if ShopEditor.fallback[myRoleName] == roleName then return end
 
-			ShopEditor.fallback[roleName] = rawdata.name
+			ShopEditor.fallback[myRoleName] = roleName
 
 			net.Start("shopFallback")
 			net.WriteUInt(roleIndex, ROLE_BITS)
-			net.WriteString(rawdata.name)
+			net.WriteString(roleName)
 			net.SendToServer()
 
 			ShopEditor.customShopRefresh = true
@@ -38,25 +38,26 @@ function CLGAMEMODESUBMENU:Populate(parent)
 
 	shopLink:SetSortItems(false)
 
-	ShopEditor.fallback[roleName] = ShopEditor.fallback[roleName] or GetGlobalString("ttt_" .. self.roleData.abbr .. "_shop_fallback")
+	ShopEditor.fallback[myRoleName] = ShopEditor.fallback[myRoleName] or GetGlobalString("ttt_" .. self.roleData.abbr .. "_shop_fallback")
 
-	local fallback = ShopEditor.fallback[roleName]
+	local fallback = ShopEditor.fallback[myRoleName]
+	local iconPlaceholder = nil
 
 	-- Add own data for creating own shop
-	shopLink:AddChoice(TryT("create_own_shop"), self.roleData, fallback == roleName)
+	shopLink:AddChoice(TryT("create_own_shop"), myRoleName, fallback == myRoleName, iconPlaceholder)
 
 	-- Since these are no simple roles, the choices have to be added manually
-	shopLink:AddChoice(TryT("shop_default"), {name = SHOP_UNSET, abbr = "shop_default", color = self.roleData.color}, fallback == SHOP_UNSET)
-	shopLink:AddChoice(TryT("shop_disabled"), {name = SHOP_DISABLED, abbr = "disable", color = self.roleData.color}, fallback == SHOP_DISABLED)
+	shopLink:AddChoice(TryT("shop_default"), SHOP_UNSET, fallback == SHOP_UNSET, iconPlaceholder)
+	shopLink:AddChoice(TryT("shop_disabled"), SHOP_DISABLED, fallback == SHOP_DISABLED, iconPlaceholder)
 
 	for _, roleData in pairs(self.roles) do
 		if roleData.index == ROLE_NONE or roleData.index == roleIndex then continue end
 
-		shopLink:AddChoice(TryT("shop_link") .. ": " .. TryT(roleData.name), roleData, fallback == roleData.name)
+		shopLink:AddChoice(TryT("shop_link") .. ": " .. TryT(roleData.name), roleData.name, fallback == roleData.name, iconPlaceholder)
 	end
 
 	-- Display all items as cards for custom shop if selected and shopFallback is refreshed
-	if fallback ~= roleName or ShopEditor.customShopRefresh then return end
+	if fallback ~= myRoleName or ShopEditor.customShopRefresh then return end
 
 	local sortedEquipmentList = ShopEditor.sortedEquipmentList[GetActiveLanguageName] or {}
 


### PR DESCRIPTION
Okay, Im gonna test those now, but you can already give feedback to the whole restructuring 😄 

Changelog below:
### Added

- Reworked our simplified Dropdowns MakePanel `PANEL:MakeComboBox(data)` version
  - Added possibility to manipulate serverside ConVars with Dropdowns. Just add .serverConvar with the conVarName to the given data similar to .convar
  - .serverConVar and .conVar are also supported
  - data.choices can now be a table containing `{title, value, select, icon, additionalData}`
  - data.selectValue is added, use it instead of data.selectName to choose the value you set
  - data.selectTitle is added and shall replace data.selectName

### Breaking Changes

- Reworked Dropdowns Panel `DComboBoxTTT2` itself
  - `PANEL:AddChoice(title, value, select, icon, data)` now uses the second argument as value string for setting convars, use the fifth argument for special data instead
  - `PANEL:ChooseOption(value, index, ignoreConVar)` no longer chooses the displayed text, but the underlying value, which also sets conVars
- Reworked our simplified Dropdowns MakePanel `PANEL:MakeComboBox(data)` version
  - `data.OnChange(value, additionalData)` is now only called with the two important arguments, the value that e.g. convars are set and the additionalData