### PR TITLE
Voice: Removed Voicerecord Command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ## Unreleased
 
+### Changed
+
 - Updated Japanese translation (by @westooooo)
+- Switched from the voicerecord commands to the GMod permission system due to a recent GMod update breaking the old voice chat
 
 ## [v0.11.3b](https://github.com/TTT-2/TTT2/tree/v0.11.3b) (2021-11-18)
 

--- a/gamemodes/terrortown/gamemode/client/cl_voice.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_voice.lua
@@ -37,7 +37,7 @@ local function VoiceTryEnable()
 
 	if not VOICE.IsSpeaking() and VOICE.CanSpeak() then
 		VOICE.isTeam = false
-		RunConsoleCommand("+voicerecord")
+		permissions.EnableVoiceChat(true)
 
 		return true
 	end
@@ -47,7 +47,7 @@ end
 
 local function VoiceTryDisable()
 	if VOICE.IsSpeaking() and not VOICE.isTeam then
-		RunConsoleCommand("-voicerecord")
+		permissions.EnableVoiceChat(false)
 
 		return true
 	end
@@ -69,10 +69,17 @@ local function VoiceTeamTryEnable()
 	local clientrd = client:GetSubRoleData()
 	local tm = client:GetTeam()
 
-	if not VOICE.IsSpeaking() and VOICE.CanSpeak() and client:IsActive() and tm ~= TEAM_NONE
-	and not TEAMS[tm].alone and not clientrd.unknownTeam and not clientrd.disabledTeamVoice then
+	if not VOICE.IsSpeaking()
+		and VOICE.CanSpeak()
+		and client:IsActive()
+		and tm ~= TEAM_NONE
+		and not TEAMS[tm].alone
+		and not clientrd.unknownTeam
+		and not clientrd.disabledTeamVoice
+	then
 		VOICE.isTeam = true
-		RunConsoleCommand("+voicerecord")
+
+		permissions.EnableVoiceChat(false)
 
 		return true
 	end
@@ -82,7 +89,7 @@ end
 
 local function VoiceTeamTryDisable()
 	if VOICE.IsSpeaking() and VOICE.isTeam then
-		RunConsoleCommand("-voicerecord")
+		permissions.EnableVoiceChat(false)
 
 		return true
 	end
@@ -400,7 +407,7 @@ function VOICE.Tick()
 		if not VOICE.CanSpeak() then
 			client.voice_battery = 0
 
-			RunConsoleCommand("-voicerecord")
+			permissions.EnableVoiceChat(false)
 		end
 	elseif client.voice_battery < VOICE.battery_max then
 		client.voice_battery = client.voice_battery + GetRechargeRate()

--- a/gamemodes/terrortown/gamemode/client/cl_voice.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_voice.lua
@@ -79,7 +79,7 @@ local function VoiceTeamTryEnable()
 	then
 		VOICE.isTeam = true
 
-		permissions.EnableVoiceChat(false)
+		permissions.EnableVoiceChat(true)
 
 		return true
 	end


### PR DESCRIPTION
Fixes #953. I couldn't test this, because I only have bots to test. One thing I noticed was that the global chat opened a UI element, the team chat didn't. I don't know if this is a new bug? But I can't see what is causing this. Might be a good idea to verify this fix before merging.