### PR TITLE
Addon Checker: Added Mounted State Checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ## Unreleased
 
+### Fixed
+
+- Fixed addon compatibility checker fussing over disabled addons
+
 ## [v0.11.4b](https://github.com/TTT-2/TTT2/tree/v0.11.4b) (2021-12-17)
 
 ### Changed

--- a/gamemodes/terrortown/gamemode/server/sv_addonchecker.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_addonchecker.lua
@@ -492,8 +492,9 @@ function addonChecker.Check()
 
 	for i = 1, #addonTable do
 		local addon = addonTable[i]
-		local detectedAddon = addonChecker.curatedList[tostring(addon.wsid)]
+		if not addon.mounted then continue end
 
+		local detectedAddon = addonChecker.curatedList[tostring(addon.wsid)]
 		if not detectedAddon then continue end
 
 		ErrorNoHalt(((detectedAddon.type == ADDON_OUTDATED) and "Outdated add-on detected: " or "Incompatible add-on detected: ") .. addon.title .. "\n")


### PR DESCRIPTION
This fixes the addon compatibility detection so that only enabled/mounted addons are checked against the incompatible list.