### PR TITLE
F1 Menu: Add check for table of valid usergroups for IsAdminMenu access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
   - data.choices can now be a table containing `{title, value, select, icon, additionalData}`
   - data.selectValue is added, use it instead of data.selectName to choose the value you set
   - data.selectTitle is added and shall replace data.selectName
+- `CLGAMEMODEMENU:ShouldShow()` now checks for global table `adminMenuAccess` when `self:IsAdminMenu() == true`
+  - `adminMenuAccess` should contain a list of usergroups that can access admin menus
+  - This table must exist on the client, so ideally it should be kept in its own Lua script (eg. `lua/autorun/client/adminMenuAccess.lua`)
+  - If `adminMenuAccess` does not exist globally, then the function will fallback on `superadmin` as a default value
 
 ### Breaking Changes
 

--- a/lua/terrortown/menus/gamemode/base_gamemodemenu.lua
+++ b/lua/terrortown/menus/gamemode/base_gamemodemenu.lua
@@ -21,7 +21,13 @@ CLGAMEMODEMENU.submenus = {}
 -- @internal
 -- @realm client
 function CLGAMEMODEMENU:ShouldShow()
-	if not LocalPlayer():IsSuperAdmin() and self:IsAdminMenu() then
+	if self:IsAdminMenu() then
+		local adminMenuAccess = adminMenuAccess or {"superadmin"}
+		for _,usergroup in ipairs(adminMenuAccess) do
+			if LocalPlayer():IsUserGroup(usergroup) then
+				return self:HasVisibleSubmenus()
+			end
+		end
 		return false
 	end
 


### PR DESCRIPTION
This change, as the title explains, rewrites `CLGAMEMODEMENU:ShouldShow()` to check if the table `adminMenuAccess` exists globally, when necessary.

`adminMenuAccess` is intended to be a user-created table -- created by the server owner/maintainer/developer/etc. -- containing a list of usergroups permitted to access the gamemode's administration menus, instead of access being restricted solely to `superadmin`.

Said table must exist on the client, so ideally it should be kept in its own Lua script (eg. `lua/autorun/client/adminMenuAccess.lua`).

---

- If true, then the function uses the existing table.
- If false, the function creates the table locally as a fallback, containing only `superadmin`.

---

- If `self:IsAdminMenu() == true`, then iterate through the table of usergroups checking if `LocalPlayer()` is in any of them.
  - Return `self:HasVisibleSubmenus()` succesfully upon finding a valid usergroup.
  - Otherwise return `false`.
- If `self:IsAdminMenu() == false`, then simply return `self:HasVisibleSubmenus()` as normal.

---

Feel free to adjust as necessary, as long as the core purpose remains.