### PR TITLE
Base Ammo Entity: Fix collision bounds blocking +use traces by using trigger bounds instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ### Fixed
 
 - Fixed addon compatibility checker fussing over disabled addons
+- Fixed ammo entities blocking +use traces
 
 ## [v0.11.4b](https://github.com/TTT-2/TTT2/tree/v0.11.4b) (2021-12-17)
 

--- a/gamemodes/terrortown/entities/entities/base_ammo_ttt.lua
+++ b/gamemodes/terrortown/entities/entities/base_ammo_ttt.lua
@@ -36,17 +36,11 @@ function ENT:Initialize()
 
 	self:PhysicsInit(SOLID_VPHYSICS)
 	self:SetMoveType(MOVETYPE_VPHYSICS)
-	self:SetSolid(SOLID_BBOX)
+	self:AddSolidFlags(FSOLID_TRIGGER)
 
 	self:SetCollisionGroup(COLLISION_GROUP_WEAPON)
 
-	local b = 26
-
-	self:SetCollisionBounds(Vector(-b, -b, -b), Vector(b, b, b))
-
-	if SERVER then
-		self:SetTrigger(true)
-	end
+	self:UseTriggerBounds(true, 24)
 
 	self.tickRemoval = false
 	self.AmmoEntMax = self.AmmoAmount


### PR DESCRIPTION
fixes #966