### PR TITLE
Security: Add new GM:TTT2AdminCheck hook, replace all IsSuperAdmin() checks with hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
   - data.selectValue is added, use it instead of data.selectName to choose the value you set
   - data.selectTitle is added and shall replace data.selectName
 - New setting to disable session limits entirely. (by @Reispfannenfresser)
+- Added `GM:TTT2AdminCheck` hook
+  - Replaced all `IsSuperAdmin()` checks with this hook
+  - This hook can be used to allow custom usergroups through these checks
 
 ### Breaking Changes
 

--- a/gamemodes/terrortown/gamemode/server/sv_admin.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_admin.lua
@@ -47,7 +47,9 @@ end
 -- @param Player ply
 -- @realm server
 function PrintTraitors(ply)
-	if not IsValid(ply) or ply:IsSuperAdmin() then
+	---
+	-- @realm server
+	if not IsValid(ply) or hook.Run("TTT2AdminCheck", ply) then
 		ServerLog(Format("%s used ttt_print_traitors\n", IsValid(ply) and ply:Nick() or "console"))
 
 		local pr = GetPrintFn(ply)
@@ -84,7 +86,9 @@ concommand.Add("ttt_print_usergroups", PrintGroups)
 function PrintReport(ply)
 	local pr = GetPrintFn(ply)
 
-	if not IsValid(ply) or ply:IsSuperAdmin() then
+	---
+	-- @realm server
+	if not IsValid(ply) or hook.Run("TTT2AdminCheck", ply) then
 		ServerLog(Format("%s used ttt_print_adminreport\n", IsValid(ply) and ply:Nick() or "console"))
 
 		for _, e in pairs(SCORE.Events) do
@@ -110,7 +114,9 @@ concommand.Add("ttt_print_adminreport", PrintReport)
 local function PrintKarma(ply)
 	local pr = GetPrintFn(ply)
 
-	if not IsValid(ply) or ply:IsSuperAdmin() then
+	---
+	-- @realm server
+	if not IsValid(ply) or hook.Run("TTT2AdminCheck", ply) then
 		ServerLog(Format("%s used ttt_print_karma\n", IsValid(ply) and ply:Nick() or "console"))
 
 		KARMA.PrintAll(pr)
@@ -178,7 +184,9 @@ local dmglog_save = CreateConVar("ttt_damagelog_save", "0", {FCVAR_NOTIFY, FCVAR
 local function PrintDamageLog(ply)
 	local pr = GetPrintFn(ply)
 
-	if not IsValid(ply) or ply:IsSuperAdmin() or GetRoundState() ~= ROUND_ACTIVE then
+	---
+	-- @realm server
+	if not IsValid(ply) or hook.Run("TTT2AdminCheck", ply) or GetRoundState() ~= ROUND_ACTIVE then
 		ServerLog(Format("%s used ttt_print_damagelog\n", IsValid(ply) and ply:Nick() or "console"))
 		pr("*** Damage log:\n")
 

--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -1401,8 +1401,10 @@ hook.Add("PlayerAuthed", "TTT2PlayerAuthedSharedHook", function(ply, steamid, un
 end)
 
 local function ttt_roundrestart(ply, command, args)
+	---
 	-- ply is nil on dedicated server console
-	if not IsValid(ply) or ply:IsAdmin() or ply:IsSuperAdmin() or cvars.Bool("sv_cheats", 0) then
+	-- @realm server
+	if not IsValid(ply) or ply:IsAdmin() or hook.Run("TTT2AdminCheck", ply) or cvars.Bool("sv_cheats", 0) then
 		LANG.Msg("round_restart")
 
 		StopRoundTimers()

--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -1466,8 +1466,10 @@ local function SetPlayerReady(_, ply)
 
 	entspawnscript.TransmitToPlayer(ply)
 
+	---
 	-- update playermodels on the client
-	if ply:IsSuperAdmin() then
+	-- @realm server
+	if hook.Run("TTT2AdminCheck", ply) then
 		playermodels.StreamModelStateToSelectedClients(false, ply)
 	end
 

--- a/gamemodes/terrortown/gamemode/shared/sh_main.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_main.lua
@@ -336,6 +336,18 @@ function GM:TTT2PlayerSprintMultiplier(ply, sprintMultiplierModifier)
 
 end
 
+---
+-- A hook that is called whenever the gamemode needs to check if the player is in the superadmin usergroup.
+-- This hook can be used to allow custom usergroups through these checks.
+-- @note This hook grants access to powerful functionality, such as the gamemode configuration, damage logs and player role information. Only allow usergroups that absolutely need such access.
+-- @param Player ply The player to be checked
+-- @return boolean if the player is a valid usergroup
+-- @hook
+-- @realm shared
+function GM:TTT2AdminCheck(ply)
+	return ply:IsSuperAdmin()
+end
+
 -- Drowning and such
 local tm, ply, plys
 

--- a/lua/terrortown/menus/gamemode/base_gamemodemenu.lua
+++ b/lua/terrortown/menus/gamemode/base_gamemodemenu.lua
@@ -21,7 +21,9 @@ CLGAMEMODEMENU.submenus = {}
 -- @internal
 -- @realm client
 function CLGAMEMODEMENU:ShouldShow()
-	if not LocalPlayer():IsSuperAdmin() and self:IsAdminMenu() then
+	---
+	-- @realm client
+	if self:IsAdminMenu() and not hook.Run("TTT2AdminCheck", LocalPlayer()) then
 		return false
 	end
 

--- a/lua/ttt2/extensions/cvars.lua
+++ b/lua/ttt2/extensions/cvars.lua
@@ -187,7 +187,9 @@ elseif SERVER then
 		local conVarName = net.ReadString()
 		local value = net.ReadString()
 
-		if not IsValid(ply) or not ply:IsSuperAdmin() then return end
+		---
+		-- @realm server
+		if not IsValid(ply) or not hook.Run("TTT2AdminCheck", ply) then return end
 
 		RunConsoleCommand(conVarName, value)
 	end)
@@ -204,7 +206,9 @@ elseif SERVER then
 	net.Receive("TTT2ServerConVarGetValue", function(len, ply)
 		if len < 1 then return end
 
-		local isAdmin = IsValid(ply) and ply:IsSuperAdmin()
+		---
+		-- @realm server
+		local isAdmin = IsValid(ply) and hook.Run("TTT2AdminCheck", ply)
 
 		requestCacheSize = net.ReadUInt(identityBitCount)
 		requestCache = {}

--- a/lua/ttt2/libraries/entspawnscript.lua
+++ b/lua/ttt2/libraries/entspawnscript.lua
@@ -484,7 +484,9 @@ if SERVER then
 		for i = 1, #plys do
 			local ply = plys[i]
 
-			if not ply:IsSuperAdmin() then continue end
+			---
+			-- @realm server
+			if not hook.Run("TTT2AdminCheck", ply) then continue end
 
 			for key, value in pairs(entspawnscript.GetSettings()) do
 				ttt2net.Set({"entspawnscript", "settings", key}, {type = "int", bits = 16}, entspawnscript.GetSetting(key), ply)
@@ -517,7 +519,9 @@ if SERVER then
 		for i = 1, #plys do
 			local ply = plys[i]
 
-			if not ply:IsSuperAdmin() then continue end
+			---
+			-- @realm server
+			if not hook.Run("TTT2AdminCheck", ply) then continue end
 
 			ttt2net.Set({"entspawnscript", "spawnamount", "weapon"}, {type = "int", bits = 16}, amountSpawns[SPAWN_TYPE_WEAPON], ply)
 			ttt2net.Set({"entspawnscript", "spawnamount", "ammo"}, {type = "int", bits = 16}, amountSpawns[SPAWN_TYPE_AMMO], ply)
@@ -1083,43 +1087,57 @@ if SERVER then
 	util.AddNetworkString("ttt2_entspawn_setting_update")
 
 	net.Receive("ttt2_remove_spawn_ent", function(_, ply)
-		if not IsValid(ply) or not ply:IsSuperAdmin() then return end
+		---
+		-- @realm server
+		if not IsValid(ply) or not hook.Run("TTT2AdminCheck", ply) then return end
 
 		entspawnscript.RemoveSpawnById(net.ReadUInt(4), net.ReadUInt(4), net.ReadUInt(32), false, ply)
 	end)
 
 	net.Receive("ttt2_add_spawn_ent", function(_, ply)
-		if not IsValid(ply) or not ply:IsSuperAdmin() then return end
+		---
+		-- @realm server
+		if not IsValid(ply) or not hook.Run("TTT2AdminCheck", ply) then return end
 
 		entspawnscript.AddSpawn(net.ReadUInt(4), net.ReadUInt(4), net.ReadVector(), net.ReadAngle(), net.ReadUInt(8), false, ply)
 	end)
 
 	net.Receive("ttt2_update_spawn_ent", function(_, ply)
-		if not IsValid(ply) or not ply:IsSuperAdmin() then return end
+		---
+		-- @realm server
+		if not IsValid(ply) or not hook.Run("TTT2AdminCheck", ply) then return end
 
 		entspawnscript.UpdateSpawn(net.ReadUInt(4), net.ReadUInt(4), net.ReadUInt(32), net.ReadVector(), net.ReadAngle(), net.ReadUInt(8), false, ply)
 	end)
 
 	net.Receive("ttt2_delete_all_spawns", function(_, ply)
-		if not IsValid(ply) or not ply:IsSuperAdmin() then return end
+		---
+		-- @realm server
+		if not IsValid(ply) or not hook.Run("TTT2AdminCheck", ply) then return end
 
 		entspawnscript.DeleteAllSpawns()
 	end)
 
 	net.Receive("ttt2_entspawn_setting_update", function(_, ply)
-		if not IsValid(ply) or not ply:IsSuperAdmin() then return end
+		---
+		-- @realm server
+		if not IsValid(ply) or not hook.Run("TTT2AdminCheck", ply) then return end
 
 		entspawnscript.SetSetting(net.ReadString(), net.ReadInt(16), net.ReadBool())
 	end)
 
 	net.Receive("ttt2_entspawn_reset", function(_, ply)
-		if not IsValid(ply) or not ply:IsSuperAdmin() then return end
+		---
+		-- @realm server
+		if not IsValid(ply) or not hook.Run("TTT2AdminCheck", ply) then return end
 
 		entspawnscript.ResetMapToDefault()
 	end)
 
 	net.Receive("ttt2_toggle_entspawn_editing", function(_, ply)
-		if not IsValid(ply) or not ply:IsSuperAdmin() then return end
+		---
+		-- @realm server
+		if not IsValid(ply) or not hook.Run("TTT2AdminCheck", ply) then return end
 
 		if net.ReadBool() then
 			entspawnscript.StartEditing(ply)

--- a/lua/ttt2/libraries/playermodels.lua
+++ b/lua/ttt2/libraries/playermodels.lua
@@ -390,7 +390,9 @@ end
 -- @realm server
 function playermodels.StreamModelStateToSelectedClients(onlyChanges, plys)
 	plys = plys or util.GetFilteredPlayers(function(ply)
-		return ply:IsSuperAdmin()
+		---
+		-- @realm server
+		return hook.Run("TTT2AdminCheck", ply)
 	end)
 
 	if not onlyChanges then
@@ -474,13 +476,17 @@ function playermodels.PlayerCanHaveHat(ply)
 end
 
 net.Receive("TTT2UpdatePlayerModel", function(_, ply)
-	if not IsValid(ply) or not ply:IsSuperAdmin() then return end
+	---
+	-- @realm server
+	if not IsValid(ply) or not hook.Run("TTT2AdminCheck", ply) then return end
 
 	playermodels.UpdateModel(net.ReadString(), net.ReadUInt(bitCount), net.ReadBool())
 end)
 
 net.Receive("TTT2ResetPlayerModels", function(_, ply)
-	if not IsValid(ply) or not ply:IsSuperAdmin() then return end
+	---
+	-- @realm server
+	if not IsValid(ply) or not hook.Run("TTT2AdminCheck", ply) then return end
 
 	playermodels.Reset()
 end)


### PR DESCRIPTION
```lua
---
-- A hook that is called whenever the gamemode needs to check if the player is in the superadmin usergroup.
-- This hook can be used to allow custom usergroups through these checks.
-- @note This hook grants access to powerful functionality, such as the gamemode configuration, damage logs and player role information. Only allow usergroups that absolutely need such access.
-- @param Player ply The player to be checked
-- @return boolean if the player is a valid usergroup
-- @hook
-- @realm shared
```

- Hook was added in `sh_main.lua` as it was the best place I could find for such a hook. If anyone else knows of a better spot for it, please tell me.
- Hook will return `ply:IsSuperAdmin()` by default.