### PR TITLE
Fall Damage: Add ConVars to allow customization for server admins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Added `GM:TTT2AdminCheck` hook
   - Replaced all `IsSuperAdmin()` checks with this hook
   - This hook can be used to allow custom usergroups through these checks
+- Added convars to modify how fall damage is applied:
+  - `ttt2_falldmg_enable (default: 1)` toggles whether or not to apply fall damage at all
+  - `ttt2_falldmg_min_velocity (default: 450)` sets the minimum velocity threshold for fall damage to occur
+  - `ttt2_falldmg_exponent (default: 1.75)` sets the exponent to increase fall damage in relation to velocity
+  - All these convars can also be adjusted in the F1->Administration->Player Settings menu
 
 ### Breaking Changes
 

--- a/gamemodes/terrortown/gamemode/server/sv_player.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player.lua
@@ -1003,6 +1003,18 @@ local fallsounds = {
 local fallsounds_count = #fallsounds
 
 ---
+-- @realm server
+local falldmg_enable = CreateConVar("ttt2_falldmg_enable", "1", {FCVAR_NOTIFY, FCVAR_ARCHIVE})
+
+---
+-- @realm server
+local falldmg_min_vel = CreateConVar("ttt2_falldmg_min_velocity", "450", {FCVAR_NOTIFY, FCVAR_ARCHIVE})
+
+---
+-- @realm server
+local falldmg_expo = CreateConVar("ttt2_falldmg_exponent", "1.75", {FCVAR_NOTIFY, FCVAR_ARCHIVE})
+
+---
 -- Called when a @{Player} makes contact with the ground.
 -- @predicted
 -- @param Player ply
@@ -1015,13 +1027,12 @@ local fallsounds_count = #fallsounds
 -- @ref https://wiki.facepunch.com/gmod/GM:OnPlayerHitGround
 -- @local
 function GM:OnPlayerHitGround(ply, in_water, on_floater, speed)
-	if in_water or speed < 450 or not IsValid(ply) then return end
+	if not falldmg_enable:GetBool() or not IsValid(ply) or in_water or speed < falldmg_min_vel:GetInt() then return end
 
 	-- Everything over a threshold hurts you, rising exponentially with speed
-	local damage = math.pow(0.05 * (speed - 420), 1.75)
+	local damage = math.pow(0.05 * (speed - (falldmg_min_vel:GetInt() - 30)), falldmg_expo:GetFloat())
 
-	-- I don't know exactly when on_floater is true, but it's probably when
-	-- landing on something that is in water.
+	-- Halve damage dealt if the impacted object is floating on water
 	if on_floater then
 		damage = damage * 0.5
 	end

--- a/lua/terrortown/lang/en.lua
+++ b/lua/terrortown/lang/en.lua
@@ -1825,3 +1825,15 @@ L.label_sprint_stamina_regeneration = "Stamina regeneration factor"
 L.label_sprint_crosshair = "Show crosshair while sprinting"
 L.label_crowbar_unlocks = "Primary attack can be used as interaction (i.e. unlocking)"
 L.label_crowbar_pushforce = "Crowbar push force"
+
+-- 2022-07-02
+L.header_playersettings_falldmg = "Fall Damage Settings"
+
+L.label_falldmg_enable = "Enable fall damage"
+L.label_falldmg_min_velocity = "Minimum velocity threshold for fall damage to occur"
+L.label_falldmg_exponent = "Exponent to increase fall damage in relation to velocity"
+
+L.help_falldmg_exponent = [[
+This value modifies how exponentially fall damage is increased with the speed the player hits the ground at.
+
+Take care when altering this value. Setting it too high can make even the smallest falls lethal, while setting it too low will allow players to fall from extreme heights and suffer little to no damage.]]

--- a/lua/terrortown/menus/gamemode/administration/playersettings.lua
+++ b/lua/terrortown/menus/gamemode/administration/playersettings.lua
@@ -81,4 +81,33 @@ function CLGAMEMODESUBMENU:Populate(parent)
 		decimal = 0,
 		master = enbReInf
 	})
+
+	local formFallDmg = vgui.CreateTTT2Form(parent, "header_playersettings_falldmg")
+
+	local enbFallDmg = formFallDmg:MakeCheckBox({
+		serverConvar = "ttt2_falldmg_enable",
+		label = "label_falldmg_enable"
+	})
+
+	formFallDmg:MakeSlider({
+		serverConvar = "ttt2_falldmg_min_velocity",
+		label = "label_falldmg_min_velocity",
+		min = 0,
+		max = 1500,
+		decimal = 0,
+		parent = enbFallDmg
+	})
+
+	formFallDmg:MakeHelp({
+		label = "help_falldmg_exponent"
+	})
+
+	formFallDmg:MakeSlider({
+		serverConvar = "ttt2_falldmg_exponent",
+		label = "label_falldmg_exponent",
+		min = 0,
+		max = 5,
+		decimal = 2,
+		parent = enbFallDmg
+	})
 end


### PR DESCRIPTION
- `ttt2_falldmg_enable (default: 1)` toggles whether or not to apply fall damage at all
- `ttt2_falldmg_min_velocity (default: 450)` sets the minimum velocity threshold for fall damage to occur
- `ttt2_falldmg_exponent (default: 1.75)` sets the exponent to increase fall damage in relation to velocity

All ConVars listed above can also be adjusted in the F1 -> Administration -> Player Settings menu.