### PR TITLE
CI: Bump glualint version to 1.21.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 env:
-  GLUALINT_VERSION: 1.17.2
+  GLUALINT_VERSION: 1.21.0
   NEODOC_VERSION: 0.1.4
 
 # Controls when the action will run. Triggers the workflow on push or pull request


### PR DESCRIPTION
The releases up to now feature some sweet additions for github
actions [1] [2].
Additionally in the case of the linux executable it is now statically
built instead of dynamically [3], which might prevent issues from
occurring in the future.

[1] https://github.com/FPtje/GLuaFixer/pull/122
[2] https://github.com/FPtje/GLuaFixer/pull/124
[3] https://github.com/FPtje/GLuaFixer/releases/tag/1.20.1