### PR TITLE
cd: Remove 'concurrency' stanza from deploy job

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,11 +9,6 @@ on:
 jobs:
   deploy-to-dev:
     runs-on: ubuntu-latest
-    # The concurrency group should match the environment name this deploys to.
-    # If set correctly this marks only one deployment on that env as 'active' in the GitHub UI.
-    concurrency:
-      group: histalek-dev-env
-      cancel-in-progress: true
     environment:
       name: histalek-dev-env
       # Sadly a 'steam://connect/<server_domain>' url is not allowed by github


### PR DESCRIPTION
Currently the concurrency leads to a maximum of one active deployment
and one pending deployment.

If a pending deployment already exists and another gets requested the
already existing pending deployment fails. In case of two PRs being
updated this would mean that the PR which is updated first would be
impossible to deploy.

Originally i intended to use the concurrency to prevent a singular PR
from creating multiple pending deployments. While this should still be
possible by using a concurrency group unique to the PR, there is also
the possibility that the default behaviour for deployments on environments
is already doing what i want.
Which is why my current approach is to remove the stanza completely.

Sadly the github documentation on this is severely lacking IMO.