### PR TITLE
Fixed: Spawn editor TargetID not showing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ### Changed
 - Fixed and updated the Chinese translation file (by @sbzlzh)
 
+### Fixed
+- Fixed the spawn editor tool not having a TargetID in some scenarios by always rendering the 'ttt_spawninfo_ent' (by @NickCloudAT)
+
 ## [v0.11.5b](https://github.com/TTT-2/TTT2/tree/v0.11.5b) (2022-08-05)
 
 ### Added

--- a/gamemodes/terrortown/entities/entities/ttt_spawninfo_ent.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_spawninfo_ent.lua
@@ -9,3 +9,8 @@ end
 
 ENT.Type = "anim"
 ENT.Base = "base_anim"
+
+-- @realm server
+function ENT:UpdateTransmitState()
+	return TRANSMIT_ALWAYS
+end


### PR DESCRIPTION
Fixed the spawn editor TargetID not showing by always rendering the "ttt_spawninfo_ent" Entity.

The Added function will now always render the entity for players, not only when needed. Without this, the entity gets culled and the TargetID stops working.