### PR TITLE
cd: Fix `deploy-to-dev` workflow not running on PRs from forks

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,6 +2,8 @@ name: CD
 
 # Run on Pull Requests to master and on manual interaction
 on:
+  pull_request_target:
+    branches: [ master ]
   pull_request:
     branches: [ master ]
   workflow_dispatch:
@@ -15,6 +17,8 @@ jobs:
       # Current workaround is a 'redirect webpage' on GitHub Pages
       # Ref. https://github.com/TTT-2/ttt-2.github.io
       url: https://ttt-2.github.io/redirect/ttt2-dev-env
+    permissions:
+      contents: read
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
The key difference here is that `pull_request` only allows PRs originating from branches of the original repository to access secrets while `pull_request_target` also allows this for PRs originating from forked repositories.

While this is potentially unsafe [1] (which i was aware of when i first added the cd workflow with the intentation that this would already work) it is safeguarded by someone having to manually approve the workflow run (currently only myself).

Using the `permissions` keyword [2] should allow to limit the scope further without restricting the access to the secrets. (At least i hope this is the case, because the github documentation is rather unclear on this IMO).

[1] https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

[2] https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#overview