### PR TITLE
guide: Add placeholder text to empty panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed and updated the Chinese translation file (by @sbzlzh)
 - Updated Japanese translation (by @westooooo)
 - Updated Simplified and Traditional Chinese (by @TEGTianFan)
+- Add placeholder message to gameplay pages (F1 Menu)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed and updated the Chinese translation file (by @sbzlzh)
 - Updated Japanese translation (by @westooooo)
 - Updated Simplified and Traditional Chinese (by @TEGTianFan)
-- Add placeholder message to gameplay pages (F1 Menu)
+- Add placeholder message to the ingame ttt2 guide (F1 Menu)
 
 ### Fixed
 

--- a/lua/terrortown/menus/gamemode/guide/equipment.lua
+++ b/lua/terrortown/menus/gamemode/guide/equipment.lua
@@ -1,10 +1,20 @@
 --- @ignore
 
 CLGAMEMODESUBMENU.base = "base_gamemodesubmenu"
-
 CLGAMEMODESUBMENU.priority = 98
 CLGAMEMODESUBMENU.title = "submenu_guide_equipment_title"
 
 function CLGAMEMODESUBMENU:Populate(parent)
+	local line1 = vgui.Create( "DLabel", parent )
+	line1:SetPos( 40, 40 )
+	line1:SetFont("DermaLarge")
+	line1:SetText( "Nothing here yet!" )
+	line1:SizeToContents()
 
+	local line2 = vgui.Create( "DLabel", parent )
+	line2:SetPos( 40, 40 )
+	line2:MoveBelow( line1, 10)
+	line2:SetFont("Trebuchet24")
+	line2:SetText( "This is work in progress, help us by contributing to the project on GitHub." )
+	line2:SizeToContents()
 end

--- a/lua/terrortown/menus/gamemode/guide/equipment.lua
+++ b/lua/terrortown/menus/gamemode/guide/equipment.lua
@@ -5,16 +5,16 @@ CLGAMEMODESUBMENU.priority = 98
 CLGAMEMODESUBMENU.title = "submenu_guide_equipment_title"
 
 function CLGAMEMODESUBMENU:Populate(parent)
-	local line1 = vgui.Create( "DLabel", parent )
-	line1:SetPos( 40, 40 )
+	local line1 = vgui.Create("DLabel", parent)
+	line1:SetPos(40, 40)
 	line1:SetFont("DermaLarge")
-	line1:SetText( "Nothing here yet!" )
+	line1:SetText("Nothing here yet!")
 	line1:SizeToContents()
 
-	local line2 = vgui.Create( "DLabel", parent )
-	line2:SetPos( 40, 40 )
-	line2:MoveBelow( line1, 10)
+	local line2 = vgui.Create("DLabel", parent)
+	line2:SetPos(40, 40)
+	line2:MoveBelow(line1, 10)
 	line2:SetFont("Trebuchet24")
-	line2:SetText( "This is work in progress, help us by contributing to the project on GitHub." )
+	line2:SetText("This is work in progress, help us by contributing to the project on GitHub.")
 	line2:SizeToContents()
 end

--- a/lua/terrortown/menus/gamemode/guide/gameplay.lua
+++ b/lua/terrortown/menus/gamemode/guide/gameplay.lua
@@ -6,16 +6,16 @@ CLGAMEMODESUBMENU.priority = 100
 CLGAMEMODESUBMENU.title = "submenu_guide_gameplay_title"
 
 function CLGAMEMODESUBMENU:Populate(parent)
-	local line1 = vgui.Create( "DLabel", parent )
-	line1:SetPos( 40, 40 )
+	local line1 = vgui.Create("DLabel", parent)
+	line1:SetPos(40, 40)
 	line1:SetFont("DermaLarge")
-	line1:SetText( "Nothing here yet!" )
+	line1:SetText("Nothing here yet!")
 	line1:SizeToContents()
 
-	local line2 = vgui.Create( "DLabel", parent )
-	line2:SetPos( 40, 40 )
-	line2:MoveBelow( line1, 10)
+	local line2 = vgui.Create("DLabel", parent)
+	line2:SetPos(40, 40)
+	line2:MoveBelow(line1, 10)
 	line2:SetFont("Trebuchet24")
-	line2:SetText( "This is work in progress, help us by contributing to the project on GitHub." )
+	line2:SetText("This is work in progress, help us by contributing to the project on GitHub.")
 	line2:SizeToContents()
 end

--- a/lua/terrortown/menus/gamemode/guide/gameplay.lua
+++ b/lua/terrortown/menus/gamemode/guide/gameplay.lua
@@ -6,5 +6,16 @@ CLGAMEMODESUBMENU.priority = 100
 CLGAMEMODESUBMENU.title = "submenu_guide_gameplay_title"
 
 function CLGAMEMODESUBMENU:Populate(parent)
+	local line1 = vgui.Create( "DLabel", parent )
+	line1:SetPos( 40, 40 )
+	line1:SetFont("DermaLarge")
+	line1:SetText( "Nothing here yet!" )
+	line1:SizeToContents()
 
+	local line2 = vgui.Create( "DLabel", parent )
+	line2:SetPos( 40, 40 )
+	line2:MoveBelow( line1, 10)
+	line2:SetFont("Trebuchet24")
+	line2:SetText( "This is work in progress, help us by contributing to the project on GitHub." )
+	line2:SizeToContents()
 end

--- a/lua/terrortown/menus/gamemode/guide/roles.lua
+++ b/lua/terrortown/menus/gamemode/guide/roles.lua
@@ -6,16 +6,16 @@ CLGAMEMODESUBMENU.priority = 99
 CLGAMEMODESUBMENU.title = "submenu_guide_roles_title"
 
 function CLGAMEMODESUBMENU:Populate(parent)
-	local line1 = vgui.Create( "DLabel", parent )
-	line1:SetPos( 40, 40 )
+	local line1 = vgui.Create("DLabel", parent)
+	line1:SetPos(40, 40)
 	line1:SetFont("DermaLarge")
-	line1:SetText( "Nothing here yet!" )
+	line1:SetText("Nothing here yet!")
 	line1:SizeToContents()
 
-	local line2 = vgui.Create( "DLabel", parent )
-	line2:SetPos( 40, 40 )
-	line2:MoveBelow( line1, 10)
+	local line2 = vgui.Create("DLabel", parent)
+	line2:SetPos(40, 40)
+	line2:MoveBelow(line1, 10)
 	line2:SetFont("Trebuchet24")
-	line2:SetText( "This is work in progress, help us by contributing to the project on GitHub." )
+	line2:SetText("This is work in progress, help us by contributing to the project on GitHub.")
 	line2:SizeToContents()
 end

--- a/lua/terrortown/menus/gamemode/guide/roles.lua
+++ b/lua/terrortown/menus/gamemode/guide/roles.lua
@@ -6,5 +6,16 @@ CLGAMEMODESUBMENU.priority = 99
 CLGAMEMODESUBMENU.title = "submenu_guide_roles_title"
 
 function CLGAMEMODESUBMENU:Populate(parent)
+	local line1 = vgui.Create( "DLabel", parent )
+	line1:SetPos( 40, 40 )
+	line1:SetFont("DermaLarge")
+	line1:SetText( "Nothing here yet!" )
+	line1:SizeToContents()
 
+	local line2 = vgui.Create( "DLabel", parent )
+	line2:SetPos( 40, 40 )
+	line2:MoveBelow( line1, 10)
+	line2:SetFont("Trebuchet24")
+	line2:SetText( "This is work in progress, help us by contributing to the project on GitHub." )
+	line2:SizeToContents()
 end


### PR DESCRIPTION
This change adds a small message to inform players, that the content here is still missing and we are happy about contributions. 

This should avoid users getting confused when seeing empty panels.