### PR TITLE
SWEPs: Slight fixes to weapon_tttbase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ## Unreleased
 
-### Fixed
+### Changed
 
-- Slight fixes to `weapon_tttbase`:
-  - Removed `SWEP.IronSightTime` as it lacked any use within the gamemode, and was redundant as ironsight times are already managed with networked data tables
-  - Fixed `SWEP.IronSightPos` to `SWEP.IronSightsPos` for both a) consistency with literally every other SWEP and function using the latter variable names, and b) because it was breaking the ironsights of any SWEP trying to use the default values inherited from `weapon_tttbase`.
+- `weapon_tttbase`:
+  - Removal of `SWEP.IronSightsTime` as it was completely unused and conflicts with a networked value intended for the same purpose
+  - Commented-out default values for `SWEP.IronSightsPos` and `SWEP.IronSightsAng` to match vanilla TTT behaviour
+    - SWEPs can still use these names as normal, they just don't have a base value to inherit anymore
 
 ## [v0.11.6b](https://github.com/TTT-2/TTT2/tree/v0.11.6b) (2022-09-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ### Fixed
 
-- Fixed `SWEP.IronSightTime` and `SWEP.IronSightPos` to `SWEP.IronSightsTime` and `SWEP.IronSightsPos`, respectively, within `weapon_tttbase`
-  - This change was made for a) consistency with every other SWEP using the latter variable names, and b) because it was breaking the ironsights of any SWEP trying to use the values inherited from `weapon_tttbase`
+- Slight fixes to `weapon_tttbase`:
+  - Removed `SWEP.IronSightTime` as it lacked any use within the gamemode, and was redundant as ironsight times are already managed with networked data tables
+  - Fixed `SWEP.IronSightPos` to `SWEP.IronSightsPos` for both a) consistency with literally every other SWEP and function using the latter variable names, and b) because it was breaking the ironsights of any SWEP trying to use the default values inherited from `weapon_tttbase`.
 
 ## [v0.11.6b](https://github.com/TTT-2/TTT2/tree/v0.11.6b) (2022-09-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ## Unreleased
 
+### Fixed
+
+- Fixed `SWEP.IronSightTime` and `SWEP.IronSightPos` to `SWEP.IronSightsTime` and `SWEP.IronSightsPos`, respectively, within `weapon_tttbase`
+  - This change was made for a) consistency with every other SWEP using the latter variable names, and b) because it was breaking the ironsights of any SWEP trying to use the values inherited from `weapon_tttbase`
+
 ## [v0.11.6b](https://github.com/TTT-2/TTT2/tree/v0.11.6b) (2022-09-25)
 
 ### Changed

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -161,10 +161,12 @@ SWEP.ReloadAnim = ACT_VM_RELOAD
 
 SWEP.fingerprints = {}
 
--- The position offset applied when entering the ironsight
-SWEP.IronSightsPos = Vector(0, 0, 0)
--- The rotational offset applied when entering the ironsight
-SWEP.IronSightsAng = Vector(0, 0, 0)
+--[[
+	-- The position offset applied when entering the ironsight
+	SWEP.IronSightsPos = Vector(0, 0, 0)
+	-- The rotational offset applied when entering the ironsight
+	SWEP.IronSightsAng = Vector(0, 0, 0)
+--]]
 
 local skipWeapons = {}
 

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -162,9 +162,9 @@ SWEP.ReloadAnim = ACT_VM_RELOAD
 SWEP.fingerprints = {}
 
 -- Time needed to enter / leave the ironsight in seconds
-SWEP.IronSightTime = 0.25
+SWEP.IronSightsTime = 0.25
 -- The position offset applied when entering the ironsight
-SWEP.IronSightPos = Vector(0, 0, 0)
+SWEP.IronSightsPos = Vector(0, 0, 0)
 -- The rotational offset applied when entering the ironsight
 SWEP.IronSightsAng = Vector(0, 0, 0)
 

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -161,8 +161,6 @@ SWEP.ReloadAnim = ACT_VM_RELOAD
 
 SWEP.fingerprints = {}
 
--- Time needed to enter / leave the ironsight in seconds
-SWEP.IronSightsTime = 0.25
 -- The position offset applied when entering the ironsight
 SWEP.IronSightsPos = Vector(0, 0, 0)
 -- The rotational offset applied when entering the ironsight


### PR DESCRIPTION
- Removed `SWEP.IronSightTime` as it lacked any use within the gamemode, and was redundant as ironsight times are already managed with networked data tables
- Fixed `SWEP.IronSightPos` to `SWEP.IronSightsPos` for both a) consistency with literally every other SWEP and function using the latter variable names, and b) because it was breaking the ironsights of any SWEP trying to use the default values inherited from `weapon_tttbase`.