### PR TITLE
fix ttt_quickslot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed hotreload of TTT2 roles library by a fresh reinitialization
 - Fixed a wrong localization line call in roles.lua (by @Satton2)
 - Fixed +zoom bind
+- Fixed ttt_quickslot command
 
 ## [v0.11.6b](https://github.com/TTT-2/TTT2/tree/v0.11.6b) (2022-09-25)
 

--- a/gamemodes/terrortown/gamemode/client/cl_wepswitch.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_wepswitch.lua
@@ -256,13 +256,13 @@ end
 local function QuickSlot(ply, cmd, args)
 	if not IsValid(ply) or not args or #args ~= 1 then return end
 
-	local slot = tonumber(args)
+	local slot = tonumber(args[1])
 	if not slot then return end
 
 	local wep = ply:GetActiveWeapon()
 	if not IsValid(wep) then return end
 
-	if MakeKindValid(wep.Kind) == slot - 1 then
+	if MakeKindValid(wep.Kind) == slot then
 		RunConsoleCommand("lastinv")
 	else
 		WSWITCH:SelectAndConfirm(slot)


### PR DESCRIPTION
ttt_quickslot did not work previously.
QuickSlot wrongly tried to convert the args table to a number.
There was also a mix up between slots and weapon kinds: The current weapon kind is already the same as the displayed number, no need to subtract 1 from user input.