### PR TITLE
ci: Update actions and glualint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 env:
-  GLUALINT_VERSION: 1.21.0
+  GLUALINT_VERSION: 1.24.1
   NEODOC_VERSION: 0.1.4
 
 # Controls when the action will run. Triggers the workflow on push or pull request
@@ -20,11 +20,11 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Download & extract glualint
       run: |
-        wget -c https://github.com/FPtje/GLuaFixer/releases/download/${GLUALINT_VERSION}/glualint-${GLUALINT_VERSION}-linux.zip -O glualint.zip
+        wget -c https://github.com/FPtje/GLuaFixer/releases/download/${GLUALINT_VERSION}/glualint-${GLUALINT_VERSION}-x86_64-linux.zip -O glualint.zip
         unzip -u glualint.zip
         rm glualint.zip
 
@@ -37,7 +37,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Setup .NET Core
       run: sudo apt-get install -y mono-complete

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 env:
-  GLUALINT_VERSION: 1.24.1
+  GLUALINT_VERSION: 1.24.2
   NEODOC_VERSION: 0.1.4
 
 # Controls when the action will run. Triggers the workflow on push or pull request

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,4 +11,4 @@ jobs:
     - uses: dangoslen/changelog-enforcer@v3
       with:
         changeLogPath: 'CHANGELOG.md'
-        skipLabels: 'skip/changelog'
+        skipLabels: 'skip-changelog'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,12 +4,11 @@ on:
       types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 jobs:
-  # Enforces the update of a changelog file on every pull request 
+  # Enforces the update of a changelog file on every pull request
   changelog:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: dangoslen/changelog-enforcer@v1.0.0
+    - uses: dangoslen/changelog-enforcer@v3
       with:
         changeLogPath: 'CHANGELOG.md'
-        skipLabel: 'skip/changelog'
+        skipLabels: 'skip/changelog'


### PR DESCRIPTION
Github deprecated support for actions that run on node.js 12 [1]. So we update the affected actions to a version that uses node.js 16.

Glualint was also some versions behind so i've updated it as well, including the changed download url.

[1] https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/