### PR TITLE
cd: Remove dev deployment on pull requests

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,34 +1,34 @@
-name: CD
-
-# Run on Pull Requests to master and on manual interaction
-on:
-  pull_request_target:
-    branches: [ master ]
-  workflow_dispatch:
-
-jobs:
-  deploy-to-dev:
-    runs-on: ubuntu-latest
-    environment:
-      name: histalek-dev-env
-      # Sadly a 'steam://connect/<server_domain>' url is not allowed by github
-      # Current workaround is a 'redirect webpage' on GitHub Pages
-      # Ref. https://github.com/TTT-2/ttt-2.github.io
-      url: https://ttt-2.github.io/redirect/ttt2-dev-env
-    permissions:
-      contents: read
-
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: rsync deployments
-      uses: burnett01/rsync-deployments@5.2
-      with:
-        switches: -avzr --delete
-        # The path should end in a directory in the garrysmod addons directory
-        # e.g. <garrysmod_install_dir>/garrysmod/addons/ttt2
-        remote_path: ${{ secrets.DEPLOY_PATH }}
-        remote_host: ${{ secrets.DEPLOY_HOST }}
-        remote_port: ${{ secrets.DEPLOY_PORT }}
-        remote_user: ${{ secrets.DEPLOY_USER }}
-        remote_key: ${{ secrets.DEPLOY_KEY }}
+# name: CD
+#
+# # Run on Pull Requests to master and on manual interaction
+# on:
+#   pull_request_target:
+#     branches: [ master ]
+#   workflow_dispatch:
+#
+# jobs:
+#   deploy-to-dev:
+#     runs-on: ubuntu-latest
+#     environment:
+#       name: histalek-dev-env
+#       # Sadly a 'steam://connect/<server_domain>' url is not allowed by github
+#       # Current workaround is a 'redirect webpage' on GitHub Pages
+#       # Ref. https://github.com/TTT-2/ttt-2.github.io
+#       url: https://ttt-2.github.io/redirect/ttt2-dev-env
+#     permissions:
+#       contents: read
+#
+#     steps:
+#     - uses: actions/checkout@v3
+#
+#     - name: rsync deployments
+#       uses: burnett01/rsync-deployments@5.2
+#       with:
+#         switches: -avzr --delete
+#         # The path should end in a directory in the garrysmod addons directory
+#         # e.g. <garrysmod_install_dir>/garrysmod/addons/ttt2
+#         remote_path: ${{ secrets.DEPLOY_PATH }}
+#         remote_host: ${{ secrets.DEPLOY_HOST }}
+#         remote_port: ${{ secrets.DEPLOY_PORT }}
+#         remote_user: ${{ secrets.DEPLOY_USER }}
+#         remote_key: ${{ secrets.DEPLOY_KEY }}


### PR DESCRIPTION
While this was certainly good to try out for a bit it certainly had multiple problems. Which i want to touch upon.

Before that, the reason for not removing the workflow file completely is to keep this as a reference if we want to use this in the future for maybe deploying the master branch on our public testserver.

Now to the problems:

1. I was the only one actually using this. That is fine, but this way it makes sense to (semi)automate this differently. Which i have done now (not public, sorry).

2. The way this deploys the pull request branch is not super resistent against my tinkering on that server and has broken before. Not that much of a problem but leading to a failed workflow on the PR which brings me to my third point.

3. Terrible user experience for contributors who are opening a PR. Until i have approved the deployment (see point 4.) the PR will display a 'yellow' waiting workflow, which might make people believe there is something wrong when there isn't. Also as i have said in point 2, if something went wrong with the deployment the workflow would got 'red' further implicating something wrong with the PR when in fact it is the deployment.

4. Bad user experience for myself (and other people i could have given access). For security reasons every deployment needs to be approved so nobody can push malicious code to the dev server. This leads to a multitude of GitHub notifications as every commit triggers a possible deployment and therefore a request for approvement. I wish GitHub would add a way to more easily trigger such a job on demand e.g. on the PR itself. AFAIK currently manually running such a workflow needs the branch of the PR to be in the main repo, which isn't the case for external contributions. (Currently manually deploying means 'Actions'-Tab -> Click on the Workflow -> 'Run Workflow' -> choosing a branch)

If we decide to use this for the master branch in the future, points 1,3 and 4 wouldn't apply and point might be way less frequent or we could try to make this more resilient against some failures.