### PR TITLE
Damage Scaling added to Equipment's Balance Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Added a new font in default_skin.lua to fit the localization (by @Satton2)
 - Fixed knife death effect being permanently applied on every following death
 - Added `PANEL:MakeTextEntry(data)` to `DFormTTT2` for strings or string-backed cvars (by @EntranceJew)
+- Added `damageScaling` property to `weapon_tttbase`, adjustable per item via "Balance Settings" under "Edit Equipment" in the F1 Menu (by @EntranceJew)
 
 ### Changed
 

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -641,7 +641,7 @@ function SWEP:ShootBullet(dmg, recoil, numbul, cone)
 	bullet.Tracer = 4
 	bullet.TracerName = self.Tracer or "Tracer"
 	bullet.Force = 10
-	bullet.Damage = dmg
+	bullet.Damage = dmg * (self.damageScaling or 1)
 
 	if CLIENT and sparkle:GetBool() then
 		bullet.Callback = Sparklies

--- a/gamemodes/terrortown/gamemode/shared/sh_shopeditor.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_shopeditor.lua
@@ -124,6 +124,20 @@ ShopEditor.savingKeys = {
 		b_desc = false,
 		showForItem = true,
 		master = "notBuyable"
+	},
+	damageScaling = {
+		group = 3,
+		order = 100,
+		typ = "float",
+		bits = 8,
+		default = 1,
+		min = 0,
+		max = 8,
+		decimal = 2,
+		name = "damage_scaling",
+		b_desc = false,
+		showForItem = true,
+		master = nil
 	}
 }
 
@@ -192,7 +206,7 @@ local function getDefaultValue(item, key, data)
 		return entspawnscript.GetSpawnTypeFromKind(item.Kind) or data.default or WEAPON_TYPE_SPECIAL
 	end
 
-	if data.typ == "number" then
+	if data.typ == "number" or data.typ == "float" then
 		return data.default or 0
 	elseif data.typ == "bool" then
 		 return data.default or false
@@ -240,6 +254,8 @@ function ShopEditor.WriteItemData(messageName, name, item, plys)
 
 		if data.typ == "number" then
 			net.WriteUInt(item[key], data.bits or 16)
+		elseif data.typ == "float" then
+			net.WriteFloat(data.decimal and math.Round(item[key], data.decimal or 0) or item[key])
 		elseif data.typ == "bool" then
 			net.WriteBool(item[key])
 		else
@@ -290,6 +306,8 @@ function ShopEditor.ReadItemData()
 
 		if data.typ == "number" then
 			equip[key] = net.ReadUInt(data.bits or 16)
+		elseif data.typ == "float" then
+			equip[key] = net.ReadFloat()
 		elseif data.typ == "bool" then
 			equip[key] = net.ReadBool()
 		else

--- a/gamemodes/terrortown/gamemode/shared/sh_sql.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_sql.lua
@@ -30,7 +30,7 @@ function sql.GetParsedData(key, data, res)
 		return nil
 	end
 
-	if data.typ == "number" then
+	if data.typ == "number" or data.typ == "float" then
 		val = tonumber(val)
 	elseif data.typ == "bool" then
 		val = val == "1"
@@ -128,6 +128,8 @@ function sql.ParseDataString(key, data)
 
 	if data.typ == "bool" or data.typ == "number" then
 		return sanitizedKey .. " INTEGER"
+	elseif data.typ == "float" then
+		return sanitizedKey .. " REAL"
 	elseif data.typ == "pos" then
 		return sanitizedKey .. "_x INTEGER," .. sanitizedKey .. "_y INTEGER"
 	elseif data.typ == "size" then

--- a/lua/terrortown/lang/en.lua
+++ b/lua/terrortown/lang/en.lua
@@ -1860,3 +1860,6 @@ L.sb_rank_tooltip_heroes = "TTT2 Heroes"
 L.sb_rank_tooltip_team = "Team"
 
 L.tbut_adminarea = "ADMIN AREA:"
+
+-- 2023-08-10
+L.equipmenteditor_name_damage_scaling = "Damage Scaling"

--- a/lua/terrortown/menus/gamemode/administration/randomshop.lua
+++ b/lua/terrortown/menus/gamemode/administration/randomshop.lua
@@ -26,7 +26,7 @@ function CLGAMEMODESUBMENU:Populate(parent)
 				default = data.default,
 				serverConvar = convarName
 			})
-		elseif data.typ == "number" then
+		elseif data.typ == "number" or data.typ == "float" then
 			if data.b_desc then
 				form2:MakeHelp({
 					label = desc
@@ -37,7 +37,7 @@ function CLGAMEMODESUBMENU:Populate(parent)
 				label = name,
 				min = data.min,
 				max = data.max,
-				decimal = 0,
+				decimal = data.decimal or 0,
 				default = data.default,
 				serverConvar = convarName
 			})

--- a/lua/terrortown/menus/gamemode/equipment/base_equipment.lua
+++ b/lua/terrortown/menus/gamemode/equipment/base_equipment.lua
@@ -55,6 +55,24 @@ function CLGAMEMODESUBMENU:Populate(parent)
 				end,
 				master = data.master and masterRefs[data.master]
 			})
+		elseif data.typ == "float" then
+			option = form:MakeSlider({
+				label = name,
+				min = data.min,
+				max = data.max,
+				decimal = data.decimal,
+				default = equipment.defaultValues[key],
+				initial = equipment[key],
+				OnChange = function(_, value)
+					net.Start("TTT2SESaveItem")
+					net.WriteString(equipment.id)
+					net.WriteUInt(1, ShopEditor.savingKeysBitCount or 16)
+					net.WriteString(key)
+					net.WriteFloat(value)
+					net.SendToServer()
+				end,
+				master = data.master and masterRefs[data.master]
+			})
 		elseif data.typ == "number" then
 			if data.subtype == "enum" then
 				option = form:MakeComboBox({

--- a/lua/ttt2/libraries/database.lua
+++ b/lua/ttt2/libraries/database.lua
@@ -358,7 +358,7 @@ local function ConvertValueWithKey(value, accessName, key)
 
 	if data.typ == "bool" then
 		value = tobool(value)
-	elseif data.typ == "number" then
+	elseif data.typ == "number" or data.typ == "float" then
 		value = tonumber(value)
 	end
 


### PR DESCRIPTION
- adds a new data type "float" for the network
- adds a new data type "float" backed by REAL for SQLite
- adds a new data type "float" for the options
- decimal handling optional
- changes randomshop also but nothing there uses it, for parity

![image](https://github.com/TTT-2/TTT2/assets/5711436/b0f373b0-afa8-4493-99e5-10b57e71e9b1)
![image](https://github.com/TTT-2/TTT2/assets/5711436/8f6026e4-27e4-4d08-b829-a953f6748f30)
![image](https://github.com/TTT-2/TTT2/assets/5711436/66916d7d-cea8-4197-8755-d0dcbba53f4f)