### PR TITLE
Fixed: Unmatched performance ConVars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed an issue in `table.GetEqualEntryKeys` when nil is provided instead of a table. (by @sbzlzh):
   - This fixes spawn problems on maps with invalid spawn points
   - This fixes errors in the F1 Menu language selection
+- Fixed two unmatched ConVars in performance menu (by @NickCloudAT)
 
 ## [v0.11.6b](https://github.com/TTT-2/TTT2/tree/v0.11.6b) (2022-09-25)
 

--- a/gamemodes/terrortown/gamemode/client/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_targetid.lua
@@ -28,11 +28,11 @@ local cvDrawHalo = CreateConVar("ttt_entity_draw_halo", "1", FCVAR_ARCHIVE)
 
 ---
 -- @realm client
-local cvEnableSpectatorsoutline = CreateConVar("ttt2_cvEnableSpectatorsoutline", "1", {FCVAR_ARCHIVE, FCVAR_USERINFO})
+local cvEnableSpectatorsoutline = CreateConVar("ttt2_enable_spectatorsoutline", "1", {FCVAR_ARCHIVE, FCVAR_USERINFO})
 
 ---
 -- @realm client
-local cvEnableOverheadicons = CreateConVar("ttt2_cvEnableOverheadicons", "1", {FCVAR_ARCHIVE, FCVAR_USERINFO})
+local cvEnableOverheadicons = CreateConVar("ttt2_enable_overheadicons", "1", {FCVAR_ARCHIVE, FCVAR_USERINFO})
 
 surface.CreateAdvancedFont("TargetID_Key", {font = "Trebuchet24", size = 26, weight = 900})
 surface.CreateAdvancedFont("TargetID_Title", {font = "Trebuchet24", size = 20, weight = 900})


### PR DESCRIPTION
Fixed the two ConVars "ttt2_enable_spectatorsoutline" and "ttt2_enable_overheadicons" being used with two different names and thus not working

In cl_targetid the old values "ttt2_cvEnableSpectatorsoutline" and "ttt2_cvEnableOverheadicons" were used.