### PR TITLE
cvar ttt2_bots_lock_on_death fixes #1043

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Added `PANEL:MakeTextEntry(data)` to `DFormTTT2` for strings or string-backed cvars (by @EntranceJew)
 - Added `damageScaling` property to `weapon_tttbase`, adjustable per item via "Balance Settings" under "Edit Equipment" in the F1 Menu (by @EntranceJew)
 - Allow admin spectators to enter "Spawn Edit" mode. (by @EntranceJew)
+- Added cvar `ttt2_bots_lock_on_death` (default: 0) to prevent bots from causing log-spam while wandering as spectators. (by @EntranceJew)
 
 ### Changed
 

--- a/gamemodes/terrortown/gamemode/server/sv_player.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player.lua
@@ -15,6 +15,10 @@ local ttt_bots_are_spectators = CreateConVar("ttt_bots_are_spectators", "0", {FC
 
 ---
 -- @realm server
+local ttt2_bots_lock_on_death = CreateConVar("ttt2_bots_lock_on_death", "0", {FCVAR_NOTIFY, FCVAR_ARCHIVE})
+
+---
+-- @realm server
 local ttt_dyingshot = CreateConVar("ttt_dyingshot", "0", {FCVAR_NOTIFY, FCVAR_ARCHIVE})
 
 ---
@@ -104,6 +108,9 @@ end
 function GM:PlayerSpawn(ply)
 	-- reset any cached weapons
 	ply:ResetCachedWeapons()
+
+	-- Allow bots to wander again.
+	if ply:IsBot() then ply:UnLock() end
 
 	-- stop bleeding
 	util.StopBleeding(ply)
@@ -631,6 +638,9 @@ function GM:DoPlayerDeath(ply, attacker, dmginfo)
 	if entspawnscript.IsEditing(ply) then
 		entspawnscript.StopEditing(ply)
 	end
+
+	-- Prevent bots from wandering and creating logspam.
+	if ply:IsBot() and ttt2_bots_lock_on_death:GetBool() then ply:Lock() end
 
 	if ply:IsSpec() then return end
 


### PR DESCRIPTION
tested it for a few rounds

admin wallhacks indicate that the spectator ghosts tend to remain where they get warped on death