### PR TITLE
Random Ammo Spawn Issue, fixes #1049

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
   - This fixes errors in the F1 Menu language selection
 - Fixed two unmatched ConVars in performance menu (by @NickCloudAT)
 - Fixed Round End Scoreboard (Round Begin) error if a player disconnected while round with no score events (by @NickCloudAT)
+- Fixed behavior of `entspawn.SpawnRandomAmmo` to produce non-deagle ammo. (by @NickCloudAT, mostly)
 
 ## [v0.11.6b](https://github.com/TTT-2/TTT2/tree/v0.11.6b) (2022-09-25)
 

--- a/lua/ttt2/libraries/entspawn.lua
+++ b/lua/ttt2/libraries/entspawn.lua
@@ -45,7 +45,7 @@ end
 -- @realm server
 function entspawn.SpawnRandomWeapon(ent)
 	local spawns = {
-		[SPAWN_TYPE_WEAPON] = {
+		[WEAPON_TYPE_RANDOM] = {
 			[1] = {
 				pos = ent:GetPos(),
 				ang = ent:GetAngles(),
@@ -64,7 +64,7 @@ end
 -- @realm server
 function entspawn.SpawnRandomAmmo(ent)
 	local spawns = {
-		[SPAWN_TYPE_AMMO] = {
+		[AMMO_TYPE_RANDOM] = {
 			[1] = {
 				pos = ent:GetPos(),
 				ang = ent:GetAngles(),


### PR DESCRIPTION
The results are similar, sometimes but the semantics differ. In this case, the final random parameter was so future-proofed that it failed to distinguish itself. Maybe a jargon file of some form would help?