### PR TITLE
voice volume scaling / spectator ducking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,22 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ### Added
 
 - Added the ability to edit slider numbers directly via an input field by clicking on the number (by @NickCloudAT)
+- Added a new way to alter player volume separately from the scoreboard (by @EntranceJew):
+  - `VOICE.(Get/Set)PreferredPlayerVoiceVolume` for setting the voice volume instead of `Player:SetVoiceVolumeScale`
+  - `VOICE.(Get/Set)PreferredPlayerVoiceMute` for setting the voice mute instead of `Player:SetMuted`
+  - `VOICE.UpdatePlayerVoiceVolume` commits / updates the voice setting according to player preferences
+- Added client submenu options for clients to change audio settings under `F1 > Gameplay > General` (by @EntranceJew):
+  - Added a convar `ttt2_voice_scaling` to control voice volume scaling, options like "power4" or "log" cause the volume scaling to have a greater perceptual impact between discrete volume settings.
+  - Added convars `ttt2_voice_duck_spectator` and `ttt2_voice_duck_spectator_amount` to lower spectator voice volume automatically.
+    - A value of `0.13` ducks someone's volume at 90% down to effectively 78%, according to the client's scaling mode.
 
 ### Changed
 
 - Updated Simplified Chinese and Traditional Chinese localization files (by @sbzlzh):
   - Add the missing `L.c4_disarm_t` translation in C4
 - Updated file code to read from `data_static` as fallback in new location allowed in .gma (by @EntranceJew)
+- Scoreboard now sets preferred player volume and mute state in client's new `ttt2_voice` table (by @EntranceJew)
+  - Keyed by steamid64, making it more reliable than UniqueID or the per-session mute and volume levels.
 
 ## [v0.11.7b](https://github.com/TTT-2/TTT2/tree/v0.11.7b) (2022-08-27)
 

--- a/gamemodes/terrortown/gamemode/client/cl_voice.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_voice.lua
@@ -26,6 +26,27 @@ local MutedState
 
 g_VoicePanelList = nil
 
+---
+-- @realm client
+local duck_spectator = CreateConVar("ttt2_voice_duck_spectator", "0", {FCVAR_ARCHIVE})
+
+---
+-- @realm client
+local duck_spectator_amount = CreateConVar("ttt2_voice_duck_spectator_amount", "0", {FCVAR_ARCHIVE})
+
+---
+-- @realm client
+local scaling_mode = CreateConVar("ttt2_voice_scaling", "linear", {FCVAR_ARCHIVE})
+
+local function CreateVoiceTable()
+	if not sql.TableExists("ttt2_voice") then
+		local query = "CREATE TABLE ttt2_voice (guid TEXT PRIMARY KEY, mute INTEGER DEFAULT 0, volume REAL DEFAULT 1)"
+		sql.Query(query)
+	end
+end
+
+CreateVoiceTable()
+
 local function VoiceTryEnable()
 	local client = LocalPlayer()
 
@@ -135,6 +156,8 @@ function GM:PlayerStartVoice(ply)
 	if not IsValid(ply) then return end
 
 	local client = LocalPlayer()
+
+	VOICE.UpdatePlayerVoiceVolume(ply)
 
 	if not IsValid(g_VoicePanelList) or not IsValid(client) then return end
 
@@ -345,6 +368,122 @@ end
 
 VOICE.battery_max = 100
 VOICE.battery_min = 10
+
+---
+-- Scales a linear volume into a Power 4 value.
+-- @param number volume
+-- @realm client
+function VOICE.LinearToPower4(volume)
+	return math.Clamp( math.pow(volume, 4), 0, 1)
+end
+
+---
+-- Scales a linear volume into a Log value.
+-- @param number volume
+-- @realm client
+function VOICE.LinearToLog(volume)
+	local rolloff_cutoff = 0.1
+	local log_a = math.pow(1 / 10, 60 / 20)
+	local log_b = math.log(1 / log_a)
+
+	local vol = log_a * math.exp(log_b * volume)
+	if volume < rolloff_cutoff then
+		local log_rolloff = 10 * log_a * math.exp(log_b * rolloff_cutoff)
+		vol = volume * log_rolloff
+	end
+
+	return math.Clamp(vol, 0, 1)
+end
+
+---
+-- Passes along the input linear volume value.
+-- @param number volume
+-- @realm client
+function VOICE.LinearToLinear(volume)
+	return volume
+end
+
+VOICE.ScalingFunctions = {
+	power4 = VOICE.LinearToPower4,
+	log = VOICE.LinearToLog,
+	linear = VOICE.LinearToLinear,
+}
+
+VOICE.GetScalingFunctions = function()
+	local opts = {}
+	for mode in pairs(VOICE.ScalingFunctions) do
+		opts[#opts + 1] = {
+			title = LANG.TryTranslation("label_voice_scaling_mode_" .. mode),
+			value = mode,
+			select = mode == scaling_mode:GetString(),
+		}
+	end
+	return opts
+end
+
+---
+-- Gets the stored volume for the player's voice.
+-- @param Player ply
+-- @realm client
+function VOICE.GetPreferredPlayerVoiceVolume(ply)
+	local val = sql.QueryValue( "SELECT volume FROM ttt2_voice WHERE guid = " .. SQLStr( ply:SteamID64() ) .. " LIMIT 1" )
+	if ( val == nil ) then return 1 end
+	return tonumber(val)
+end
+
+---
+-- Sets the stored volume for the player's voice.
+-- @param Player ply
+-- @param number volume
+-- @realm client
+function VOICE.SetPreferredPlayerVoiceVolume(ply, volume)
+	return sql.Query( "REPLACE INTO ttt2_voice ( guid, volume ) VALUES ( " .. SQLStr( ply:SteamID64() ) .. ", " .. SQLStr( volume ) .. " )" )
+end
+
+---
+-- Gets the stored mute state for the player's voice.
+-- @param Player ply
+-- @realm client
+function VOICE.GetPreferredPlayerVoiceMuted(ply)
+	local val = sql.QueryValue( "SELECT mute FROM ttt2_voice WHERE guid = " .. SQLStr( ply:SteamID64() ) .. " LIMIT 1" )
+	if ( val == nil ) then return false end
+	return tobool(val)
+end
+
+---
+-- Sets the stored mute state for the player's voice.
+-- @param Player ply
+-- @param boolean is_muted
+-- @realm client
+function VOICE.SetPreferredPlayerVoiceMuted(ply, is_muted)
+	return sql.Query( "REPLACE INTO ttt2_voice ( guid, mute ) VALUES ( " .. SQLStr( ply:SteamID64() ) .. ", " .. SQLStr( is_muted and 1 or 0 ) .. " )" )
+end
+
+---
+-- Refreshes and applies the preferred volume and mute state for a player's voice.
+-- @param Player ply
+-- @realm client
+function VOICE.UpdatePlayerVoiceVolume(ply)
+	local mute = VOICE.GetPreferredPlayerVoiceMuted(ply)
+	if ply.SetMute then
+		ply:SetMute(mute)
+	end
+
+	local vol = VOICE.GetPreferredPlayerVoiceVolume(ply)
+	if duck_spectator:GetBool() and ply:IsSpec() then
+		vol = vol * (1 - duck_spectator_amount:GetFloat())
+	end
+	local out_vol = vol
+
+	local func = VOICE.ScalingFunctions[scaling_mode:GetString()]
+	if isfunction(func) then
+		out_vol = func( vol )
+	end
+
+	ply:SetVoiceVolumeScale( out_vol )
+
+	return out_vol, mute
+end
 
 ---
 -- Initializes the voice battery

--- a/gamemodes/terrortown/gamemode/client/vgui/cl_sb_row.lua
+++ b/gamemodes/terrortown/gamemode/client/vgui/cl_sb_row.lua
@@ -331,7 +331,9 @@ function PANEL:SetPlayer(ply)
 
 	self.voice.DoClick = function()
 		if IsValid(ply) and ply ~= client then
-			ply:SetMuted(not ply:IsMuted())
+			local muted = VOICE.GetPreferredPlayerVoiceMuted(ply)
+			VOICE.SetPreferredPlayerVoiceMuted(ply, not muted)
+			VOICE.UpdatePlayerVoiceVolume(ply)
 		end
 	end
 
@@ -445,7 +447,7 @@ function PANEL:UpdatePlayerData()
 	end
 
 	if self.Player ~= LocalPlayer() then
-		local muted = self.Player:IsMuted()
+		local muted = VOICE.GetPreferredPlayerVoiceMuted(self.Player)
 
 		self.voice:SetImage(muted and "icon16/sound_mute.png" or "icon16/sound.png")
 	else
@@ -659,13 +661,14 @@ function PANEL:ScrollPlayerVolume(delta)
 	-- Bots return nil for the steamid64 on the client, so we need to improvise a bit
 	local identifier = ply:IsBot() and ply:Nick() or ply:SteamID64()
 
-	local cur_volume = ply:GetVoiceVolumeScale()
+	local cur_volume = VOICE.GetPreferredPlayerVoiceVolume(ply)
 	cur_volume = cur_volume ~= nil and cur_volume or 1
 
 	local new_volume = delta == -1 and math.max(0, cur_volume - 0.01) or math.min(1, cur_volume + 0.01)
 	new_volume = math.Round(new_volume, 2)
 
-	ply:SetVoiceVolumeScale(new_volume)
+	VOICE.SetPreferredPlayerVoiceVolume(ply, new_volume)
+	VOICE.UpdatePlayerVoiceVolume(ply)
 
 	if self.voice.percentage_frame ~= nil and not self.voice.percentage_frame:IsVisible() then
 		self.voice.percentage_frame:Show()

--- a/lua/terrortown/lang/de.lua
+++ b/lua/terrortown/lang/de.lua
@@ -1891,3 +1891,11 @@ L.label_roles_credits_kill_award = "Aktiviere Ausrüstungspunktebelohnung für M
 --L.slot_weapon_special = "Special Slot"
 --L.slot_weapon_extra = "Extra Slot"
 --L.slot_weapon_class = "Class Slot"
+
+-- 2023-10-04
+-- L.label_voice_duck_spectator = "Duck spectator voices"
+-- L.label_voice_duck_spectator_amount = "Spectator voice duck amount"
+-- L.label_voice_scaling = "Voice Volume Scaling Mode"
+-- L.label_voice_scaling_mode_linear = "Linear"
+-- L.label_voice_scaling_mode_power4 = "Power 4"
+-- L.label_voice_scaling_mode_log = "Logarithmic"

--- a/lua/terrortown/lang/en.lua
+++ b/lua/terrortown/lang/en.lua
@@ -1891,3 +1891,11 @@ L.slot_weapon_unarmed = "Unarmed Slot"
 L.slot_weapon_special = "Special Slot"
 L.slot_weapon_extra = "Extra Slot"
 L.slot_weapon_class = "Class Slot"
+
+-- 2023-10-04
+L.label_voice_duck_spectator = "Duck spectator voices"
+L.label_voice_duck_spectator_amount = "Spectator voice duck amount"
+L.label_voice_scaling = "Voice Volume Scaling Mode"
+L.label_voice_scaling_mode_linear = "Linear"
+L.label_voice_scaling_mode_power4 = "Power 4"
+L.label_voice_scaling_mode_log = "Logarithmic"

--- a/lua/terrortown/lang/es.lua
+++ b/lua/terrortown/lang/es.lua
@@ -1891,3 +1891,11 @@ L.desc_event_kill_other_using = "{victim} ({vrole} / {vteam}) fue asesinado por 
 --L.slot_weapon_special = "Special Slot"
 --L.slot_weapon_extra = "Extra Slot"
 --L.slot_weapon_class = "Class Slot"
+
+-- 2023-10-04
+-- L.label_voice_duck_spectator = "Duck spectator voices"
+-- L.label_voice_duck_spectator_amount = "Spectator voice duck amount"
+-- L.label_voice_scaling = "Voice Volume Scaling Mode"
+-- L.label_voice_scaling_mode_linear = "Linear"
+-- L.label_voice_scaling_mode_power4 = "Power 4"
+-- L.label_voice_scaling_mode_log = "Logarithmic"

--- a/lua/terrortown/lang/fr.lua
+++ b/lua/terrortown/lang/fr.lua
@@ -1891,3 +1891,11 @@ L.karma_unknown_tooltip = "Inconnu"
 --L.slot_weapon_special = "Special Slot"
 --L.slot_weapon_extra = "Extra Slot"
 --L.slot_weapon_class = "Class Slot"
+
+-- 2023-10-04
+-- L.label_voice_duck_spectator = "Duck spectator voices"
+-- L.label_voice_duck_spectator_amount = "Spectator voice duck amount"
+-- L.label_voice_scaling = "Voice Volume Scaling Mode"
+-- L.label_voice_scaling_mode_linear = "Linear"
+-- L.label_voice_scaling_mode_power4 = "Power 4"
+-- L.label_voice_scaling_mode_log = "Logarithmic"

--- a/lua/terrortown/lang/it.lua
+++ b/lua/terrortown/lang/it.lua
@@ -1891,3 +1891,11 @@ L.desc_event_kill_other_using = "{victim} ({vrole} / {vteam}) è stata ucciso da
 --L.slot_weapon_special = "Special Slot"
 --L.slot_weapon_extra = "Extra Slot"
 --L.slot_weapon_class = "Class Slot"
+
+-- 2023-10-04
+-- L.label_voice_duck_spectator = "Duck spectator voices"
+-- L.label_voice_duck_spectator_amount = "Spectator voice duck amount"
+-- L.label_voice_scaling = "Voice Volume Scaling Mode"
+-- L.label_voice_scaling_mode_linear = "Linear"
+-- L.label_voice_scaling_mode_power4 = "Power 4"
+-- L.label_voice_scaling_mode_log = "Logarithmic"

--- a/lua/terrortown/lang/ja.lua
+++ b/lua/terrortown/lang/ja.lua
@@ -1887,3 +1887,11 @@ L.help_falldmg_exponent = [[
 --L.slot_weapon_special = "Special Slot"
 --L.slot_weapon_extra = "Extra Slot"
 --L.slot_weapon_class = "Class Slot"
+
+-- 2023-10-04
+-- L.label_voice_duck_spectator = "Duck spectator voices"
+-- L.label_voice_duck_spectator_amount = "Spectator voice duck amount"
+-- L.label_voice_scaling = "Voice Volume Scaling Mode"
+-- L.label_voice_scaling_mode_linear = "Linear"
+-- L.label_voice_scaling_mode_power4 = "Power 4"
+-- L.label_voice_scaling_mode_log = "Logarithmic"

--- a/lua/terrortown/lang/pl.lua
+++ b/lua/terrortown/lang/pl.lua
@@ -1891,3 +1891,11 @@ L.none = "Brak Roli"
 --L.slot_weapon_special = "Special Slot"
 --L.slot_weapon_extra = "Extra Slot"
 --L.slot_weapon_class = "Class Slot"
+
+-- 2023-10-04
+-- L.label_voice_duck_spectator = "Duck spectator voices"
+-- L.label_voice_duck_spectator_amount = "Spectator voice duck amount"
+-- L.label_voice_scaling = "Voice Volume Scaling Mode"
+-- L.label_voice_scaling_mode_linear = "Linear"
+-- L.label_voice_scaling_mode_power4 = "Power 4"
+-- L.label_voice_scaling_mode_log = "Logarithmic"

--- a/lua/terrortown/lang/pt_br.lua
+++ b/lua/terrortown/lang/pt_br.lua
@@ -1919,3 +1919,11 @@ L.xfer_team_indicator = "Time"
 --L.slot_weapon_special = "Special Slot"
 --L.slot_weapon_extra = "Extra Slot"
 --L.slot_weapon_class = "Class Slot"
+
+-- 2023-10-04
+-- L.label_voice_duck_spectator = "Duck spectator voices"
+-- L.label_voice_duck_spectator_amount = "Spectator voice duck amount"
+-- L.label_voice_scaling = "Voice Volume Scaling Mode"
+-- L.label_voice_scaling_mode_linear = "Linear"
+-- L.label_voice_scaling_mode_power4 = "Power 4"
+-- L.label_voice_scaling_mode_log = "Logarithmic"

--- a/lua/terrortown/lang/ru.lua
+++ b/lua/terrortown/lang/ru.lua
@@ -1894,3 +1894,11 @@ L.tbut_adminarea = "Администраторская зона:"
 --L.slot_weapon_special = "Special Slot"
 --L.slot_weapon_extra = "Extra Slot"
 --L.slot_weapon_class = "Class Slot"
+
+-- 2023-10-04
+-- L.label_voice_duck_spectator = "Duck spectator voices"
+-- L.label_voice_duck_spectator_amount = "Spectator voice duck amount"
+-- L.label_voice_scaling = "Voice Volume Scaling Mode"
+-- L.label_voice_scaling_mode_linear = "Linear"
+-- L.label_voice_scaling_mode_power4 = "Power 4"
+-- L.label_voice_scaling_mode_log = "Logarithmic"

--- a/lua/terrortown/lang/zh_hans.lua
+++ b/lua/terrortown/lang/zh_hans.lua
@@ -1895,3 +1895,11 @@ L.slot_weapon_unarmed = "空手槽"
 L.slot_weapon_special = "特殊槽"
 L.slot_weapon_extra = "额外槽"
 L.slot_weapon_class = "职业槽"
+
+-- 2023-10-04
+-- L.label_voice_duck_spectator = "Duck spectator voices"
+-- L.label_voice_duck_spectator_amount = "Spectator voice duck amount"
+-- L.label_voice_scaling = "Voice Volume Scaling Mode"
+-- L.label_voice_scaling_mode_linear = "Linear"
+-- L.label_voice_scaling_mode_power4 = "Power 4"
+-- L.label_voice_scaling_mode_log = "Logarithmic"

--- a/lua/terrortown/lang/zh_tw.lua
+++ b/lua/terrortown/lang/zh_tw.lua
@@ -1894,3 +1894,11 @@ L.slot_weapon_unarmed = "空手槽"
 L.slot_weapon_special = "特殊槽"
 L.slot_weapon_extra = "額外槽"
 L.slot_weapon_class = "職業槽"
+
+-- 2023-10-04
+-- L.label_voice_duck_spectator = "Duck spectator voices"
+-- L.label_voice_duck_spectator_amount = "Spectator voice duck amount"
+-- L.label_voice_scaling = "Voice Volume Scaling Mode"
+-- L.label_voice_scaling_mode_linear = "Linear"
+-- L.label_voice_scaling_mode_power4 = "Power 4"
+-- L.label_voice_scaling_mode_log = "Logarithmic"

--- a/lua/terrortown/menus/gamemode/gameplay/general.lua
+++ b/lua/terrortown/menus/gamemode/gameplay/general.lua
@@ -28,6 +28,31 @@ function CLGAMEMODESUBMENU:Populate(parent)
 		convar = "ttt_mute_team_check"
 	})
 
+	form:MakeComboBox({
+		label = "label_voice_scaling",
+		convar = "ttt2_voice_scaling",
+		choices = VOICE.GetScalingFunctions(),
+		OnChange = function()
+			for _, ply in ipairs(player.GetAll()) do
+				VOICE.UpdatePlayerVoiceVolume(ply)
+			end
+		end,
+	})
+
+	local enbSpecDuck = form:MakeCheckBox({
+		label = "label_voice_duck_spectator",
+		convar = "ttt2_voice_duck_spectator"
+	})
+
+	form:MakeSlider({
+		label = "label_voice_duck_spectator_amount",
+		convar = "ttt2_voice_duck_spectator_amount",
+		min = 0,
+		max = 1,
+		decimal = 2,
+		master = enbSpecDuck,
+	})
+
 	local enbSprint = form:MakeCheckBox({
 		label = "label_gameplay_dtsprint_enable",
 		convar = "ttt2_enable_doubletap_sprint"


### PR DESCRIPTION
I think there should be hooks in here somewhere so equipment like the Mute Radio can continue to exist, but I'm not sure where.

I don't know if I make note of it specifically but bots report distinct values for SteamID64 so that workaround isn't necessary anymore.

problems:
 - if someone dies while talking, once their audio becomes non-3D their volume should be changed prior to that, but presently I don't know where that happens, because the name-plate stays team-colored until they finish talking.
 - also the dropdown selector raises errors for me if changed several times which I believe is just an issue that already existed, the convar still functions