### PR TITLE
Fix/Changes: Combobox callback fixes/changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Updated file code to read from `data_static` as fallback in new location allowed in .gma (by @EntranceJew)
 - Scoreboard now sets preferred player volume and mute state in client's new `ttt2_voice` table (by @EntranceJew)
   - Keyed by steamid64, making it more reliable than UniqueID or the per-session mute and volume levels.
+- Added "olValue" to the onSelect/onChange function of comboboxes (by @NickCloudAT)
+
+### Fixed
+- Fixed Comboboxes throwing an invalid callback error in some instances (by @NickCloudAT)
 
 ## [v0.11.7b](https://github.com/TTT-2/TTT2/tree/v0.11.7b) (2022-08-27)
 

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dform_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dform_ttt2.lua
@@ -291,7 +291,7 @@ end
 -- @note Structure of data = {
 -- label, default, choices = { [1] = {title, value, select, icon, additionalData}, [2] = ...},
 -- conVar, serverConVar, selectId or selectTitle or selectValue,
--- function OnChange(value, additionalData, dropDownPanel), master = { function AddSlave(self, slave) }
+-- function OnChange(value, additionalData, oldValue, dropDownPanel), master = { function AddSlave(self, slave) }
 -- }
 -- @note If ConVars are used the values are always strings, so make sure, that you used strings for values, when setting up choices
 -- @return Panel The created combobox
@@ -344,9 +344,9 @@ function PANEL:MakeComboBox(data)
 		end
 	end
 
-	right.OnSelect = function(slf, index, value, additionalData)
+	right.OnSelect = function(slf, index, value, additionalData, oldValue)
 		if data and isfunction(data.OnChange) then
-			data.OnChange(value, additionalData, slf)
+			data.OnChange(value, additionalData, oldValue, slf)
 		end
 	end
 

--- a/lua/terrortown/menus/gamemode/language/language.lua
+++ b/lua/terrortown/menus/gamemode/language/language.lua
@@ -25,8 +25,8 @@ function CLGAMEMODESUBMENU:Populate(parent)
 		label = "label_language_set",
 		convar = "ttt_language",
 		choices = choices,
-		OnChange = function(value)
-			if value == GetActiveLanguageName() then return end
+		OnChange = function(value, _, oldValue)
+			if value == oldValue then return end
 
 			vguihandler.InvalidateVSkin()
 			vguihandler.Rebuild()


### PR DESCRIPTION
With this commit comboboxes won't throw an error for a "nil" callback anymore. For some reason the game can not keep track of callbacks correctly anymore.

Also added a "oldValue" to the onSelect/onChange function of the combobox to ensure the previous set value is still sent.

I would happily have some people test this to see if I broke something or not and give their 2 cent on this.

Some things I'm not yet sure and maybe somebody has a better idea:
- Should the "oldValue" be nil if "self.selected" is not present or should we set it to the new value?
- I put "oldValue" as the last argument as to not break compatibility with perhaps already existing comboboxes.


Related issue: https://github.com/TTT-2/TTT2/issues/1068