### PR TITLE
Fix: F1 translation percentage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
   - role info popup for traitors should now show teammembers again if the traitor shop is disabled
   - `pon` and `table` libraries got a small fix respectively
   - the shop and roleselection now reference `roles.INNOCENT` instead of the removed `INNOCENT` global, same for `TRAITOR` and `DETECTIVE`
+  - Fixed wrong translation % in F1-Menu when changing language (by @NickCloudAT)
 
 ### Removed
 

--- a/lua/terrortown/menus/gamemode/language/language.lua
+++ b/lua/terrortown/menus/gamemode/language/language.lua
@@ -26,8 +26,6 @@ function CLGAMEMODESUBMENU:Populate(parent)
 		convar = "ttt_language",
 		choices = choices,
 		OnChange = function(value)
-			if value == GetActiveLanguageName() then return end
-
 			vguihandler.InvalidateVSkin()
 			vguihandler.Rebuild()
 		end


### PR DESCRIPTION
Fixed the percentage in F1 menu displaying the wrong number.

Seems like just removing the check fixes the issue.. Although the VGUI will refresh even if selecting the same language again.. But I think thats not really a big deal.