### PR TITLE
fix: Make sure accessors use DTVars

### DIFF
--- a/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
@@ -69,20 +69,6 @@ AccessorFunc(ENT, "arm_time", "ArmTime", FORCE_NUMBER)
 -- @realm shared
 AccessorFunc(ENT, "timer_length", "TimerLength", FORCE_NUMBER)
 
--- Generate accessors for DT vars. This way all consumer code can keep accessing
--- the vars as they always did, the only difference is that behind the scenes
--- they are set up as DT vars.
-
----
--- @accessor number
--- @realm shared
-AccessorFunc(ENT, "explode_time", "ExplodeTime", FORCE_NUMBER)
-
----
--- @accessor boolean
--- @realm shared
-AccessorFunc(ENT, "armed", "Armed", FORCE_BOOL)
-
 ENT.timeBeep = 0
 ENT.safeWires = nil
 
@@ -90,8 +76,8 @@ ENT.safeWires = nil
 -- Initializes the data
 -- @realm shared
 function ENT:SetupDataTables()
-	self:DTVar("Int", 0, "explode_time")
-	self:DTVar("Bool", 0, "armed")
+	self:NetworkVar("Int", 0, "explode_time")
+	self:NetworkVar("Bool", 0, "armed")
 end
 
 ---

--- a/gamemodes/terrortown/entities/entities/ttt_health_station.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_health_station.lua
@@ -5,7 +5,7 @@
 
 if SERVER then
 	AddCSLuaFile()
-else -- CLIENT
+else
 	-- this entity can be DNA-sampled so we need some display info
 	ENT.Icon = "vgui/ttt/icon_health"
 	ENT.PrintName = "hstation_name"
@@ -26,11 +26,6 @@ ENT.HealRate = 1
 ENT.HealFreq = 0.2
 
 ---
--- @accessor number
--- @realm shared
-AccessorFunc(ENT, "StoredHealth", "StoredHealth", FORCE_NUMBER)
-
----
 -- @accessor Player
 -- @realm shared
 AccessorFunc(ENT, "Placer", "Placer")
@@ -38,7 +33,7 @@ AccessorFunc(ENT, "Placer", "Placer")
 ---
 -- @realm shared
 function ENT:SetupDataTables()
-	self:DTVar("Int", 0, "StoredHealth")
+	self:NetworkVar("Int", 0, "StoredHealth")
 end
 
 ---
@@ -215,7 +210,7 @@ if SERVER then
 			LANG.Msg(self:GetPlacer(), "hstation_broken")
 		end
 	end
-else -- CLIENT
+else
 	local TryT = LANG.TryTranslation
 	local ParT = LANG.GetParamTranslation
 


### PR DESCRIPTION
After the removal of `AccessorFuncDT()` some accessors might be using a local var instead of the network var. With this change this should be fixed again.

We shouldn't use `ENT:DTVar()` in general and instead use `ENT:NetworkVar()` as that also correctly creates the necessary accessors.

Thanks @EntranceJew for noticing.