### PR TITLE
fix: Correct network var names

### DIFF
--- a/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
@@ -76,8 +76,8 @@ ENT.safeWires = nil
 -- Initializes the data
 -- @realm shared
 function ENT:SetupDataTables()
-	self:NetworkVar("Int", 0, "explode_time")
-	self:NetworkVar("Bool", 0, "armed")
+	self:NetworkVar("Int", 0, "ExplodeTime")
+	self:NetworkVar("Bool", 0, "Armed")
 end
 
 ---


### PR DESCRIPTION
I failed to see that with the old `AccessorFuncDT()` call it was possible to influence the accessor function names which resulted in accessors that were cased differently than their respective networked vars.

This renames the networked vars which shouldn't itself matter as the vars should only ever be accessed via their accessors anyway.