### PR TITLE
[FIX] Line break rework

### DIFF
--- a/lua/ttt2/extensions/draw.lua
+++ b/lua/ttt2/extensions/draw.lua
@@ -496,22 +496,22 @@ local function InternalGetWrappedText(text, width, scale)
 		-- To improve performance, we don't want to iterate over every single
 		-- character. Therefore we assume the length based on an average first.
 
-		local charCount = string.len(text)
-		local wCharAverage = surface.GetTextSize(text) / charCount -- - 2 -- decrease some pixels to be on the safe side
-		local charCountPerLine = math.floor(width / wCharAverage)
+		local charCount = utf8.len(text)
+		local wCharAverage = surface.GetTextSize(text) / charCount
+		local charCountPerLine = math.floor(width / wCharAverage * 0.8) -- decreae a bit to have tolerance
 		local lastStartPos = 1
 		local lineNumber = 1
 
 		while true do
 			local nextStartPos = lastStartPos + charCountPerLine
-			lines[lineNumber] = string.sub(text, lastStartPos, nextStartPos -1)
+			lines[lineNumber] = utf8.sub(text, lastStartPos, nextStartPos -1)
 			lastStartPos = nextStartPos
 
 			local wLine
 
 			-- then iterate over further chars until line end is reached
 			for i = lastStartPos, charCount do
-				local added = lines[lineNumber] .. string.sub(text, i)
+				local added = lines[lineNumber] .. utf8.GetChar(text, i)
 
 				wLine = surface.GetTextSize(added)
 


### PR DESCRIPTION
fixes #1110

The old `draw.GetWrappedText` function could only handle text that is broken up at whitespaces. This was reworked with a special mode that kicks in, if a line without whitespaces is longer than the max width. The function devides inbetween characters and tries to fit as many as possible on one line.

This works well for languages such as chinese, but it is compatible with any language.

![image](https://github.com/TTT-2/TTT2/assets/13639408/b9240424-3262-4cd3-b817-922cfb92c775)
