### PR TITLE
Prop Possesion: Made input directions more intuitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed blurred box rendering for boxes not starting at `0,0` (by @TimGoll)
 - Optimized allocations by using global Vector / Angle when possible.
 - Fixed the dynamic armor damage calculation being wrong when damage can only get partially reduced
-- Fixed propspec inputs being sometimes unpredictable (by @TimGoll)
+- Fixed propspec inputs behaving sometimes unexpectedly (by @TimGoll)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed blurred box rendering for boxes not starting at `0,0` (by @TimGoll)
 - Optimized allocations by using global Vector / Angle when possible.
 - Fixed the dynamic armor damage calculation being wrong when damage can only get partially reduced
+- Fixed propspec inputs being sometimes unpredictable (by @TimGoll)
 
 ### Removed
 

--- a/gamemodes/terrortown/gamemode/server/sv_propspec.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_propspec.lua
@@ -147,42 +147,44 @@ function PROPSPEC.Key(ply, key)
 		return true
 	end
 
-	local pr = ply.propspec
+	local pSpec = ply.propspec
 
-	if pr.t > CurTime() or pr.punches < 1 then
+	if pSpec.t > CurTime() or pSpec.punches < 1 then
 		return true
 	end
 
-	local m = math.min(150, phys:GetMass())
+	local mass = math.min(150, phys:GetMass())
 	local force = propspec_force:GetInt()
-	local aim = ply:GetAimVector()
-	local mf = m * force
+	local mf = mass * force
+	local vectorAim = ply:GetAimVector()
 
-	pr.t = CurTime() + 0.15
+	local vectorAimPlanar = Vector(vectorAim.x, vectorAim.y, 0)
+	vectorAimPlanar:Normalize()
+
+	local vectorPerpendicularLeft = Vector(-vectorAimPlanar.y, -vectorAimPlanar.x, 0)
+	local vectorPerpendicularRight = Vector(vectorAimPlanar.y, -vectorAimPlanar.x, 0)
+
+	pSpec.t = CurTime() + 0.15
 
 	if key == IN_JUMP then
-		-- upwards bump
 		phys:ApplyForceCenter(Vector(0, 0, mf))
 
-		pr.t = CurTime() + 0.05
+		pSpec.t = CurTime() + 0.05
 	elseif key == IN_FORWARD then
-		-- bump away from player
-		phys:ApplyForceCenter(aim * mf)
+		phys:ApplyForceCenter(vectorAimPlanar * mf)
 	elseif key == IN_BACK then
-		phys:ApplyForceCenter(aim * (mf * -1))
+		phys:ApplyForceCenter(vectorAimPlanar * (mf * -1))
 	elseif key == IN_MOVELEFT then
-		phys:AddAngleVelocity(Vector(0, 0, 200))
-		phys:ApplyForceCenter(Vector(0, 0, mf / 3))
+		phys:ApplyForceCenter(vectorPerpendicularLeft * mf * 0.33)
 	elseif key == IN_MOVERIGHT then
-		phys:AddAngleVelocity(Vector(0, 0, -200))
-		phys:ApplyForceCenter(Vector(0, 0, mf / 3))
+		phys:ApplyForceCenter(vectorPerpendicularRight * mf * 0.33)
 	else
 		return true -- eat other keys, and do not decrement punches
 	end
 
-	pr.punches = math.max(pr.punches - 1, 0)
+	pSpec.punches = math.max(pSpec.punches - 1, 0)
 
-	ply:SetNWFloat("specpunches", pr.punches / pr.max)
+	ply:SetNWFloat("specpunches", pSpec.punches / pSpec.max)
 
 	return true
 end

--- a/gamemodes/terrortown/gamemode/server/sv_propspec.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_propspec.lua
@@ -161,7 +161,7 @@ function PROPSPEC.Key(ply, key)
 	local vectorAimPlanar = Vector(vectorAim.x, vectorAim.y, 0)
 	vectorAimPlanar:Normalize()
 
-	local vectorPerpendicularLeft = Vector(-vectorAimPlanar.y, -vectorAimPlanar.x, 0)
+	local vectorPerpendicularLeft = Vector(-vectorAimPlanar.y, vectorAimPlanar.x, 0)
 	local vectorPerpendicularRight = Vector(vectorAimPlanar.y, -vectorAimPlanar.x, 0)
 
 	pSpec.t = CurTime() + 0.15

--- a/gamemodes/terrortown/gamemode/server/sv_propspec.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_propspec.lua
@@ -173,7 +173,7 @@ function PROPSPEC.Key(ply, key)
 	elseif key == IN_FORWARD then
 		phys:ApplyForceCenter(vectorAimPlanar * mf)
 	elseif key == IN_BACK then
-		phys:ApplyForceCenter(vectorAimPlanar * (mf * -1))
+		phys:ApplyForceCenter(-vectorAimPlanar * mf)
 	elseif key == IN_MOVELEFT then
 		phys:ApplyForceCenter(vectorPerpendicularLeft * mf * 0.33)
 	elseif key == IN_MOVERIGHT then


### PR DESCRIPTION
Reworked the propspec inputs to be more predictable. The old implementation was really janky and did not take into account in which way the player is looking, see #1093 

I also removed the angular force, because I'm pretty sure it was only added to "fix" the broken implementation.