### PR TITLE
Revert "use global vectors, especially inside those loops"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,6 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
   - Fixed wrong translation % in F1-Menu when changing language (by @NickCloudAT)
 - Fixed disguiser breaking UI on hot reload (by @TimGoll)
 - Fixed blurred box rendering for boxes not starting at `0,0` (by @TimGoll)
-- Optimized allocations by using global Vector / Angle when possible.
 - Fixed the dynamic armor damage calculation being wrong when damage can only get partially reduced
 - Fixed propspec inputs behaving sometimes unexpectedly (by @TimGoll)
 

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -163,9 +163,9 @@ SWEP.fingerprints = {}
 
 --[[
 	-- The position offset applied when entering the ironsight
-	SWEP.IronSightsPos = vector_origin
+	SWEP.IronSightsPos = Vector(0, 0, 0)
 	-- The rotational offset applied when entering the ironsight
-	SWEP.IronSightsAng = vector_origin
+	SWEP.IronSightsAng = Vector(0, 0, 0)
 --]]
 
 local skipWeapons = {}

--- a/gamemodes/terrortown/entities/weapons/weapon_zm_improvised.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_zm_improvised.lua
@@ -185,7 +185,7 @@ function SWEP:PrimaryAttack()
 					Num = 1,
 					Src = spos,
 					Dir = owner:GetAimVector(),
-					Spread = vector_origin,
+					Spread = Vector(0, 0, 0),
 					Tracer = 0,
 					Force = 1,
 					Damage = 0

--- a/gamemodes/terrortown/entities/weapons/weapon_zm_pistol.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_zm_pistol.lua
@@ -40,4 +40,4 @@ SWEP.ViewModel = "models/weapons/cstrike/c_pist_fiveseven.mdl"
 SWEP.WorldModel = "models/weapons/w_pist_fiveseven.mdl"
 
 SWEP.IronSightsPos = Vector(-5.95, -4, 2.799)
-SWEP.IronSightsAng = vector_origin
+SWEP.IronSightsAng = Vector(0, 0, 0)

--- a/gamemodes/terrortown/entities/weapons/weapon_zm_revolver.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_zm_revolver.lua
@@ -42,4 +42,4 @@ SWEP.ViewModel = "models/weapons/cstrike/c_pist_deagle.mdl"
 SWEP.WorldModel = "models/weapons/w_pist_deagle.mdl"
 
 SWEP.IronSightsPos = Vector(-6.361, -3.701, 2.15)
-SWEP.IronSightsAng = vector_origin
+SWEP.IronSightsAng = Vector(0, 0, 0)

--- a/gamemodes/terrortown/entities/weapons/weapon_zm_sledge.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_zm_sledge.lua
@@ -42,4 +42,4 @@ SWEP.WorldModel = "models/weapons/w_mach_m249para.mdl"
 SWEP.HeadshotMultiplier = 2.2
 
 SWEP.IronSightsPos = Vector(-5.96, -5.119, 2.349)
-SWEP.IronSightsAng = vector_origin
+SWEP.IronSightsAng = Vector(0, 0, 0)

--- a/gamemodes/terrortown/gamemode/server/sv_player.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player.lua
@@ -1097,7 +1097,7 @@ function GM:OnPlayerHitGround(ply, in_water, on_floater, speed)
 		dmg:SetDamageType(DMG_FALL)
 		dmg:SetAttacker(game.GetWorld())
 		dmg:SetInflictor(game.GetWorld())
-		dmg:SetDamageForce(vector_up)
+		dmg:SetDamageForce(Vector(0, 0, 1))
 		dmg:SetDamage(damage)
 
 		ply:TakeDamageInfo(dmg)

--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -880,7 +880,7 @@ function plymeta:Revive(delay, OnRevive, DoCheck, needsCorpse, blockRound, OnFai
 			end
 
 			self:SetPos(spawnPos)
-			self:SetEyeAngles(spawnEyeAngle or angle_zero)
+			self:SetEyeAngles(spawnEyeAngle or Angle(0, 0, 0))
 
 			---
 			-- @realm server

--- a/gamemodes/terrortown/gamemode/shared/sh_door.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_door.lua
@@ -300,7 +300,7 @@ if SERVER then
 	-- (problems with area portals). If it is a double door, both doors will be destroyed by
 	-- default.
 	-- @param Player ply The player that wants to destroy the door
-	-- @param[default=vector_origin] Vector pushForce The push force for the door
+	-- @param[default=Vector(0, 0, 0)] Vector pushForce The push force for the door
 	-- @param[default=false] boolean surpressPair Should the call of the other door (if in a pair) be omitted?
 	-- @return Entity Returns the entity of the created prop
 	-- @realm server
@@ -356,7 +356,7 @@ if SERVER then
 
 			doorProp.isDoorProp = true
 
-			doorProp:GetPhysicsObject():ApplyForceCenter(pushForce or vector_origin)
+			doorProp:GetPhysicsObject():ApplyForceCenter(pushForce or Vector(0, 0, 0))
 
 			---
 			-- @realm server

--- a/gamemodes/terrortown/gamemode/shared/sh_main.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_main.lua
@@ -23,7 +23,7 @@ TTT2ShopFallbackInitialized = false
 local function TTT2RegisterSWEP(equipment, name, initialize)
 	local doHotreload = TTT2ShopFallbackInitialized
 
-	-- Handle first initialization or do hotreload
+	-- Handle first initialization or do hotreload 
 	if initialize then
 		equipment = weapons.GetStored(name)
 		doHotreload = false
@@ -392,7 +392,7 @@ function GM:Tick()
 						dmginfo:SetDamageType(DMG_DROWN)
 						dmginfo:SetAttacker(game.GetWorld())
 						dmginfo:SetInflictor(game.GetWorld())
-						dmginfo:SetDamageForce(vector_up)
+						dmginfo:SetDamageForce(Vector(0, 0, 1))
 
 						ply:TakeDamageInfo(dmginfo)
 

--- a/lua/ttt2/libraries/plyspawn.lua
+++ b/lua/ttt2/libraries/plyspawn.lua
@@ -10,7 +10,7 @@ local table = table
 local mathSin = math.sin
 local mathCos = math.cos
 
-local spawnPointVariations = {vector_origin}
+local spawnPointVariations = {Vector(0, 0, 0)}
 
 for i = 0, 360, 22.5 do
 	spawnPointVariations[#spawnPointVariations + 1] = Vector(mathCos(i), mathSin(i), 0)


### PR DESCRIPTION
This reverts commit 917d9c1c90651971eb71754bb6cf3bdd5745b5a4.

# Conflicts:
#	CHANGELOG.md