### PR TITLE
[Lang] Cleaned up Language with Param Translation

### DIFF
--- a/lua/terrortown/lang/es.lua
+++ b/lua/terrortown/lang/es.lua
@@ -406,7 +406,7 @@ L.dna_killer = "¡Se ha encontrado una muestra de ADN del asesino en el cadáver
 L.dna_duplicate = "¡Duplicado! Ya tienes esta muestra de ADN en tu escáner."
 L.dna_no_killer = "El ADN no pudo ser analizado (¿Asesino desconectado?)."
 L.dna_armed = "¡Hay una bomba colocada! ¡Desactívala primero!"
-L.dna_object = "Se han encontrado {num} muestra(s) de ADN nueva(s) del objeto."
+--L.dna_object = "Collected a sample of the last owner from the object."
 L.dna_gone = "No se han encontrado restos de ADN en esta zona."
 
 L.dna_desc = [[

--- a/lua/terrortown/lang/fr.lua
+++ b/lua/terrortown/lang/fr.lua
@@ -406,7 +406,7 @@ L.dna_killer = "Échantillon ADN du tueur récupéré sur le corps!"
 --L.dna_duplicate = "Match! You already have this DNA sample in your scanner."
 L.dna_no_killer = "L'ADN n'a pas pu être récupérée (le tueur s'est déconnecté?)."
 L.dna_armed = "La bombe est amorcée! Désamorcez-la d'abord!"
-L.dna_object = "Vous avez collecté {num} échantillon(s) d'ADN sur cet objet."
+--L.dna_object = "Collected a sample of the last owner from the object."
 L.dna_gone = "Aucun ADN détecté dans la zone."
 
 L.dna_desc = [[

--- a/lua/terrortown/lang/it.lua
+++ b/lua/terrortown/lang/it.lua
@@ -406,7 +406,7 @@ L.dna_killer = "Preso un campione di DNA dell'assassino dal cadavere!"
 --L.dna_duplicate = "Match! You already have this DNA sample in your scanner."
 L.dna_no_killer = "Il DNA non può essere preso (assassino disconnesso?)."
 L.dna_armed = "La bomba è innescata! Disinnescala prima!"
-L.dna_object = "Preso {num} nuovo campione di DNA dall'oggetto."
+--L.dna_object = "Collected a sample of the last owner from the object."
 L.dna_gone = "DNA non rilevato nella zona."
 
 L.dna_desc = [[
@@ -496,7 +496,7 @@ L.target_credits = "Identifica per ricevere i crediti non spesi"
 L.tbut_single = "Uso singolo"
 L.tbut_reuse = "Riutilizzabile"
 L.tbut_retime = "Riutilizzabile dopo {num} secondi"
-L.tbut_help = "Premi {key} per attivare"
+L.tbut_help = "Premi {usekey} per attivare"
 
 -- Spectator muting of living/dead
 L.mute_living = "Giocatori in vita mutati"
@@ -904,7 +904,7 @@ L.shop_default = "Usa shop di default"
 -- 2019-05-05
 L.reroll_name = "Rimescola"
 --L.reroll_menutitle = "Reroll equipment"
-L.reroll_no_credits = "Non hai crediti per rimescolare!"
+--L.reroll_no_credits = "You need {amount} credits to reroll!"
 L.reroll_button = "Rimescola"
 --L.reroll_help = "Use {amount} credits to get a new random set of equipment in your shop!"
 
@@ -930,7 +930,7 @@ L.hud_forced_failed = "Fallito nell'impostare l'HUD {hudname}. Sei un admin ed e
 L.hud_restricted_failed = "Fallito nell'impostare l'HUD {hudname}. Sei un admin?"
 
 L.shop_role_select = "Seleziona un ruolo"
-L.shop_role_selected = "Lo shop del {roles} è stato selezionato!"
+L.shop_role_selected = "Lo shop del {role} è stato selezionato!"
 L.shop_search = "Cerca"
 
 -- 2019-10-19

--- a/lua/terrortown/lang/ja.lua
+++ b/lua/terrortown/lang/ja.lua
@@ -402,7 +402,7 @@ L.dna_killer = "死体から殺害者のDNAサンプルを入手した！"
 L.dna_duplicate = "一致した！スキャナーにこのDNAが登録されたぞ。"
 L.dna_no_killer = "DNAは回収されることができないようだ (殺害者はゲームを退出したんだろうか?)."
 L.dna_armed = "この爆弾は稼働中だ！早く解除するんだ！"
-L.dna_object = "オブジェクトから{num}個の新しいDNAサンプルを入手した。"
+--L.dna_object = "Collected a sample of the last owner from the object."
 L.dna_gone = "このエリアにDNA反応はないようだ。"
 
 L.dna_desc = [[
@@ -926,7 +926,7 @@ L.hud_forced_failed = " {hudname} を固定できなかった。これを行う�
 L.hud_restricted_failed = " {hudname} を制限できなかった。あなたはそれを行う権限がないようだ。"
 
 L.shop_role_select = "役職選択"
-L.shop_role_selected = "{roles}のショップを選択した"
+L.shop_role_selected = "{role}のショップを選択した"
 L.shop_search = "検索"
 
 -- 2019-10-19

--- a/lua/terrortown/lang/pl.lua
+++ b/lua/terrortown/lang/pl.lua
@@ -41,7 +41,7 @@ L.win_showreport = "Spójrzmy na raport rundy na {num} sekund."
 
 --L.limit_round = "Round limit reached. The next map will load soon."
 --L.limit_time = "Time limit reached. The next map will load soon."
-L.limit_left = "{num} rund(a), albo {time} minut, do zmiany mapy na {mapname}."
+--L.limit_left = "{num} round(s) or {time} minutes remaining before the map changes."
 
 -- Credit awards
 L.credit_all = "Twój team został nagrodzony {num} kredytami na zakupy."
@@ -406,7 +406,7 @@ L.dna_killer = "Zebrano próbkę DNA zabójcy z trupa!"
 --L.dna_duplicate = "Match! You already have this DNA sample in your scanner."
 L.dna_no_killer = "Nie można było pobrać DNA (zabójca się rozłączył?)."
 L.dna_armed = "Ta bomba jest uzbrojona! Rozbrój ją najpierw!"
-L.dna_object = "Zebrano {num} nową próbkę DNA z obiektu."
+--L.dna_object = "Collected a sample of the last owner from the object."
 L.dna_gone = "DNA nie zostało znalezione na tym terenie."
 
 L.dna_desc = [[
@@ -676,7 +676,7 @@ L.aw_sui2_title = "Samotny i zdesperowany"
 L.aw_sui2_text = "był jedynym, który zabił samego siebie."
 
 L.aw_exp1_title = "Badania MateriaŁÓw Wybuchowych"
-L.aw_exp1_text = "został wyrÓżniony za badania nad eksplozjami. Pomogło mu [num} obiektów."
+L.aw_exp1_text = "został wyrÓżniony za badania nad eksplozjami. Pomogło mu {num} obiektów."
 
 L.aw_exp2_title = "Badania Terenowe"
 L.aw_exp2_text = "sprawdził swoją odporność na wybuchy. Nie była wystarczająco wysoka."
@@ -930,7 +930,7 @@ L.hud_forced_failed = "Nie udało się wymusić HUD {hudname}. Nie masz permisji
 L.hud_restricted_failed = "Nie udało się nadać restrykcji HUDa {hudname}. Nie masz permisji."
 
 L.shop_role_select = "Wybierz rolę"
-L.shop_role_selected = "{roles} wybrano do sklepu!"
+L.shop_role_selected = "{role} wybrano do sklepu!"
 L.shop_search = "Szukaj"
 
 -- 2019-10-19

--- a/lua/terrortown/lang/pt_br.lua
+++ b/lua/terrortown/lang/pt_br.lua
@@ -466,8 +466,8 @@ L.tele_no_mark = "Nenhum local marcado. Marque um local para teletransportar-se.
 L.tele_no_mark_ground = "Você não pode marcar um local para teletransportar-se se você não estiver em um chão sólido!"
 L.tele_no_mark_crouch = "Você não pode marcar um local para teletransportar-se enquanto estiver agachado!"
 
-L.tele_help_pri = "{primaryfire} teletransporta para o local marcado."
-L.tele_help_sec = "{secondaryfire} marca um local de teletransporte."
+--L.tele_help_pri = "Teleports to marked location"
+--L.tele_help_sec = "Marks current location"
 
 L.tele_desc = [[
 Teletransporta para um local previamente marcado.
@@ -523,7 +523,7 @@ L.target_credits = "Vasculhe para receber créditos não gastos"
 L.tbut_single = "Uso único"
 L.tbut_reuse = "Reutilizável"
 L.tbut_retime = "Reutilizável após {num} seg"
-L.tbut_help = "Pressione {key} para ativar"
+L.tbut_help = "Pressione {usekey} para ativar"
 
 -- Spectator muting of living/dead
 L.mute_living = "Jogadores vivos emudecidos"
@@ -1022,7 +1022,7 @@ L.door_locked = "Esta porta esta trancada."
 
 -- 2020-02-11
 L.automoved_to_spec = "(MENSAGEM AUTOMATICA) Eu fui movimentado para o Espetador porque eu estava Parado/AFK."
-L.mute_team = "{time} mutado."
+L.mute_team = "{team} mutado."
 
 -- 2020-02-16
 L.door_auto_closes = "Esta porta fecha automaticamente.."

--- a/lua/terrortown/lang/ru.lua
+++ b/lua/terrortown/lang/ru.lua
@@ -408,7 +408,7 @@ L.dna_killer = "Вы собрали образец ДНК убийцы с это
 L.dna_duplicate = "Совпадение! У вас уже есть этот образец ДНК в сканере."
 L.dna_no_killer = "Образец ДНК не может быть собран (убийца покинул сервер?)."
 L.dna_armed = "Бомба все ещё работает! Сначала обезвредьте её!"
-L.dna_object = "Собрано новых образцов ДНК: {num}."
+--L.dna_object = "Collected a sample of the last owner from the object."
 L.dna_gone = "ДНК не обнаружено в этой области."
 
 L.dna_desc = [[
@@ -807,7 +807,7 @@ L.aw_flg2_title = "Сигнальная ракета обозначает ого
 L.aw_flg2_text = "рассказал {num} людям об опасности ношения легковоспламеняющейся одежды."
 
 L.aw_hug1_title = "Большой разброс"
-L.aw_hug1_text = "был в гармонии со своим H.U.G.E, умудрившись как-то заставить свои пули убить 4 человек."
+--L.aw_hug1_text = "was in tune with their H.U.G.E, somehow managing to make their bullets hit {num} people."
 
 L.aw_hug2_title = "Терпеливая пара"
 L.aw_hug2_text = "продолжал стрелять из H.U.G.E. и обнаружил, что терпение вознаградило его {num} убийствами."

--- a/lua/terrortown/lang/sv.lua
+++ b/lua/terrortown/lang/sv.lua
@@ -39,9 +39,9 @@ L.win_time = "Tiden har tagit slut. Förrädarna har förlorat."
 --L.win_nones = "No-one won!"
 L.win_showreport = "Låt oss ta en titt på rund-rapporten i {num} sekunder."
 
-L.limit_round = "Gränsen för antalet rundor har nåtts. {mapname} kommer laddas snart."
-L.limit_time = "Tidsgränsen har tagit slut. {mapname} kommer laddas snart."
-L.limit_left = "{num} rundor eller {time} minuter återstår innan kartan ändras till {mapname}."
+--L.limit_round = "Round limit reached. The next map will load soon."
+--L.limit_time = "Time limit reached. The next map will load soon."
+--L.limit_left = "{num} round(s) or {time} minutes remaining before the map changes."
 
 -- Credit awards
 --L.credit_all = "Your team have been awarded {num} equipment credit(s) for your performance."
@@ -371,12 +371,10 @@ av dess användare.]]
 L.knife_name = "Kniv"
 L.knife_thrown = "Kastkniv"
 
-L.knife_desc = [[
-Dödar ganska skadade mål
-omedelbart och tyst, men har
-endast ett användningsområde.
-
-Kan kastas med {secondaryfire}]]
+--L.knife_desc = [[
+--Kills wounded targets instantly and silently, but only has a single use.
+--
+--Can be thrown using alternate fire.]]
 
 -- Poltergeist
 L.polter_desc = [[
@@ -444,7 +442,7 @@ L.dna_killer = "Hittade ett prov av mördarens DNA på liket!"
 --L.dna_duplicate = "Match! You already have this DNA sample in your scanner."
 L.dna_no_killer = "DNAt kunde inte återfås (har mördaren gått ur spelet?)"
 L.dna_armed = "Bomben går fortfarande! Desarmera den först!"
-L.dna_object = "Samlade in {num} nya DNA-prov från föremålet."
+--L.dna_object = "Collected a sample of the last owner from the object."
 L.dna_gone = "DNA kunde inte hittas i området. (Har mördaren gått ur spelet?)"
 
 L.dna_desc = [[
@@ -481,8 +479,8 @@ L.tele_no_mark = "Ingen plats markerad. Markera en destination innan du teleport
 L.tele_no_mark_ground = "Kan ej markera en teleporteringsplats om du inte står på fast mark!"
 L.tele_no_mark_crouch = "Kan ej markera en teleporteringsplats om du duckar!"
 
-L.tele_help_pri = "{primaryfire} teleporterar till markerad plats."
-L.tele_help_sec = "{secondaryfire} markerar nuvarande plats."
+--L.tele_help_pri = "Teleports to marked location"
+--L.tele_help_sec = "Marks current location"
 
 L.tele_desc = [[
 Teleportera till en
@@ -540,7 +538,7 @@ L.target_credits = "Sök igenom för att erhålla ospenderade krediter"
 L.tbut_single = "Engångsanvändning"
 L.tbut_reuse = "Omanvändningsbar"
 L.tbut_retime = "Omanvändningsbar efter {num} sekunder"
-L.tbut_help = "Tryck {key} för att aktivera"
+L.tbut_help = "Tryck {usekey} för att aktivera"
 
 -- Spectator muting of living/dead
 L.mute_living = "Levande spelare nedtystade"
@@ -672,7 +670,7 @@ L.tip36 = "En genomgång av spelläget finns tillgängligt under {helpkey}. I de
 
 L.tip37 = "På poängtavlan kan du klicka på någons namn och välja en tagg för dem, t.ex. 'misstänkt' eller 'vän'. Denna tagg dyker sedan upp om du siktar på spelaren."
 
-L.tip38 = "Många placerbara verktyg (såsom C4, Radio) kan sättas fast på väggar genom att klicka på {secondaryfire}."
+--L.tip38 = "Many of the placeable equipment items (such as C4, Radio) can be stuck on walls using secondary fire."
 
 L.tip39 = "C4 som exploderar på grund av en misslyckad desarmering har mindre explosionsradie än en C4 där timern når noll."
 
@@ -1242,16 +1240,16 @@ L.help_title = "Hjälp och Inställningar"
 --L.label_bind_disguiser = "Toggle disguiser"
 
 -- 2020-06-24
-L.dna_help_primary = "{primaryfire} för att ta DNA-prov"
-L.dna_help_secondary = "{secondaryfire} för att öppna skann-kontroller"
+--L.dna_help_primary = "Collect a DNA sample"
+--L.dna_help_secondary = "Switch the DNA slot"
 --L.dna_help_reload = "Delete a sample"
 
-L.binoc_help_pri = "{primaryfire} identifirerar ett lik."
-L.binoc_help_sec = "{secondaryfire} ändrar inzoomnings-nivån."
+--L.binoc_help_pri = "Search a body."
+--L.binoc_help_sec = "Change zoom level."
 
-L.vis_help_pri = "{primaryfire} släpper det aktiverade redskapet."
+--L.vis_help_pri = "Drop the activated device."
 
-L.decoy_help_pri = "{primaryfire} riggar Lockbetet."
+--L.decoy_help_pri = "Plant the Decoy."
 
 -- 2020-08-07
 --L.pickup_error_spec = "You cannot pick this up as a spectator."

--- a/lua/terrortown/lang/uk.lua
+++ b/lua/terrortown/lang/uk.lua
@@ -39,9 +39,9 @@ L.win_time = "Час вичерпано. Зрадники програли."
 --L.win_nones = "No-one won!"
 L.win_showreport = "Подивімось на звіт раунду протягом {num} секунд."
 
-L.limit_round = "Ліміт раундів досягнуто. {mapname} завантажиться скоро."
-L.limit_time = "Ліміт часу вичерпано. {mapname} завантажиться скоро."
-L.limit_left = "Залишилося {num} раундів чи {time} хвилин перед зміною мапи на {mapname}."
+--L.limit_round = "Round limit reached. The next map will load soon."
+--L.limit_time = "Time limit reached. The next map will load soon."
+--L.limit_left = "{num} round(s) or {time} minutes remaining before the map changes."
 
 -- Credit awards
 --L.credit_all = "Your team have been awarded {num} equipment credit(s) for your performance."
@@ -418,7 +418,7 @@ L.dna_killer = "З тіла взято зразок ДНК вбивці!"
 --L.dna_duplicate = "Match! You already have this DNA sample in your scanner."
 L.dna_no_killer = "ДНК не вдалося відновити (вбивця вийшов з гри?)."
 L.dna_armed = "Ця бомба працює! Спочатку знешкодьте його!"
-L.dna_object = "Зібрано {num} нових зразків ДНК з об’єкта."
+--L.dna_object = "Collected a sample of the last owner from the object."
 L.dna_gone = "ДНК поряд не виявлено."
 
 L.dna_desc = [[
@@ -453,8 +453,8 @@ L.tele_no_mark = "Локація телепортації не встановл�
 L.tele_no_mark_ground = "Неможливо позначити локацію телепортації поки під ногами немає поверхні!"
 L.tele_no_mark_crouch = "Неможливо позначити локацію телепортації навсидячки!"
 
-L.tele_help_pri = "Використовуйте {primaryfire}, щоб телепортуватися до позначеної локації."
-L.tele_help_sec = "Використовуйте {secondaryfire}, щоб позначити поточну локацію."
+--L.tele_help_pri = "Teleports to marked location"
+--L.tele_help_sec = "Marks current location"
 
 L.tele_desc = [[
 Телепортація до попередньо позначеного місця.
@@ -509,7 +509,7 @@ L.target_credits = "Огляньте, щоб отримати невитраче
 L.tbut_single = "Одноразове використання"
 L.tbut_reuse = "Багаторазове використання"
 L.tbut_retime = "Можна використати ще раз через {num} секунд"
-L.tbut_help = "Натисніть {key}, щоб активувати"
+L.tbut_help = "Натисніть {usekey}, щоб активувати"
 
 -- Spectator muting of living/dead
 L.mute_living = "Живі гравці заглушені"
@@ -1204,16 +1204,16 @@ L.help_title = "Допомога та Налаштування"
 --L.label_bind_disguiser = "Toggle disguiser"
 
 -- 2020-06-24
-L.dna_help_primary = "Використовуйте {primaryfire}, щоб зібрати зразок ДНК"
-L.dna_help_secondary = "Використовуйте {secondaryfire}, щоб відкрити панель сканування"
+--L.dna_help_primary = "Collect a DNA sample"
+--L.dna_help_secondary = "Switch the DNA slot"
 --L.dna_help_reload = "Delete a sample"
 
-L.binoc_help_pri = "{primaryfire} ідентифікувати тіло."
-L.binoc_help_sec = "{secondaryfire} змінити режим приближення."
+--L.binoc_help_pri = "Search a body."
+--L.binoc_help_sec = "Change zoom level."
 
-L.vis_help_pri = "{primaryfire} кинути активований пристрій."
+--L.vis_help_pri = "Drop the activated device."
 
-L.decoy_help_pri = "{primaryfire} встановити Приманку."
+--L.decoy_help_pri = "Plant the Decoy."
 
 -- 2020-08-07
 --L.pickup_error_spec = "You cannot pick this up as a spectator."

--- a/lua/terrortown/lang/zh_hans.lua
+++ b/lua/terrortown/lang/zh_hans.lua
@@ -406,7 +406,7 @@ L.dna_killer = "成功采集到凶手的DNA样本！"
 L.dna_duplicate = "匹配！你的扫描仪里已经有这个DNA样本了。"
 L.dna_no_killer = "DNA样本无法检索（凶手已离线？）"
 L.dna_armed = "炸弹已启动！赶紧拆除它！"
-L.dna_object = "在目标上采集到 {num} 个新DNA样本。"
+--L.dna_object = "Collected a sample of the last owner from the object."
 L.dna_gone = "区域内没侦测到可采集之DNA样本。"
 
 L.dna_desc = [[
@@ -440,8 +440,8 @@ L.tele_no_mark = "标记传送地点后才能传送。"
 L.tele_no_mark_ground = "站在地面上才能标记传送地点！"
 L.tele_no_mark_crouch = "站起来才能标记传送点！"
 
-L.tele_help_pri = "{primaryfire} 传送到已标记的传送地点。"
-L.tele_help_sec = "{scondaryfire} 标记传送地点。"
+--L.tele_help_pri = "Teleports to marked location"
+--L.tele_help_sec = "Marks current location"
 
 L.tele_desc = [[
 可以传送到先前标记的地点。
@@ -1467,7 +1467,7 @@ L.help_spawn_editor_info = [[
 L.help_spawn_editor_enable = "在某些地图上，可能会建议使用在地图自带的原始生成点，而不用动态系统来取代它们。禁用这个复选框只对当前活动地图禁用。其他地图仍将使用动态系统。"
 L.help_spawn_editor_hint = "提示：要离开生成编辑器，重新打开游戏模式菜单。"
 L.help_spawn_editor_spawn_amount = [[
-目前在这张地图上有 {weapon} 个武器生成点，{ammo} 个弹药生成点和 player} 个玩家生成点。
+目前在这张地图上有 {weapon} 个武器生成点，{ammo} 个弹药生成点和 {player} 个玩家生成点。
 点击'开始编辑生成'来改变这个生成。
 
 {weaponrandom}x 随机武器生成

--- a/lua/terrortown/lang/zh_tw.lua
+++ b/lua/terrortown/lang/zh_tw.lua
@@ -405,7 +405,7 @@ L.dna_killer = "成功採集到兇手的DNA樣本！"
 L.dna_duplicate = "匹配！你的掃描儀裡已經有這個DNA樣本了。"
 L.dna_no_killer = "DNA樣本無法檢索（兇手已斷線？）"
 L.dna_armed = "炸彈已啟動！趕緊拆除它！"
-L.dna_object = "在目標上採集到 {num} 個新DNA樣本。"
+--L.dna_object = "Collected a sample of the last owner from the object."
 L.dna_gone = "區域內沒偵測到可採集之DNA樣本。"
 
 L.dna_desc = [[
@@ -1466,7 +1466,7 @@ L.help_spawn_editor_info = [[
 L.help_spawn_editor_enable = "在某些地圖上，可能會建議使用在地圖自帶的原始生成點，而不用動態系統來取代它們。禁用這個複選框只對當前活動地圖禁用。其他地圖仍將使用動態系統。"
 L.help_spawn_editor_hint = "提示：要離開生成編輯器，重新打開遊戲模式菜單。"
 L.help_spawn_editor_spawn_amount = [[
-目前在這張地圖上有 {weapon} 個武器生成點，{ammo} 個彈藥生成點和 player} 個玩家生成點。
+目前在這張地圖上有 {weapon} 個武器生成點，{ammo} 個彈藥生成點和 {player} 個玩家生成點。
 點擊'開始編輯生成'來改變這個生成。
 
 {weaponrandom}x 隨機武器生成


### PR DESCRIPTION
Over the time some language strings changed. But this change was not applied to all languages. Since our new language tool is able to spot these, it was easy to fix them.

I also noticed a few errors that I could fix without removing the strings (missing brackets, wrong var names etc)