### PR TITLE
Fix: ComboBox integer values not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Optimized allocations by using global Vector / Angle when possible.
 - Fixed the dynamic armor damage calculation being wrong when damage can only get partially reduced
 - Fixed propspec inputs behaving sometimes unexpectedly (by @TimGoll)
+- Fixed ComboBoxes not working with integer values (by @NickCloudAT)
 
 ### Removed
 

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dform_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dform_ttt2.lua
@@ -319,9 +319,10 @@ function PANEL:MakeComboBox(data)
 			local choice = data.choices[i]
 
 			if istable(choice) then
-				right:AddChoice(choice.title, choice.value, choice.select, choice.icon, choice.data)
+				right:AddChoice(choice.title, tostring(choice.value), choice.select, choice.icon, choice.data)
 			else
 				-- Support old simple structure
+				choice = tostring(choice)
 				right:AddChoice(choice, choice)
 			end
 		end


### PR DESCRIPTION
For the new style only 1 tostring (for choice.value) is enough.

For the "old simple structure" we need a tostring for choice in general or it might error when mixing strings and integers as values because of the sorting methode.

Addresses: https://github.com/TTT-2/TTT2/issues/1071