### PR TITLE
fix: Deprecate `AccessorFuncDT` instead of removing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,9 +60,12 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed propspec inputs behaving sometimes unexpectedly (by @TimGoll)
 - Fixed ComboBoxes not working with integer values (by @NickCloudAT)
 
+### Deprecated
+
+- Deprecated `AccessorFuncDT()`, Addons should remove the function call and replace `DTVar()` calls with `NetworkVar()`
+
 ### Removed
 
-- Removed `AccessorfuncDT()` in favor of using gmod's `Accessorfunc()`
 - Removed spectator texts from the UI in favor of the new key binding information (by @TimGoll)
 
 ## [v0.11.7b](https://github.com/TTT-2/TTT2/tree/v0.11.7b) (2022-08-27)

--- a/lua/ttt2/libraries/none.lua
+++ b/lua/ttt2/libraries/none.lua
@@ -23,6 +23,28 @@ function clr(color)
 end
 
 ---
+-- This @{function} creates a getter and a setter @{function} for DTVars of an entity
+-- The create @{function} names are based on the var name and the prefix "Get" and "Set"
+-- @note Instead of using this function simply replace `ENT:DTVar()` calls with `ENT:NetworkVar()`.
+-- @param table tbl the @{table} that should receive the Getter and Setter @{function}
+-- @param string varname the name the tbl @{table} should have as key value
+-- @param string name the name that should be concatenated to the prefix "Get" and "Set"
+-- @deprecated
+-- @realm shared
+function AccessorFuncDT(tbl, varname, name)
+	MsgN("[DEPRECATION WARNING] Using `AccessorFuncDT` is deprecated and will be removed in a future version.")
+	tbl["Get" .. name] = function(s)
+		return s.dt and s.dt[varname]
+	end
+
+	tbl["Set" .. name] = function(s, v)
+		if s.dt then
+			s.dt[varname] = v
+		end
+	end
+end
+
+---
 -- Short helper for input.LookupBinding, returns capitalised key or a default
 -- @param string binding
 -- @param string default


### PR DESCRIPTION
Seems like a few other addons are using this function and removing it causes them to break. So we will deprecate it instead and give addon developers a chance to update their addons.

Sadly i have not found a good way to log which addon is still using this. Using `ErrorNoHaltWithStack()` will show the addon in the stacktrace but it will also be presented to players as "The addon 'TTT2' is causing errors".
So i went with `MsgN()` for now.