### PR TITLE
VGUI: Fix slider textbox

### DIFF
--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dnumslider_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dnumslider_ttt2.lua
@@ -31,11 +31,6 @@ function PANEL:Init()
 		self:SetValueFromTextBox()
 	end
 
-	-- On enter keypres, apply new values
-	self.TextArea.OnEnter = function(textarea, val)
-		self:SetValueFromTextBox()
-	end
-
 	self.TextArea.Paint = function(slf, w, h)
 		derma.SkinHook("Paint", "SliderTextAreaTTT2", slf, w, h)
 		return true
@@ -178,7 +173,6 @@ function PANEL:SetValue(value, ignoreCallbackEnabledVars)
 	self.m_fValue = value
 
 	self:ValueChanged(value)
-
 	-- Set ConVars only when Mouse is released
 	if ignoreCallbackEnabledVars or self:IsEditing() then return end
 
@@ -190,8 +184,7 @@ end
 function PANEL:SetValueFromTextBox()
 	local val = self.TextArea:GetText()
 	val = val ~= "" and val or 0
-	self:SetValue(self.TextArea:GetText())
-	self:SetCallbackEnabledVarValues(val)
+	self:SetValue(val)
 	self.TextArea:SetText(val)
 end
 
@@ -267,7 +260,7 @@ end
 -- @return boolean
 -- @realm client
 function PANEL:IsEditing()
-	return self.TextArea:IsEditing() or self.Slider:IsEditing()
+	return self.textBoxEnabled or self.Slider:IsEditing()
 end
 
 ---


### PR DESCRIPTION
Since the database rework #984, the slider textbox was causing errors and lead to an unusable shop per map.
![grafik](https://github.com/TTT-2/TTT2/assets/72046466/89a59d04-aade-4d37-8260-4698e1cbf3af)

This was because the textbox directly called the SetCallbackEnabledVarValues with a string, which is not handled by the database approach, but worked for convars.

Also optimized the textbox interaction:
- `OnEnter` also calls `OnLoseFocus`, so I removed it
- IsEditing now uses the new Textbox-Check
- Therefore no extra call to SetCallbackEnabledVarValues needs to be done


