### PR TITLE
UI: Moved reset buttons onto the left

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to TTT2 will be documented here. Inspired by [keep a changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Unreleased
+- Moved reset buttons onto the left (by @a7f3)
 
 ### Added
 

--- a/lua/terrortown/menus/gamemode/administration/entspawn.lua
+++ b/lua/terrortown/menus/gamemode/administration/entspawn.lua
@@ -134,7 +134,7 @@ function CLGAMEMODESUBMENU:PopulateButtonPanel(parent)
 
 	buttonReset:SetText("button_reset")
 	buttonReset:SetSize(100, 45)
-	buttonReset:SetPos(parent:GetWide() - 120, 20)
+	buttonReset:SetPos(20, 20)
 	buttonReset.DoClick = function()
 		entspawnscript.ResetMapToDefault()
 
@@ -145,7 +145,9 @@ function CLGAMEMODESUBMENU:PopulateButtonPanel(parent)
 
 	buttonToggle:SetText("button_start_entspawn_edit")
 	buttonToggle:SetSize(180, 45)
-	buttonToggle:SetPos(20, 20)
+
+	-- Don't really like the way the offset is done here, though I guess is better than a magic number
+	buttonToggle:SetPos(parent:GetWide() - (180 + 20 + 195 + 20), 20)
 	buttonToggle.DoClick = function(slf)
 		entspawnscript.StartEditing()
 
@@ -156,7 +158,7 @@ function CLGAMEMODESUBMENU:PopulateButtonPanel(parent)
 
 	buttonDelete:SetText("button_delete_all_spawns")
 	buttonDelete:SetSize(195, 45)
-	buttonDelete:SetPos(220, 20)
+	buttonDelete:SetPos(parent:GetWide() - (195 + 20), 20)
 	buttonDelete.DoClick = function(slf)
 		entspawnscript.DeleteAllSpawns()
 	end

--- a/lua/terrortown/menus/gamemode/administration/playermodels.lua
+++ b/lua/terrortown/menus/gamemode/administration/playermodels.lua
@@ -110,7 +110,7 @@ function CLGAMEMODESUBMENU:PopulateButtonPanel(parent)
 
 	buttonReset:SetText("button_reset_models")
 	buttonReset:SetSize(225, 45)
-	buttonReset:SetPos(parent:GetWide() - 245, 20)
+	buttonReset:SetPos(20, 20)
 	buttonReset.DoClick = function()
 		playermodels.Reset()
 	end

--- a/lua/terrortown/menus/gamemode/administration/rolelayering.lua
+++ b/lua/terrortown/menus/gamemode/administration/rolelayering.lua
@@ -44,7 +44,7 @@ function CLGAMEMODESUBMENU:PopulateButtonPanel(parent)
 
 	buttonReset:SetText("button_reset")
 	buttonReset:SetSize(100, 45)
-	buttonReset:SetPos(parent:GetWide() - 120, 20)
+	buttonReset:SetPos(20, 20)
 	buttonReset.DoClick = function()
 		rolelayering.SendDataToServer(ROLE_NONE, {})
 

--- a/lua/terrortown/menus/gamemode/appearance/hudswitcher.lua
+++ b/lua/terrortown/menus/gamemode/appearance/hudswitcher.lua
@@ -147,11 +147,24 @@ function CLGAMEMODESUBMENU:PopulateButtonPanel(parent)
 	local currentHUDName = HUDManager.GetHUD()
 	local currentHUD = huds.GetStored(currentHUDName)
 
+	local buttonReset = vgui.Create("DButtonTTT2", parent)
+
+	buttonReset:SetText("button_reset")
+	buttonReset:SetSize(100, 45)
+	buttonReset:SetPos(20, 20)
+	buttonReset.DoClick = function(btn)
+		if not currentHUD then return end
+
+		currentHUD:Reset()
+		currentHUD:SaveData()
+	end
+	buttonReset:SetEnabled(not currentHUD.disableHUDEditor)
+
 	local buttonEditor = vgui.Create("DButtonTTT2", parent)
 
 	buttonEditor:SetText("button_hud_editor")
 	buttonEditor:SetSize(175, 45)
-	buttonEditor:SetPos(20, 20)
+	buttonEditor:SetPos(parent:GetWide() - 195, 20)
 	buttonEditor.DoClick = function(btn)
 		if not currentHUDName then return end
 
@@ -161,18 +174,7 @@ function CLGAMEMODESUBMENU:PopulateButtonPanel(parent)
 	end
 	buttonEditor:SetEnabled(not currentHUD.disableHUDEditor)
 
-	local buttonReset = vgui.Create("DButtonTTT2", parent)
 
-	buttonReset:SetText("button_reset")
-	buttonReset:SetSize(100, 45)
-	buttonReset:SetPos(parent:GetWide() - 120, 20)
-	buttonReset.DoClick = function(btn)
-		if not currentHUD then return end
-
-		currentHUD:Reset()
-		currentHUD:SaveData()
-	end
-	buttonReset:SetEnabled(not currentHUD.disableHUDEditor)
 end
 
 function CLGAMEMODESUBMENU:HasButtonPanel()


### PR DESCRIPTION
Fixes #1098, and 2 more
Moved the `hudswitcher.lua` code block to be the same order logically as in the game

Screenshots:
![Screenshot from 2023-12-07 03-33-41](https://github.com/TTT-2/TTT2/assets/124642739/08daf0bb-2846-479f-bfe7-51954d0fc1ce)
![Screenshot from 2023-12-07 03-33-51](https://github.com/TTT-2/TTT2/assets/124642739/cf2d302e-bfcc-421c-a812-799246bf63a0)
![Screenshot from 2023-12-07 03-33-58](https://github.com/TTT-2/TTT2/assets/124642739/416d9eff-0c3a-4077-aa68-b0a1b3e4bb23)
![Screenshot from 2023-12-07 03-34-18](https://github.com/TTT-2/TTT2/assets/124642739/fba3e6f6-8928-4e32-8140-d04d85a0d290)
