### PR TITLE
fix: prevent nil error in database module

### DIFF
--- a/lua/ttt2/libraries/database.lua
+++ b/lua/ttt2/libraries/database.lua
@@ -1089,15 +1089,18 @@ if SERVER then
 				return true, value
 			end
 
-			local newTable = {}
-			for _key in pairs(dataTable.keys) do
-				newTable[_key] = sqlData[_key]
+			if sqlData then
+				local newTable = {}
+				for _key in pairs(dataTable.keys) do
+					newTable[_key] = sqlData[_key]
+				end
+
+				sqlData = newTable
+				ConvertTable(sqlData, accessName)
+
+				dataTable.storedData[itemName] = sqlData
 			end
 
-			sqlData = newTable
-			ConvertTable(sqlData, accessName)
-
-			dataTable.storedData[itemName] = sqlData
 		else
 			-- Get all data, convert and return it
 			sqlData = dataTable.orm:All()


### PR DESCRIPTION
In cases where `itemName` is not in the `accessName` database table a nil error would occur while trying to index `sqlData`.

`sqlData` is populated via the ORM library `:find(itemName)` function which returns the database entry with `itemName` as its primary key. This returns nil if no such entry is found.

This behaviour was not checked here and results in breaking the equipment shop.

The minimal working fix would be to if-clause only the `sqlData[_key]` access. I've scoped the if-clause over a few more items which should all be NOOPs in case of `sqlData` being nil.