### PR TITLE
Mini Scoreboard Confirmed Spectator Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
   - `DNumSliderTTT2`, `DCheckBoxLabelTTT2`, `DComboBoxTTT2`
 - Added dashing to propspec (by @TimGoll)
 - Added new functions to database module
-  -`database.SetDefaultValuesFromItem(accessName, itemName, item)` 
+  -`database.SetDefaultValuesFromItem(accessName, itemName, item)`
 
 ### Changed
 
@@ -99,6 +99,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - net.SendStream() can now also handle tables larger than 256kB, which exceeded the maximum net receive buffer
 - Fixed nil value of SetValue in `DNumSliderTTT2` , `DCheckBoxLabelTTT2`. And fix nil value for boxCache[name] in `PlayerModels` (by @sbzlzh)
 - Prevent weapon_tttbase Lua errors with NPCs (by @BuzzHaddaBig in base TTT)
+- Fix miniscoreboard HUD from showing confirmed players that switched to spectator as having been revived (by @EntranceJew)
 
 ### Deprecated
 

--- a/gamemodes/terrortown/gamemode/shared/hud_elements/tttminiscoreboard/pure_skin_miniscoreboard.lua
+++ b/gamemodes/terrortown/gamemode/shared/hud_elements/tttminiscoreboard/pure_skin_miniscoreboard.lua
@@ -179,7 +179,7 @@ function HUDELEMENT:Draw()
 		surface.SetDrawColor(clr(ply_color))
 		surface.DrawRect(tmp_x, tmp_y, self.ply_ind_size, self.ply_ind_size)
 
-		if ply:WasRevivedAndConfirmed() then
+		if not ply:IsSpec() and ply:WasRevivedAndConfirmed() then
 			draw.FilteredTexture(tmp_x + 3, tmp_y + 3, self.ply_ind_size - 6, self.ply_ind_size - 6, self.icon_revived, 180, COLOR_BLACK)
 		elseif ply:OnceFound() and not ply:RoleKnown() then -- draw marker on indirect confirmed bodies
 			draw.FilteredTexture(tmp_x + 3, tmp_y + 3, self.ply_ind_size - 6, self.ply_ind_size - 6, self.icon_in_conf, 120, COLOR_BLACK)


### PR DESCRIPTION
mini scoreboard kept showing confirmed players that became spectators as revived, which is wrong

video of before / after fix hotreloads:
https://github.com/TTT-2/TTT2/assets/5711436/baf1a083-4165-4a17-9395-550735f2e903

