### PR TITLE
ci: Bump neodoc version to fix workflow error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 env:
   GLUALINT_VERSION: 1.26.0
-  NEODOC_VERSION: 0.1.5
+  NEODOC_VERSION: 0.1.6
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch


### PR DESCRIPTION
This should fix our current neodoc ci failure
(or rather prevent it from happening again)