### PR TITLE
Fix missing fastutf8

### DIFF
--- a/gamemodes/terrortown/gamemode/shared/sh_init.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_init.lua
@@ -551,6 +551,7 @@ include("ttt2/extensions/input.lua")
 include("ttt2/extensions/cvars.lua")
 
 -- include libraries
+include("ttt2/libraries/fastutf8.lua")
 include("ttt2/libraries/huds.lua")
 include("ttt2/libraries/hudelements.lua")
 include("ttt2/libraries/items.lua")
@@ -577,7 +578,6 @@ include("ttt2/libraries/playermodels.lua")
 include("ttt2/libraries/entspawnscript.lua")
 include("ttt2/libraries/bodysearch.lua")
 include("ttt2/libraries/keyhelp.lua")
-include("ttt2/libraries/fastutf8.lua")
 
 -- include ttt required files
 ttt_include("sh_decal")

--- a/gamemodes/terrortown/gamemode/shared/sh_init.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_init.lua
@@ -577,6 +577,7 @@ include("ttt2/libraries/playermodels.lua")
 include("ttt2/libraries/entspawnscript.lua")
 include("ttt2/libraries/bodysearch.lua")
 include("ttt2/libraries/keyhelp.lua")
+include("ttt2/libraries/fastutf8.lua")
 
 -- include ttt required files
 ttt_include("sh_decal")


### PR DESCRIPTION
![image](https://github.com/TTT-2/TTT2/assets/92261479/ef8402e8-eeb1-42ae-bf6d-9c8bb78fcb05)
Fixed missing fastutf8, found that there seems to be something missing to introduce it correctly causing the error in the picture to occur when pressing F1 or pressing TAB after already using Chinese.