### PR TITLE
revert most of the change from #1006

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ### Fixed
 
 - Fixed the UI being unable to handle wrapping text with non-utf8 languages that do not use ASCII whitespaces (by @TimGoll & @saibotk)
+- Fixed ttt_game_text not working due to a refactor
 
 ## [v0.12.0b](https://github.com/TTT-2/TTT2/tree/v0.12.0b) (2023-12-11)
 


### PR DESCRIPTION
PR #1006 tried to simplify the gametext entity. While doing so it changed many things that break the functionality. This one is on us for being to lax while reviewing it. Most of these changes should not have been done.