### PR TITLE
Fix #1171, undefined entity after a player disconnected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed ttt_game_text not working due to a refactor
 - Fixed dete call HUD being invisible
 - Fixed edgecase where undefined killer angle or pos were accessed
-- Fixed a null entitiy error in the miniscoreboard
+- Fixed a null entity error in the miniscoreboard
 
 ## [v0.12.0b](https://github.com/TTT-2/TTT2/tree/v0.12.0b) (2023-12-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed ttt_game_text not working due to a refactor
 - Fixed dete call HUD being invisible
 - Fixed edgecase where undefined killer angle or pos were accessed
+- Fixed a null entitiy error in the miniscoreboard
 
 ## [v0.12.0b](https://github.com/TTT-2/TTT2/tree/v0.12.0b) (2023-12-11)
 

--- a/gamemodes/terrortown/gamemode/shared/hud_elements/tttminiscoreboard/pure_skin_miniscoreboard.lua
+++ b/gamemodes/terrortown/gamemode/shared/hud_elements/tttminiscoreboard/pure_skin_miniscoreboard.lua
@@ -179,10 +179,12 @@ function HUDELEMENT:Draw()
 		surface.SetDrawColor(clr(ply_color))
 		surface.DrawRect(tmp_x, tmp_y, self.ply_ind_size, self.ply_ind_size)
 
-		if ply:WasRevivedAndConfirmed() then
-			draw.FilteredTexture(tmp_x + 3, tmp_y + 3, self.ply_ind_size - 6, self.ply_ind_size - 6, self.icon_revived, 180, COLOR_BLACK)
-		elseif ply:OnceFound() and not ply:RoleKnown() then -- draw marker on indirect confirmed bodies
-			draw.FilteredTexture(tmp_x + 3, tmp_y + 3, self.ply_ind_size - 6, self.ply_ind_size - 6, self.icon_in_conf, 120, COLOR_BLACK)
+		if IsValid(ply) then
+			if ply:WasRevivedAndConfirmed() then
+				draw.FilteredTexture(tmp_x + 3, tmp_y + 3, self.ply_ind_size - 6, self.ply_ind_size - 6, self.icon_revived, 180, COLOR_BLACK)
+			elseif ply:OnceFound() and not ply:RoleKnown() then -- draw marker on indirect confirmed bodies
+				draw.FilteredTexture(tmp_x + 3, tmp_y + 3, self.ply_ind_size - 6, self.ply_ind_size - 6, self.icon_in_conf, 120, COLOR_BLACK)
+			end
 		end
 
 		-- draw lines around the element

--- a/gamemodes/terrortown/gamemode/shared/hud_elements/tttminiscoreboard/pure_skin_miniscoreboard.lua
+++ b/gamemodes/terrortown/gamemode/shared/hud_elements/tttminiscoreboard/pure_skin_miniscoreboard.lua
@@ -179,7 +179,7 @@ function HUDELEMENT:Draw()
 		surface.SetDrawColor(clr(ply_color))
 		surface.DrawRect(tmp_x, tmp_y, self.ply_ind_size, self.ply_ind_size)
 
-		if not ply:IsSpec() and ply:WasRevivedAndConfirmed() then
+		if ply:WasRevivedAndConfirmed() then
 			draw.FilteredTexture(tmp_x + 3, tmp_y + 3, self.ply_ind_size - 6, self.ply_ind_size - 6, self.icon_revived, 180, COLOR_BLACK)
 		elseif ply:OnceFound() and not ply:RoleKnown() then -- draw marker on indirect confirmed bodies
 			draw.FilteredTexture(tmp_x + 3, tmp_y + 3, self.ply_ind_size - 6, self.ply_ind_size - 6, self.icon_in_conf, 120, COLOR_BLACK)

--- a/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
@@ -953,7 +953,7 @@ end
 -- @return boolean
 -- @realm shared
 function plymeta:WasRevivedAndConfirmed()
-	return IsValid(self) and not ply:IsSpec() and not self:TTT2NETGetBool("body_found", false) and self:OnceFound()
+	return not self:IsSpec() and not self:TTT2NETGetBool("body_found", false) and self:OnceFound()
 end
 
 ---

--- a/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
@@ -953,7 +953,7 @@ end
 -- @return boolean
 -- @realm shared
 function plymeta:WasRevivedAndConfirmed()
-	return not self:TTT2NETGetBool("body_found", false) and self:OnceFound()
+	return IsValid(self) and not ply:IsSpec() and not self:TTT2NETGetBool("body_found", false) and self:OnceFound()
 end
 
 ---


### PR DESCRIPTION
@EntranceJew added a spec check in #1157. This causes issues if the player entity is null that were previously ignored. I added a validity check here.

I also moved the Spec check into the existing function, so all HUDs (e.g. octagonal) have this fix as well