### PR TITLE
Beacon: Rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ### Added
 
-- Added the beacon back into TTT2, a equipment weapon that was disabled long ago in base TTT
-  - A weapon that can only be bought by policing roles
-  - Adds a wallhack in a radius around them that is visible to anyone
+- Added the beacon back into TTT2, an equipment that was disabled long ago in base TTT
+  - Can only be bought by policing roles
+  - Creates a wallhack in a sphere around it, which is visible to everyone
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ## Unreleased
 
+### Added
+
+- Added the beacon back into TTT2, a equipment weapon that was disabled long ago in base TTT
+  - A weapon that can only be bought by policing roles
+  - Adds a wallhack in a radius around them that is visible to anyone
+
 ### Fixed
 
 - Fixed missing water level icon breaking scoreboard

--- a/gamemodes/terrortown/entities/entities/ttt_beacon.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_beacon.lua
@@ -21,6 +21,8 @@ local beaconDetectionRange = 135
 local soundZap = Sound("npc/assassin/ball_zap1.wav")
 local soundBeep = Sound("weapons/c4/cc4_beep1.wav")
 
+---
+-- @realm shared
 function ENT:Initialize()
 	self:SetModel(self.Model)
 
@@ -43,6 +45,9 @@ function ENT:Initialize()
 	end
 end
 
+---
+-- @param Entity activator
+-- @realm shared
 function ENT:UseOverride(activator)
 	if not IsValid(activator) or self:GetOwner() ~= activator then return end
 
@@ -59,6 +64,8 @@ function ENT:UseOverride(activator)
 	self:Remove()
 end
 
+---
+-- @realm shared
 function ENT:OnTakeDamage(dmginfo)
 	self:TakePhysicsDamage(dmginfo)
 	self:SetHealth(self:Health() - dmginfo:GetDamage())
@@ -79,6 +86,8 @@ function ENT:OnTakeDamage(dmginfo)
 	end
 end
 
+---
+-- @realm shared
 function ENT:Think()
 	if SERVER then
 		sound.Play(soundBeep, self:GetPos(), 100, 80)
@@ -107,6 +116,8 @@ function ENT:Think()
 end
 
 if SERVER then
+	---
+	-- @realm server
 	function ENT:UpdateTransmitState()
 		return TRANSMIT_ALWAYS
 	end

--- a/gamemodes/terrortown/entities/entities/ttt_beacon.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_beacon.lua
@@ -19,7 +19,7 @@ ENT.CanUseKey = true
 local beaconDetectionRange = 135
 
 local soundZap = Sound("npc/assassin/ball_zap1.wav")
-local soundBeep = Sound("weapons/c4/c4_soundBeep1.wav")
+local soundBeep = Sound("weapons/c4/cc4_beep1.wav")
 
 function ENT:Initialize()
 	self:SetModel(self.Model)
@@ -140,6 +140,7 @@ end
 
 if CLIENT then
 	local TryT = LANG.TryTranslation
+	local ParT = LANG.GetParamTranslation
 
 	local baseOpacity = 35
 	local factorRenderDistance = 3
@@ -148,7 +149,7 @@ if CLIENT then
 		marks.Remove(self.lastPlysFound or {})
 	end
 
-	-- handle looking at C4
+	-- handle looking at Beacon
 	hook.Add("TTTRenderEntityInfo", "HUDDrawTargetIDBeacon", function(tData)
 		local client = LocalPlayer()
 		local ent = tData:GetEntity()
@@ -164,8 +165,15 @@ if CLIENT then
 
 		tData:SetTitle(TryT(ent.PrintName))
 
-		tData:SetKeyBinding("+use")
-		--tData:AddDescriptionLine(TryT("c4_short_desc"))
+		if ent:GetOwner() == client then
+			tData:SetKeyBinding("+use")
+			tData:SetSubtitle(ParT("target_pickup", {usekey = Key("+use", "USE")}))
+		else
+			tData:AddIcon(roles.DETECTIVE.iconMaterial)
+			tData:SetSubtitle(TryT("beacon_pickup_disabled"))
+		end
+
+		tData:AddDescriptionLine(TryT("beacon_short_desc"))
 	end)
 
 	hook.Add("PostDrawTranslucentRenderables", "BeaconRenderRadius", function(_, bSkybox)

--- a/gamemodes/terrortown/entities/entities/ttt_beacon.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_beacon.lua
@@ -65,6 +65,7 @@ function ENT:UseOverride(activator)
 end
 
 ---
+-- @param CTakeDamageInfo dmginfo
 -- @realm shared
 function ENT:OnTakeDamage(dmginfo)
 	self:TakePhysicsDamage(dmginfo)
@@ -156,6 +157,8 @@ if CLIENT then
 	local baseOpacity = 35
 	local factorRenderDistance = 3
 
+	---
+	-- @realm client
 	function ENT:OnRemove()
 		marks.Remove(self.lastPlysFound or {})
 	end

--- a/gamemodes/terrortown/entities/entities/ttt_beacon.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_beacon.lua
@@ -1,0 +1,105 @@
+---
+-- @class ENT
+-- @section ttt_beacon
+
+if SERVER then
+	AddCSLuaFile()
+end
+
+if CLIENT then
+	ENT.Icon = "vgui/ttt/icon_beacon"
+	ENT.PrintName = "Beacon"
+end
+
+ENT.Type = "anim"
+ENT.Model = Model("models/props_lab/reciever01b.mdl")
+ENT.CanHavePrints = true
+ENT.CanUseKey = true
+
+function ENT:Initialize()
+	self:SetModel(self.Model)
+
+	if SERVER then
+		self:PhysicsInit(SOLID_VPHYSICS)
+	end
+
+	self:SetMoveType(MOVETYPE_VPHYSICS)
+	self:SetSolid(SOLID_VPHYSICS)
+	self:SetCollisionGroup(COLLISION_GROUP_INTERACTIVE)
+
+	if SERVER then
+		self:SetMaxHealth(100)
+	end
+	self:SetHealth(100)
+
+	if SERVER then
+		self:SetUseType(SIMPLE_USE)
+		self:NextThink(CurTime() + 1)
+	end
+end
+
+function ENT:UseOverride(activator)
+	if IsValid(activator) and self:GetOwner() == activator then
+		local wep = activator:GetWeapon("weapon_ttt_beacon")
+
+		if IsValid(wep) then
+			local pickup = wep:PickupBeacon()
+
+			if not pickup then return end
+			-- else pickup successful, continue with print transfer and removal
+		else
+			wep = activator:Give("weapon_ttt_beacon")
+		end
+
+		self:Remove()
+	end
+end
+
+local zapsound = Sound("npc/assassin/ball_zap1.wav")
+function ENT:OnTakeDamage(dmginfo)
+	self:TakePhysicsDamage(dmginfo)
+
+	self:SetHealth(self:Health() - dmginfo:GetDamage())
+
+	if self:Health() < 0 then
+		self:Remove()
+
+		local effect = EffectData()
+		effect:SetOrigin(self:GetPos())
+		util.Effect("cball_explode", effect)
+		sound.Play(zapsound, self:GetPos())
+
+		if IsValid(self:GetOwner()) then
+			TraitorMsg(self:GetOwner(), "ONE OF YOUR BEACONS HAS BEEN DESTROYED!")
+		end
+	end
+end
+
+local beep = Sound("weapons/c4/c4_beep1.wav")
+function ENT:Think()
+	if SERVER then
+		sound.Play(beep, self:GetPos(), 100, 80)
+	else
+		local dlight = DynamicLight(self:EntIndex())
+		if dlight then
+			dlight.Pos = self:GetPos()
+			dlight.r = 0
+			dlight.g = 0
+			dlight.b = 255
+			dlight.Brightness = 1
+			dlight.Size = 128
+			dlight.Decay = 500
+			dlight.DieTime = CurTime() + 0.1
+		end
+	end
+
+	self:NextThink(CurTime() + 5)
+
+	return true
+end
+
+if SERVER then
+	function ENT:UpdateTransmitState()
+		return TRANSMIT_ALWAYS
+	end
+end

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_beacon.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_beacon.lua
@@ -1,0 +1,227 @@
+---
+-- @class SWEP
+-- @section weapon_ttt_beacon
+
+if SERVER then
+	AddCSLuaFile()
+end
+
+DEFINE_BASECLASS "weapon_tttbase"
+
+SWEP.HoldType = "normal"
+
+if CLIENT then
+	SWEP.PrintName = "beacon_name"
+	SWEP.Slot = 6
+
+	SWEP.ViewModelFOV = 10
+	SWEP.ViewModelFlip = false
+
+	SWEP.EquipMenuData = {
+		type = "item_weapon",
+		desc = "beacon_desc"
+	}
+
+	SWEP.Icon = "vgui/ttt/icon_beacon"
+end
+
+SWEP.Base = "weapon_tttbase"
+
+SWEP.ViewModel = "models/weapons/v_crowbar.mdl"
+SWEP.WorldModel = "models/props_lab/reciever01b.mdl"
+
+SWEP.Primary.ClipSize = 3
+SWEP.Primary.DefaultClip = 1
+SWEP.Primary.Automatic = true
+SWEP.Primary.Ammo = "slam"
+SWEP.Primary.Delay = 1.0
+
+SWEP.Secondary.ClipSize = -1
+SWEP.Secondary.DefaultClip = -1
+SWEP.Secondary.Automatic = true
+SWEP.Secondary.Ammo = "none"
+SWEP.Secondary.Delay = 1.0
+
+SWEP.Kind = WEAPON_EQUIP
+
+SWEP.CanBuy = {ROLE_DETECTIVE}
+SWEP.LimitedStock = true -- only buyable once
+SWEP.WeaponID = AMMO_BEACON
+
+SWEP.Spawnable = true
+SWEP.AllowDrop = false
+SWEP.NoSights = true
+
+function SWEP:OnDrop()
+	self:Remove()
+end
+
+function SWEP:PrimaryAttack()
+	self:SetNextPrimaryFire( CurTime() + self.Primary.Delay )
+
+	if self:CanPrimaryAttack() then
+		self:BeaconDrop()
+	end
+end
+
+function SWEP:SecondaryAttack()
+	self:SetNextSecondaryFire( CurTime() + self.Secondary.Delay )
+
+	if self:CanPrimaryAttack() then
+		self:BeaconStick()
+	end
+end
+
+local throwsound = Sound( "Weapon_SLAM.SatchelThrow" )
+
+-- might be able to move this drop/stick stuff into something more general now
+-- that a number of weapons use it
+function SWEP:BeaconDrop()
+	if SERVER then
+		local ply = self:GetOwner()
+		if not IsValid(ply) then return end
+
+		if self.Planted then return end
+
+		local vsrc = ply:GetShootPos()
+		local vang = ply:GetAimVector()
+		local vvel = ply:GetVelocity()
+
+		local vthrow = vvel + vang * 200
+
+		local beacon = ents.Create("ttt_beacon")
+		if IsValid(beacon) then
+			beacon:SetPos(vsrc + vang * 10)
+			beacon:SetOwner(ply)
+			beacon:Spawn()
+
+			beacon:PointAtEntity(ply)
+
+			local ang = beacon:GetAngles()
+			ang:RotateAroundAxis(ang:Right(), 90)
+			beacon:SetAngles(ang)
+
+			beacon:PhysWake()
+			local phys = beacon:GetPhysicsObject()
+			if IsValid(phys) then
+				phys:SetVelocity(vthrow)
+			end
+
+			self:PlacedBeacon()
+		end
+	end
+
+	self:EmitSound(throwsound)
+end
+
+function SWEP:BeaconStick()
+	if SERVER then
+		local ply = self:GetOwner()
+
+		if not IsValid(ply) or not self.Planted then return end
+
+		local ignore = {ply, self}
+		local spos = ply:GetShootPos()
+		local epos = spos + ply:GetAimVector() * 80
+		local tr = util.TraceLine({
+			start = spos,
+			endpos = epos,
+			filter = ignore,
+			mask = MASK_SOLID
+		})
+
+		if tr.HitWorld then
+			local beacon = ents.Create("ttt_beacon")
+			if IsValid(beacon) then
+			beacon:PointAtEntity(ply)
+
+			local tr_ent = util.TraceEntity({
+				start = spos,
+				endpos = epos,
+				filter = ignore,
+				mask = MASK_SOLID
+			}, beacon)
+
+			if tr_ent.HitWorld then
+
+				local ang = tr_ent.HitNormal:Angle()
+				--ang:RotateAroundAxis(ang:Right(), -90)
+				--ang:RotateAroundAxis(ang:Up(), -180)
+				--ang:RotateAroundAxis(ang:Forward(), 90)
+
+				beacon:SetPos(tr_ent.HitPos + ang:Forward() * 2.5)
+				beacon:SetAngles(ang)
+				beacon:SetOwner(ply)
+				beacon:Spawn()
+
+				local phys = beacon:GetPhysicsObject()
+				if IsValid(phys) then
+					phys:EnableMotion(false)
+				end
+
+				beacon.IsOnWall = true
+
+				self:PlacedBeacon()
+			end
+			end
+		end
+	end
+end
+
+function SWEP:PlacedBeacon()
+	self:TakePrimaryAmmo(1)
+
+	if not self:CanPrimaryAttack() then
+		self:Remove()
+
+		self.Planted = true
+	end
+end
+
+function SWEP:PickupBeacon()
+	if self:Clip1() >= self.Primary.ClipSize then
+		return false
+	else
+		self:SetClip1(self:Clip1() + 1)
+		return true
+	end
+end
+
+-- Ammo hackery after getting bought
+function SWEP:WasBought(buyer)
+	self:SetClip1(self:Clip1() + 2)
+end
+
+function SWEP:Reload()
+	return false
+end
+
+function SWEP:OnRemove()
+	if CLIENT and IsValid(self:GetOwner()) and self:GetOwner() == LocalPlayer() and self:GetOwner():IsTerror() then
+		RunConsoleCommand("lastinv")
+	end
+end
+
+if CLIENT then
+	function SWEP:Initialize()
+		self:AddHUDHelp("Click to place the beacon")
+
+		return self.BaseClass.Initialize(self)
+	end
+end
+
+function SWEP:Deploy()
+	self:GetOwner():DrawViewModel(false)
+
+	return true
+end
+
+function SWEP:DrawWorldModel()
+	if not IsValid(self:GetOwner()) then
+		self:DrawModel()
+	end
+end
+
+function SWEP:DrawWorldModelTranslucent()
+
+end

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_beacon.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_beacon.lua
@@ -79,9 +79,8 @@ local throwsound = Sound( "Weapon_SLAM.SatchelThrow" )
 function SWEP:BeaconDrop()
 	if SERVER then
 		local ply = self:GetOwner()
-		if not IsValid(ply) then return end
 
-		if self.Planted then return end
+		if not IsValid(ply) then return end
 
 		local vsrc = ply:GetShootPos()
 		local vang = ply:GetAimVector()
@@ -118,7 +117,7 @@ function SWEP:BeaconStick()
 	if SERVER then
 		local ply = self:GetOwner()
 
-		if not IsValid(ply) or not self.Planted then return end
+		if not IsValid(ply) then return end
 
 		local ignore = {ply, self}
 		local spos = ply:GetShootPos()
@@ -133,36 +132,32 @@ function SWEP:BeaconStick()
 		if tr.HitWorld then
 			local beacon = ents.Create("ttt_beacon")
 			if IsValid(beacon) then
-			beacon:PointAtEntity(ply)
+				beacon:PointAtEntity(ply)
 
-			local tr_ent = util.TraceEntity({
-				start = spos,
-				endpos = epos,
-				filter = ignore,
-				mask = MASK_SOLID
-			}, beacon)
+				local tr_ent = util.TraceEntity({
+					start = spos,
+					endpos = epos,
+					filter = ignore,
+					mask = MASK_SOLID
+				}, beacon)
 
-			if tr_ent.HitWorld then
+				if tr_ent.HitWorld then
+					local ang = tr_ent.HitNormal:Angle()
 
-				local ang = tr_ent.HitNormal:Angle()
-				--ang:RotateAroundAxis(ang:Right(), -90)
-				--ang:RotateAroundAxis(ang:Up(), -180)
-				--ang:RotateAroundAxis(ang:Forward(), 90)
+					beacon:SetPos(tr_ent.HitPos + ang:Forward() * 2.5)
+					beacon:SetAngles(ang)
+					beacon:SetOwner(ply)
+					beacon:Spawn()
 
-				beacon:SetPos(tr_ent.HitPos + ang:Forward() * 2.5)
-				beacon:SetAngles(ang)
-				beacon:SetOwner(ply)
-				beacon:Spawn()
+					local phys = beacon:GetPhysicsObject()
+					if IsValid(phys) then
+						phys:EnableMotion(false)
+					end
 
-				local phys = beacon:GetPhysicsObject()
-				if IsValid(phys) then
-					phys:EnableMotion(false)
+					beacon.IsOnWall = true
+
+					self:PlacedBeacon()
 				end
-
-				beacon.IsOnWall = true
-
-				self:PlacedBeacon()
-			end
 			end
 		end
 	end
@@ -173,8 +168,6 @@ function SWEP:PlacedBeacon()
 
 	if not self:CanPrimaryAttack() then
 		self:Remove()
-
-		self.Planted = true
 	end
 end
 
@@ -204,7 +197,7 @@ end
 
 if CLIENT then
 	function SWEP:Initialize()
-		self:AddHUDHelp("Click to place the beacon")
+		self:AddTTT2HUDHelp("visualizer_help_pri", "visualizer_help_sec")
 
 		return self.BaseClass.Initialize(self)
 	end

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_beacon.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_beacon.lua
@@ -6,8 +6,6 @@ if SERVER then
 	AddCSLuaFile()
 end
 
-DEFINE_BASECLASS "weapon_tttbase"
-
 SWEP.HoldType = "normal"
 
 if CLIENT then

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_beacon.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_beacon.lua
@@ -237,7 +237,7 @@ if CLIENT then
 	---
 	-- @realm client
 	function SWEP:Initialize()
-		self:AddTTT2HUDHelp("visualizer_help_pri", "visualizer_help_sec")
+		self:AddTTT2HUDHelp("beacon_help_pri", "beacon_help_sec")
 
 		return self.BaseClass.Initialize(self)
 	end

--- a/lua/terrortown/lang/de.lua
+++ b/lua/terrortown/lang/de.lua
@@ -2073,3 +2073,18 @@ L.crowbar_help_secondary = "Spieler schubsen"
 --L.label_keyhelper_possession_dash = "prop: dash in view direction"
 --L.label_keyhelper_weapon_drop = "drop selected weapon if possible"
 --L.label_keyhelper_ammo_drop = "drop ammo from selected weapon out of clip"
+
+-- 2023-12-14
+--L.visualizer_help_pri = "Throw Beacon on the ground"
+--L.visualizer_help_sec = "Stick Beacon to surface"
+--L.beacon_name = "Beacon"
+--L.beacon_desc = [[
+--Broadcasts player locations to everyone in a sphere around this beacon.
+--
+--Use to keep track of locations on the map that are hard to see.]]
+
+--L.msg_beacon_destroyed = "One of your beacons has been destroyed!"
+--L.msg_beacon_death = "A player died in close proximity to one of your beacons."
+
+--L.beacon_pickup_disabled = "Only the owner of the beacon can pick it up"
+--L.beacon_short_desc = "Beacons are used by policing roles to add local wallhacks around them"

--- a/lua/terrortown/lang/en.lua
+++ b/lua/terrortown/lang/en.lua
@@ -2080,3 +2080,5 @@ L.beacon_desc = [[
 Broadcasts a location to everyone.
 
 Use to warn or group innocents.]]
+
+L.msg_beacon_destroyed = "One of your beacons has been destroyed!"

--- a/lua/terrortown/lang/en.lua
+++ b/lua/terrortown/lang/en.lua
@@ -2075,6 +2075,8 @@ L.label_keyhelper_weapon_drop = "drop selected weapon if possible"
 L.label_keyhelper_ammo_drop = "drop ammo from selected weapon out of clip"
 
 -- 2023-12-14
+L.visualizer_help_pri = "Throw Beacon on the ground"
+L.visualizer_help_sec = "Stick Beacon to surface"
 L.beacon_name = "Beacon"
 L.beacon_desc = [[
 Broadcasts player locations to everyone in a sphere around this beacon.
@@ -2082,3 +2084,7 @@ Broadcasts player locations to everyone in a sphere around this beacon.
 Use to keep track of locations on the map that are hard to see.]]
 
 L.msg_beacon_destroyed = "One of your beacons has been destroyed!"
+L.msg_beacon_death = "A player died in close proximity to one of your beacons."
+
+L.beacon_pickup_disabled = "Only the owner of the beacon can pick it up"
+L.beacon_short_desc = "Beacons are used by policing roles to add local wallhacks around them"

--- a/lua/terrortown/lang/en.lua
+++ b/lua/terrortown/lang/en.lua
@@ -2073,3 +2073,10 @@ L.label_spec_prop_dash = "Dash force multiplier"
 L.label_keyhelper_possession_dash = "prop: dash in view direction"
 L.label_keyhelper_weapon_drop = "drop selected weapon if possible"
 L.label_keyhelper_ammo_drop = "drop ammo from selected weapon out of clip"
+
+-- 2023-12-14
+L.beacon_name = "Beacon"
+L.beacon_desc = [[
+Broadcasts a location to everyone.
+
+Use to warn or group innocents.]]

--- a/lua/terrortown/lang/en.lua
+++ b/lua/terrortown/lang/en.lua
@@ -2077,8 +2077,8 @@ L.label_keyhelper_ammo_drop = "drop ammo from selected weapon out of clip"
 -- 2023-12-14
 L.beacon_name = "Beacon"
 L.beacon_desc = [[
-Broadcasts a location to everyone.
+Broadcasts player locations to everyone in a sphere around this beacon.
 
-Use to warn or group innocents.]]
+Use to keep track of locations on the map that are hard to see.]]
 
 L.msg_beacon_destroyed = "One of your beacons has been destroyed!"

--- a/lua/terrortown/lang/en.lua
+++ b/lua/terrortown/lang/en.lua
@@ -2075,8 +2075,8 @@ L.label_keyhelper_weapon_drop = "drop selected weapon if possible"
 L.label_keyhelper_ammo_drop = "drop ammo from selected weapon out of clip"
 
 -- 2023-12-14
-L.visualizer_help_pri = "Throw Beacon on the ground"
-L.visualizer_help_sec = "Stick Beacon to surface"
+L.beacon_help_pri = "Throw Beacon on the ground"
+L.beacon_help_sec = "Stick Beacon to surface"
 L.beacon_name = "Beacon"
 L.beacon_desc = [[
 Broadcasts player locations to everyone in a sphere around this beacon.

--- a/lua/terrortown/lang/es.lua
+++ b/lua/terrortown/lang/es.lua
@@ -2073,3 +2073,18 @@ L.search_eyes = "Gracias a tus habilidades de detective, has identificado que la
 --L.label_keyhelper_possession_dash = "prop: dash in view direction"
 --L.label_keyhelper_weapon_drop = "drop selected weapon if possible"
 --L.label_keyhelper_ammo_drop = "drop ammo from selected weapon out of clip"
+
+-- 2023-12-14
+--L.visualizer_help_pri = "Throw Beacon on the ground"
+--L.visualizer_help_sec = "Stick Beacon to surface"
+--L.beacon_name = "Beacon"
+--L.beacon_desc = [[
+--Broadcasts player locations to everyone in a sphere around this beacon.
+--
+--Use to keep track of locations on the map that are hard to see.]]
+
+--L.msg_beacon_destroyed = "One of your beacons has been destroyed!"
+--L.msg_beacon_death = "A player died in close proximity to one of your beacons."
+
+--L.beacon_pickup_disabled = "Only the owner of the beacon can pick it up"
+--L.beacon_short_desc = "Beacons are used by policing roles to add local wallhacks around them"

--- a/lua/terrortown/lang/fr.lua
+++ b/lua/terrortown/lang/fr.lua
@@ -2073,3 +2073,18 @@ L.search_eyes = "En utilisant vos compétences de détective, vous avez identifi
 --L.label_keyhelper_possession_dash = "prop: dash in view direction"
 --L.label_keyhelper_weapon_drop = "drop selected weapon if possible"
 --L.label_keyhelper_ammo_drop = "drop ammo from selected weapon out of clip"
+
+-- 2023-12-14
+--L.visualizer_help_pri = "Throw Beacon on the ground"
+--L.visualizer_help_sec = "Stick Beacon to surface"
+--L.beacon_name = "Beacon"
+--L.beacon_desc = [[
+--Broadcasts player locations to everyone in a sphere around this beacon.
+--
+--Use to keep track of locations on the map that are hard to see.]]
+
+--L.msg_beacon_destroyed = "One of your beacons has been destroyed!"
+--L.msg_beacon_death = "A player died in close proximity to one of your beacons."
+
+--L.beacon_pickup_disabled = "Only the owner of the beacon can pick it up"
+--L.beacon_short_desc = "Beacons are used by policing roles to add local wallhacks around them"

--- a/lua/terrortown/lang/it.lua
+++ b/lua/terrortown/lang/it.lua
@@ -2073,3 +2073,18 @@ L.search_eyes = "Usando le tue abilità da detective, hai identificato che l'ult
 --L.label_keyhelper_possession_dash = "prop: dash in view direction"
 --L.label_keyhelper_weapon_drop = "drop selected weapon if possible"
 --L.label_keyhelper_ammo_drop = "drop ammo from selected weapon out of clip"
+
+-- 2023-12-14
+--L.visualizer_help_pri = "Throw Beacon on the ground"
+--L.visualizer_help_sec = "Stick Beacon to surface"
+--L.beacon_name = "Beacon"
+--L.beacon_desc = [[
+--Broadcasts player locations to everyone in a sphere around this beacon.
+--
+--Use to keep track of locations on the map that are hard to see.]]
+
+--L.msg_beacon_destroyed = "One of your beacons has been destroyed!"
+--L.msg_beacon_death = "A player died in close proximity to one of your beacons."
+
+--L.beacon_pickup_disabled = "Only the owner of the beacon can pick it up"
+--L.beacon_short_desc = "Beacons are used by policing roles to add local wallhacks around them"

--- a/lua/terrortown/lang/ja.lua
+++ b/lua/terrortown/lang/ja.lua
@@ -2073,3 +2073,18 @@ L.search_eyes = "こいつが最後の人物は、{player}。こいつは敵か�
 --L.label_keyhelper_possession_dash = "prop: dash in view direction"
 --L.label_keyhelper_weapon_drop = "drop selected weapon if possible"
 --L.label_keyhelper_ammo_drop = "drop ammo from selected weapon out of clip"
+
+-- 2023-12-14
+--L.visualizer_help_pri = "Throw Beacon on the ground"
+--L.visualizer_help_sec = "Stick Beacon to surface"
+--L.beacon_name = "Beacon"
+--L.beacon_desc = [[
+--Broadcasts player locations to everyone in a sphere around this beacon.
+--
+--Use to keep track of locations on the map that are hard to see.]]
+
+--L.msg_beacon_destroyed = "One of your beacons has been destroyed!"
+--L.msg_beacon_death = "A player died in close proximity to one of your beacons."
+
+--L.beacon_pickup_disabled = "Only the owner of the beacon can pick it up"
+--L.beacon_short_desc = "Beacons are used by policing roles to add local wallhacks around them"

--- a/lua/terrortown/lang/pl.lua
+++ b/lua/terrortown/lang/pl.lua
@@ -2073,3 +2073,18 @@ L.search_eyes = "Używając umiejętności detektywa, zidentyfikowałeś ostatni
 --L.label_keyhelper_possession_dash = "prop: dash in view direction"
 --L.label_keyhelper_weapon_drop = "drop selected weapon if possible"
 --L.label_keyhelper_ammo_drop = "drop ammo from selected weapon out of clip"
+
+-- 2023-12-14
+--L.visualizer_help_pri = "Throw Beacon on the ground"
+--L.visualizer_help_sec = "Stick Beacon to surface"
+--L.beacon_name = "Beacon"
+--L.beacon_desc = [[
+--Broadcasts player locations to everyone in a sphere around this beacon.
+--
+--Use to keep track of locations on the map that are hard to see.]]
+
+--L.msg_beacon_destroyed = "One of your beacons has been destroyed!"
+--L.msg_beacon_death = "A player died in close proximity to one of your beacons."
+
+--L.beacon_pickup_disabled = "Only the owner of the beacon can pick it up"
+--L.beacon_short_desc = "Beacons are used by policing roles to add local wallhacks around them"

--- a/lua/terrortown/lang/pt_br.lua
+++ b/lua/terrortown/lang/pt_br.lua
@@ -2073,3 +2073,18 @@ L.search_eyes = "Usando suas técnicas de detetive, você identificou a última 
 --L.label_keyhelper_possession_dash = "prop: dash in view direction"
 --L.label_keyhelper_weapon_drop = "drop selected weapon if possible"
 --L.label_keyhelper_ammo_drop = "drop ammo from selected weapon out of clip"
+
+-- 2023-12-14
+--L.visualizer_help_pri = "Throw Beacon on the ground"
+--L.visualizer_help_sec = "Stick Beacon to surface"
+--L.beacon_name = "Beacon"
+--L.beacon_desc = [[
+--Broadcasts player locations to everyone in a sphere around this beacon.
+--
+--Use to keep track of locations on the map that are hard to see.]]
+
+--L.msg_beacon_destroyed = "One of your beacons has been destroyed!"
+--L.msg_beacon_death = "A player died in close proximity to one of your beacons."
+
+--L.beacon_pickup_disabled = "Only the owner of the beacon can pick it up"
+--L.beacon_short_desc = "Beacons are used by policing roles to add local wallhacks around them"

--- a/lua/terrortown/lang/ru.lua
+++ b/lua/terrortown/lang/ru.lua
@@ -2075,3 +2075,18 @@ L.search_eyes = "Используя свои детективные навыки
 --L.label_keyhelper_possession_dash = "prop: dash in view direction"
 --L.label_keyhelper_weapon_drop = "drop selected weapon if possible"
 --L.label_keyhelper_ammo_drop = "drop ammo from selected weapon out of clip"
+
+-- 2023-12-14
+--L.visualizer_help_pri = "Throw Beacon on the ground"
+--L.visualizer_help_sec = "Stick Beacon to surface"
+--L.beacon_name = "Beacon"
+--L.beacon_desc = [[
+--Broadcasts player locations to everyone in a sphere around this beacon.
+--
+--Use to keep track of locations on the map that are hard to see.]]
+
+--L.msg_beacon_destroyed = "One of your beacons has been destroyed!"
+--L.msg_beacon_death = "A player died in close proximity to one of your beacons."
+
+--L.beacon_pickup_disabled = "Only the owner of the beacon can pick it up"
+--L.beacon_short_desc = "Beacons are used by policing roles to add local wallhacks around them"

--- a/lua/terrortown/lang/sv.lua
+++ b/lua/terrortown/lang/sv.lua
@@ -2073,3 +2073,18 @@ L.search_eyes = "Genom att använda dina detektivfärdigheter kan du identifiera
 --L.label_keyhelper_possession_dash = "prop: dash in view direction"
 --L.label_keyhelper_weapon_drop = "drop selected weapon if possible"
 --L.label_keyhelper_ammo_drop = "drop ammo from selected weapon out of clip"
+
+-- 2023-12-14
+--L.visualizer_help_pri = "Throw Beacon on the ground"
+--L.visualizer_help_sec = "Stick Beacon to surface"
+--L.beacon_name = "Beacon"
+--L.beacon_desc = [[
+--Broadcasts player locations to everyone in a sphere around this beacon.
+--
+--Use to keep track of locations on the map that are hard to see.]]
+
+--L.msg_beacon_destroyed = "One of your beacons has been destroyed!"
+--L.msg_beacon_death = "A player died in close proximity to one of your beacons."
+
+--L.beacon_pickup_disabled = "Only the owner of the beacon can pick it up"
+--L.beacon_short_desc = "Beacons are used by policing roles to add local wallhacks around them"

--- a/lua/terrortown/lang/tr.lua
+++ b/lua/terrortown/lang/tr.lua
@@ -2072,3 +2072,18 @@ L.label_spec_prop_dash = "Atılma kuvveti çarpanı"
 L.label_keyhelper_possession_dash = "nesne: bakılan yönde atıl"
 L.label_keyhelper_weapon_drop = "mümkünse seçilen silahı bırak"
 L.label_keyhelper_ammo_drop = "seçilen silahın şarjöründen cephane çıkar"
+
+-- 2023-12-14
+--L.visualizer_help_pri = "Throw Beacon on the ground"
+--L.visualizer_help_sec = "Stick Beacon to surface"
+--L.beacon_name = "Beacon"
+--L.beacon_desc = [[
+--Broadcasts player locations to everyone in a sphere around this beacon.
+--
+--Use to keep track of locations on the map that are hard to see.]]
+
+--L.msg_beacon_destroyed = "One of your beacons has been destroyed!"
+--L.msg_beacon_death = "A player died in close proximity to one of your beacons."
+
+--L.beacon_pickup_disabled = "Only the owner of the beacon can pick it up"
+--L.beacon_short_desc = "Beacons are used by policing roles to add local wallhacks around them"

--- a/lua/terrortown/lang/uk.lua
+++ b/lua/terrortown/lang/uk.lua
@@ -2073,3 +2073,18 @@ L.search_eyes = "Використовуючи свої навички детек
 --L.label_keyhelper_possession_dash = "prop: dash in view direction"
 --L.label_keyhelper_weapon_drop = "drop selected weapon if possible"
 --L.label_keyhelper_ammo_drop = "drop ammo from selected weapon out of clip"
+
+-- 2023-12-14
+--L.visualizer_help_pri = "Throw Beacon on the ground"
+--L.visualizer_help_sec = "Stick Beacon to surface"
+--L.beacon_name = "Beacon"
+--L.beacon_desc = [[
+--Broadcasts player locations to everyone in a sphere around this beacon.
+--
+--Use to keep track of locations on the map that are hard to see.]]
+
+--L.msg_beacon_destroyed = "One of your beacons has been destroyed!"
+--L.msg_beacon_death = "A player died in close proximity to one of your beacons."
+
+--L.beacon_pickup_disabled = "Only the owner of the beacon can pick it up"
+--L.beacon_short_desc = "Beacons are used by policing roles to add local wallhacks around them"

--- a/lua/terrortown/lang/zh_hans.lua
+++ b/lua/terrortown/lang/zh_hans.lua
@@ -2073,3 +2073,18 @@ L.label_spec_prop_dash = "冲刺力倍增器"
 L.label_keyhelper_possession_dash = "prop：向视线方向冲刺"
 L.label_keyhelper_weapon_drop = "尽可能丢出所选武器"
 L.label_keyhelper_ammo_drop = "将选定武器的弹药从弹夹中取出"
+
+-- 2023-12-14
+--L.visualizer_help_pri = "Throw Beacon on the ground"
+--L.visualizer_help_sec = "Stick Beacon to surface"
+--L.beacon_name = "Beacon"
+--L.beacon_desc = [[
+--Broadcasts player locations to everyone in a sphere around this beacon.
+--
+--Use to keep track of locations on the map that are hard to see.]]
+
+--L.msg_beacon_destroyed = "One of your beacons has been destroyed!"
+--L.msg_beacon_death = "A player died in close proximity to one of your beacons."
+
+--L.beacon_pickup_disabled = "Only the owner of the beacon can pick it up"
+--L.beacon_short_desc = "Beacons are used by policing roles to add local wallhacks around them"

--- a/lua/terrortown/lang/zh_tw.lua
+++ b/lua/terrortown/lang/zh_tw.lua
@@ -2073,3 +2073,18 @@ L.search_eyes = "透過你的探查技能，你確信他臨死前見到的最後
 --L.label_keyhelper_possession_dash = "prop: dash in view direction"
 --L.label_keyhelper_weapon_drop = "drop selected weapon if possible"
 --L.label_keyhelper_ammo_drop = "drop ammo from selected weapon out of clip"
+
+-- 2023-12-14
+--L.visualizer_help_pri = "Throw Beacon on the ground"
+--L.visualizer_help_sec = "Stick Beacon to surface"
+--L.beacon_name = "Beacon"
+--L.beacon_desc = [[
+--Broadcasts player locations to everyone in a sphere around this beacon.
+--
+--Use to keep track of locations on the map that are hard to see.]]
+
+--L.msg_beacon_destroyed = "One of your beacons has been destroyed!"
+--L.msg_beacon_death = "A player died in close proximity to one of your beacons."
+
+--L.beacon_pickup_disabled = "Only the owner of the beacon can pick it up"
+--L.beacon_short_desc = "Beacons are used by policing roles to add local wallhacks around them"


### PR DESCRIPTION
TTT has a disabled item called "Beacon". Its use is pretty limited and was therefore disabled. While working on the entity bringdown vol2 I got an idea on how to add some fun to this weapon:

The beacon is now a "live-radar" that only works in a small-ish sphere. It uses the marks module for this:
![image](https://github.com/TTT-2/TTT2/assets/13639408/fd6deeac-d842-44ca-a3a9-a473f4558f5a)
Once a player walks out of this sphere, the wallhack is removed again.

The owner of the beacon is also informed about two events:
- a player died next to their beacon
- one of their beacons was destroyed