### PR TITLE
Equipment Menu: command for opening a specific tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ## Unreleased
 
+### Added
+
+- Added `ttt_cl_traitorpopup_tab` to allow players or addons to open a specified tab in the Equipment Menu (by @Spanospy):
+  - Example: `ttt_cl_traitorpopup_tab "Transfer"` for opening the credit transfer selection tab.
+
 ### Fixed
 
 - Binoculars scan no longer gets interrupted when changing zoom level

--- a/gamemodes/terrortown/gamemode/client/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_equip.lua
@@ -957,6 +957,45 @@ end
 concommand.Add("ttt_cl_traitorpopup_close", ForceCloseTraitorMenu)
 
 --
+-- Opens the menu to a specified tab, if it exists.
+--
+
+local function SwitchTraitorMenuTab(ply, cmd, args)
+
+	--Open the menu if it's not already open
+	if not IsValid(eqframe) then
+		TraitorMenuPopup()
+	end
+
+	if IsValid(eqframe) then
+
+		---@cast eqframe -nil
+		local dsheet = eqframe:Find("DPropertySheet") --Or eqframe:GetChild(4) ?
+
+		local tabs = dsheet:GetItems()
+		local tabindex = nil
+
+		local targettab = args[1]
+
+		for index,tab in pairs(tabs) do
+			if tab.Name == targettab then
+				tabindex = index
+				break
+			end
+		end
+
+		if tabindex then
+			dsheet:SetActiveTab(tabs[tabindex].Tab)
+		else
+			ForceCloseTraitorMenu()
+			print("No tab named " .. targettab .. " found!") --TODO lang this?
+		end
+
+	end
+end
+concommand.Add("ttt_cl_traitorpopup_tab", SwitchTraitorMenuTab)
+
+--
 -- NET RELATED STUFF:
 --
 

--- a/gamemodes/terrortown/gamemode/client/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_equip.lua
@@ -963,7 +963,7 @@ concommand.Add("ttt_cl_traitorpopup_close", ForceCloseTraitorMenu)
 local function SwitchTraitorMenuTab(ply, cmd, args)
 
 	local closeIfNotFound
-	local targettab = args[1]
+	local targettab = args[1]:lower()
 
 	if not targettab then return end
 
@@ -984,7 +984,7 @@ local function SwitchTraitorMenuTab(ply, cmd, args)
 		local tabindex = nil
 
 		for index,tab in pairs(tabs) do
-			if tab.Name == targettab then
+			if tab.Name:lower() == targettab then
 				tabindex = index
 				break
 			end

--- a/gamemodes/terrortown/gamemode/client/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_equip.lua
@@ -962,9 +962,17 @@ concommand.Add("ttt_cl_traitorpopup_close", ForceCloseTraitorMenu)
 
 local function SwitchTraitorMenuTab(ply, cmd, args)
 
+	local closeIfNotFound
+	local targettab = args[1]
+
+	if not targettab then return end
+
 	--Open the menu if it's not already open
 	if not IsValid(eqframe) then
 		TraitorMenuPopup()
+		closeIfNotFound = true
+	else
+		closeIfNotFound = false
 	end
 
 	if IsValid(eqframe) then
@@ -974,8 +982,6 @@ local function SwitchTraitorMenuTab(ply, cmd, args)
 
 		local tabs = dsheet:GetItems()
 		local tabindex = nil
-
-		local targettab = args[1]
 
 		for index,tab in pairs(tabs) do
 			if tab.Name == targettab then
@@ -987,7 +993,9 @@ local function SwitchTraitorMenuTab(ply, cmd, args)
 		if tabindex then
 			dsheet:SetActiveTab(tabs[tabindex].Tab)
 		else
-			ForceCloseTraitorMenu()
+			if closeIfNotFound then
+				ForceCloseTraitorMenu()
+			end
 			print("No tab named " .. targettab .. " found!") --TODO lang this?
 		end
 

--- a/gamemodes/terrortown/gamemode/client/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_equip.lua
@@ -962,41 +962,48 @@ concommand.Add("ttt_cl_traitorpopup_close", ForceCloseTraitorMenu)
 
 local function SwitchTraitorMenuTab(ply, cmd, args)
 
-	local closeIfNotFound
-	local targettab = args[1]:lower()
+	if not args[1] then return end
 
-	if not targettab then return end
+	local MenuWasOpen
+	local TargetTab = args[1]:lower()
 
-	--Open the menu if it's not already open
+	-- Ensure the menu is open, and track whether it was already.
 	if not IsValid(eqframe) then
 		TraitorMenuPopup()
-		closeIfNotFound = true
+		MenuWasOpen = false
 	else
-		closeIfNotFound = false
+		MenuWasOpen = true
 	end
 
 	if IsValid(eqframe) then
 
 		---@cast eqframe -nil
-		local dsheet = eqframe:Find("DPropertySheet") --Or eqframe:GetChild(4) ?
+		local dsheet = eqframe:Find("DPropertySheet")
 
 		local tabs = dsheet:GetItems()
-		local tabindex = nil
+		local FoundTab = nil
 
-		for index,tab in pairs(tabs) do
-			if tab.Name:lower() == targettab then
-				tabindex = index
+		for index,TabItem in pairs(tabs) do
+			if TabItem.Name:lower() == TargetTab then
+				FoundTab = TabItem.Tab
 				break
 			end
 		end
 
-		if tabindex then
-			dsheet:SetActiveTab(tabs[tabindex].Tab)
+		if FoundTab then
+			if dsheet:GetActiveTab() == FoundTab then
+				if MenuWasOpen then
+					--This allows the menu to be closed using the same command / arg to open it
+					ForceCloseTraitorMenu()
+				end
+			else
+				dsheet:SetActiveTab(FoundTab)
+			end
 		else
-			if closeIfNotFound then
+			if not MenuWasOpen then
 				ForceCloseTraitorMenu()
 			end
-			print("No tab named " .. targettab .. " found!") --TODO lang this?
+			print("ttt_cl_traitorpopup_tab failed, No tab named " .. TargetTab .. " was found")
 		end
 
 	end


### PR DESCRIPTION
Mainly throwing this pull request to get some feedback/opinions on adding this.

My use case is that I want my addon to be able to display a tab it adds, for example when a user presses a keybind for it. For now I just have it open the tab as soon as it's brought: [link](https://github.com/Spanospy/ttt2-item_beacon_hacker/blob/2c38a74c62646fd67bc4e79c3ff0283214e50d42/lua/terrortown/entities/items/item_beacon_hacker.lua#L107)

The way this is implemented also allows users to make their own bindings to quickly open the transfer, radio or disguise tabs, if they so wish.

I am aware that this half-a-decade old equipment menu is probably due for a overhaul, even if just UI wise. Still, I feel like the idea of this functionality could be useful to have.