### PR TITLE
Radio: Only owner can pickup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ### Changed
 
 - Updated the Turkish localization file (by @NovaDiablox)
+- Radio can now only be picked up by placer
 
 ### Fixed
 

--- a/gamemodes/terrortown/entities/entities/ttt_radio.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_radio.lua
@@ -57,7 +57,7 @@ end
 -- @param Player activator
 -- @realm shared
 function ENT:UseOverride(activator)
-	if IsValid(activator) and activator:IsPlayer() and activator:IsInTeam(self:GetOwner()) then
+	if IsValid(activator) and activator:IsPlayer() and activator == self:GetOwner() then
 		local prints = self.fingerprints or {}
 
 		-- picks up weapon, switches if possible and needed, returns weapon if successful
@@ -71,7 +71,7 @@ function ENT:UseOverride(activator)
 
 		table.Add(wep.fingerprints, prints)
 	else
-		LANG.Msg(activator, "radio_pickup_wrong_team")
+		LANG.Msg(activator, "entity_pickup_owner_only")
 	end
 end
 
@@ -316,7 +316,13 @@ if CLIENT then
 		tData:SetOutlineColor(client:GetRoleColor())
 
 		tData:SetTitle(TryT(ent.PrintName))
-		tData:SetSubtitle(ParT("target_pickup", {usekey = Key("+use", "USE")}))
+
+		if ent:GetOwner() == client then
+			tData:SetSubtitle(ParT("target_pickup", {usekey = Key("+use", "USE")}))
+		else
+			tData:SetSubtitle(TryT("entity_pickup_owner_only"))
+		end
+
 		tData:SetKeyBinding("+use")
 		tData:AddDescriptionLine(TryT("radio_short_desc"))
 	end)

--- a/lua/terrortown/lang/de.lua
+++ b/lua/terrortown/lang/de.lua
@@ -2072,3 +2072,6 @@ L.crowbar_help_secondary = "Spieler schubsen"
 --L.label_keyhelper_possession_dash = "prop: dash in view direction"
 --L.label_keyhelper_weapon_drop = "drop selected weapon if possible"
 --L.label_keyhelper_ammo_drop = "drop ammo from selected weapon out of clip"
+
+-- 2023-11-18
+--L.entity_pickup_owner_only = "Only the owner can pick this up"

--- a/lua/terrortown/lang/de.lua
+++ b/lua/terrortown/lang/de.lua
@@ -914,7 +914,6 @@ L.target_switch_drop_weapon_info_noslot = "In Inventatplatz {slot} ist keine weg
 L.corpse_searched_by_detective = "Diese Leiche wurde von einer öffentlichen Ordnungsrolle untersucht"
 L.corpse_too_far_away = "Leiche zu weit weg zum Untersuchen."
 
-L.radio_pickup_wrong_team = "Du kannst nicht das Radio eines anderen Teams aufheben."
 L.radio_short_desc = "Waffengeräusche sind Musik für mich"
 
 L.hstation_subtitle = "Drücke [{usekey}] um Leben zu regenerieren."

--- a/lua/terrortown/lang/en.lua
+++ b/lua/terrortown/lang/en.lua
@@ -914,7 +914,6 @@ L.target_switch_drop_weapon_info_noslot = "There is no droppable weapon in slot 
 L.corpse_searched_by_detective = "This corpse was searched by a public policing role"
 L.corpse_too_far_away = "The corpse is too far away."
 
-L.radio_pickup_wrong_team = "You can't pick up the radio from another team."
 L.radio_short_desc = "Weapon sounds are music to me"
 
 L.hstation_subtitle = "Press [{usekey}] to receive health."
@@ -2073,3 +2072,5 @@ L.label_spec_prop_dash = "Dash force multiplier"
 L.label_keyhelper_possession_dash = "prop: dash in view direction"
 L.label_keyhelper_weapon_drop = "drop selected weapon if possible"
 L.label_keyhelper_ammo_drop = "drop ammo from selected weapon out of clip"
+
+L.entity_pickup_owner_only = "Only the owner can pick this up"

--- a/lua/terrortown/lang/en.lua
+++ b/lua/terrortown/lang/en.lua
@@ -2073,4 +2073,5 @@ L.label_keyhelper_possession_dash = "prop: dash in view direction"
 L.label_keyhelper_weapon_drop = "drop selected weapon if possible"
 L.label_keyhelper_ammo_drop = "drop ammo from selected weapon out of clip"
 
+-- 2023-11-18
 L.entity_pickup_owner_only = "Only the owner can pick this up"

--- a/lua/terrortown/lang/es.lua
+++ b/lua/terrortown/lang/es.lua
@@ -914,7 +914,6 @@ L.target_switch_drop_weapon_info_noslot = "No hay un arma que esté ocupando el 
 --L.corpse_searched_by_detective = "This corpse was searched by a public policing role"
 L.corpse_too_far_away = "El cadáver está muy lejos."
 
-L.radio_pickup_wrong_team = "No puedes recoger la radio de otro equipo."
 L.radio_short_desc = "Los sonidos de las armas son música para mis oídos"
 
 L.hstation_subtitle = "Mantén presionado [{usekey}] para recibir curación."

--- a/lua/terrortown/lang/es.lua
+++ b/lua/terrortown/lang/es.lua
@@ -2072,3 +2072,6 @@ L.search_eyes = "Gracias a tus habilidades de detective, has identificado que la
 --L.label_keyhelper_possession_dash = "prop: dash in view direction"
 --L.label_keyhelper_weapon_drop = "drop selected weapon if possible"
 --L.label_keyhelper_ammo_drop = "drop ammo from selected weapon out of clip"
+
+-- 2023-11-18
+--L.entity_pickup_owner_only = "Only the owner can pick this up"

--- a/lua/terrortown/lang/fr.lua
+++ b/lua/terrortown/lang/fr.lua
@@ -914,7 +914,6 @@ L.target_switch_drop_weapon_info_noslot = "Il n'y a pas d'arme à lâcher dans c
 --L.corpse_searched_by_detective = "This corpse was searched by a public policing role"
 L.corpse_too_far_away = "Ce cadavre est trop loin."
 
-L.radio_pickup_wrong_team = "Vous ne pouvez pas prendre la radio d'une autre team."
 L.radio_short_desc = "Les sons des armes sont de la musique pour moi"
 
 L.hstation_subtitle = "Appuyez sur [{usekey}] pour recevoir des soins."

--- a/lua/terrortown/lang/fr.lua
+++ b/lua/terrortown/lang/fr.lua
@@ -2072,3 +2072,6 @@ L.search_eyes = "En utilisant vos compétences de détective, vous avez identifi
 --L.label_keyhelper_possession_dash = "prop: dash in view direction"
 --L.label_keyhelper_weapon_drop = "drop selected weapon if possible"
 --L.label_keyhelper_ammo_drop = "drop ammo from selected weapon out of clip"
+
+-- 2023-11-18
+--L.entity_pickup_owner_only = "Only the owner can pick this up"

--- a/lua/terrortown/lang/it.lua
+++ b/lua/terrortown/lang/it.lua
@@ -914,7 +914,6 @@ L.target_switch_drop_weapon_info_noslot = "Non c'è un'arma che puoi lasciare ne
 --L.corpse_searched_by_detective = "This corpse was searched by a public policing role"
 L.corpse_too_far_away = "Il cadavere è troppo lontano."
 
-L.radio_pickup_wrong_team = "Non puoi prendere la radio di un'altra squadra."
 L.radio_short_desc = "I suoni delle armi sono come musica per me"
 
 L.hstation_subtitle = "Premi [{usekey}] per ricevere vita."

--- a/lua/terrortown/lang/it.lua
+++ b/lua/terrortown/lang/it.lua
@@ -2072,3 +2072,6 @@ L.search_eyes = "Usando le tue abilità da detective, hai identificato che l'ult
 --L.label_keyhelper_possession_dash = "prop: dash in view direction"
 --L.label_keyhelper_weapon_drop = "drop selected weapon if possible"
 --L.label_keyhelper_ammo_drop = "drop ammo from selected weapon out of clip"
+
+-- 2023-11-18
+--L.entity_pickup_owner_only = "Only the owner can pick this up"

--- a/lua/terrortown/lang/ja.lua
+++ b/lua/terrortown/lang/ja.lua
@@ -914,7 +914,6 @@ L.target_switch_drop_weapon_info_noslot = "スロット{slot}には捨てるも�
 --L.corpse_searched_by_detective = "This corpse was searched by a public policing role"
 L.corpse_too_far_away = "その死体から遠すぎる。"
 
-L.radio_pickup_wrong_team = "別陣営が所有するラジオは使えないようだ。"
 L.radio_short_desc = "銃声こそ音楽だ"
 
 L.hstation_subtitle = "[{usekey}]で回復する."

--- a/lua/terrortown/lang/ja.lua
+++ b/lua/terrortown/lang/ja.lua
@@ -2072,3 +2072,6 @@ L.search_eyes = "こいつが最後の人物は、{player}。こいつは敵か�
 --L.label_keyhelper_possession_dash = "prop: dash in view direction"
 --L.label_keyhelper_weapon_drop = "drop selected weapon if possible"
 --L.label_keyhelper_ammo_drop = "drop ammo from selected weapon out of clip"
+
+-- 2023-11-18
+--L.entity_pickup_owner_only = "Only the owner can pick this up"

--- a/lua/terrortown/lang/pl.lua
+++ b/lua/terrortown/lang/pl.lua
@@ -914,7 +914,6 @@ L.target_switch_drop_weapon_info_noslot = "Broni z tego slotu {slot} nie można 
 --L.corpse_searched_by_detective = "This corpse was searched by a public policing role"
 L.corpse_too_far_away = "Ciało jest za daleko."
 
-L.radio_pickup_wrong_team = "Nie możesz mieć radio innego teamu."
 L.radio_short_desc = "Wystrzały broni są dla mnie muzyką"
 
 L.hstation_subtitle = "Naciśnij [{usekey}] aby otrzymać życie."

--- a/lua/terrortown/lang/pl.lua
+++ b/lua/terrortown/lang/pl.lua
@@ -2072,3 +2072,6 @@ L.search_eyes = "Używając umiejętności detektywa, zidentyfikowałeś ostatni
 --L.label_keyhelper_possession_dash = "prop: dash in view direction"
 --L.label_keyhelper_weapon_drop = "drop selected weapon if possible"
 --L.label_keyhelper_ammo_drop = "drop ammo from selected weapon out of clip"
+
+-- 2023-11-18
+--L.entity_pickup_owner_only = "Only the owner can pick this up"

--- a/lua/terrortown/lang/pt_br.lua
+++ b/lua/terrortown/lang/pt_br.lua
@@ -914,7 +914,6 @@ L.target_switch_drop_weapon_info_noslot = "Não há uma arma dropavel no slot {s
 --L.corpse_searched_by_detective = "This corpse was searched by a public policing role"
 L.corpse_too_far_away = "Este corpo está muito longe."
 
-L.radio_pickup_wrong_team = "Você não pode pegar a rádio de outro time."
 L.radio_short_desc = "Tiros de arma são músicas para meus ouvidos"
 
 L.hstation_subtitle = "Pressione [{usekey}] para receber vida."

--- a/lua/terrortown/lang/pt_br.lua
+++ b/lua/terrortown/lang/pt_br.lua
@@ -2072,3 +2072,6 @@ L.search_eyes = "Usando suas técnicas de detetive, você identificou a última 
 --L.label_keyhelper_possession_dash = "prop: dash in view direction"
 --L.label_keyhelper_weapon_drop = "drop selected weapon if possible"
 --L.label_keyhelper_ammo_drop = "drop ammo from selected weapon out of clip"
+
+-- 2023-11-18
+--L.entity_pickup_owner_only = "Only the owner can pick this up"

--- a/lua/terrortown/lang/ru.lua
+++ b/lua/terrortown/lang/ru.lua
@@ -916,7 +916,6 @@ L.target_switch_drop_weapon_info_noslot = "В слоте {slot} нет выбр�
 --L.corpse_searched_by_detective = "This corpse was searched by a public policing role"
 L.corpse_too_far_away = "Тело слишком далеко."
 
-L.radio_pickup_wrong_team = "Вы не можете подобрать Радио другой команды."
 L.radio_short_desc = "Звуки выстрелов для меня словно музыка"
 
 L.hstation_subtitle = "[{usekey}]: восстановить здоровье."

--- a/lua/terrortown/lang/ru.lua
+++ b/lua/terrortown/lang/ru.lua
@@ -2074,3 +2074,6 @@ L.search_eyes = "Используя свои детективные навыки
 --L.label_keyhelper_possession_dash = "prop: dash in view direction"
 --L.label_keyhelper_weapon_drop = "drop selected weapon if possible"
 --L.label_keyhelper_ammo_drop = "drop ammo from selected weapon out of clip"
+
+-- 2023-11-18
+--L.entity_pickup_owner_only = "Only the owner can pick this up"

--- a/lua/terrortown/lang/sv.lua
+++ b/lua/terrortown/lang/sv.lua
@@ -2072,3 +2072,6 @@ L.search_eyes = "Genom att använda dina detektivfärdigheter kan du identifiera
 --L.label_keyhelper_possession_dash = "prop: dash in view direction"
 --L.label_keyhelper_weapon_drop = "drop selected weapon if possible"
 --L.label_keyhelper_ammo_drop = "drop ammo from selected weapon out of clip"
+
+-- 2023-11-18
+--L.entity_pickup_owner_only = "Only the owner can pick this up"

--- a/lua/terrortown/lang/sv.lua
+++ b/lua/terrortown/lang/sv.lua
@@ -914,7 +914,6 @@ L.hat_retrieve = "Du plockade upp hatten av en detektiv."
 --L.corpse_searched_by_detective = "This corpse was searched by a public policing role"
 --L.corpse_too_far_away = "The corpse is too far away."
 
---L.radio_pickup_wrong_team = "You can't pick up the radio from another team."
 --L.radio_short_desc = "Weapon sounds are music to me"
 
 --L.hstation_subtitle = "Press [{usekey}] to receive health."

--- a/lua/terrortown/lang/tr.lua
+++ b/lua/terrortown/lang/tr.lua
@@ -1932,7 +1932,7 @@ Bir kamu polisliği rolü ancak ölüm doğrulandıktan sonra bir cesede çağr�
 L.search_policingrole_confirm_disabled_1 = [[
 Ceset ancak bir kamu polisliği rolü ile doğrulanabilir. Haberdar etmek için cesedi bildirin!]]
 L.search_policingrole_confirm_disabled_2 = [[
-Ceset ancak bir kamu polisliği rolü ile doğrulanabilir. Haberdar etmek için cesedi bildirin! 
+Ceset ancak bir kamu polisliği rolü ile doğrulanabilir. Haberdar etmek için cesedi bildirin!
 Onlar onayladıktan sonra buradaki bilgileri görebilirsiniz.]]
 L.search_spec = [[
 Bir izleyici olarak bir cesedin tüm bilgilerini görebilirsiniz, ancak kullanıcı arayüzü ile etkileşime giremezsiniz.]]
@@ -2072,3 +2072,6 @@ L.label_spec_prop_dash = "Atılma kuvveti çarpanı"
 L.label_keyhelper_possession_dash = "nesne: bakılan yönde atıl"
 L.label_keyhelper_weapon_drop = "mümkünse seçilen silahı bırak"
 L.label_keyhelper_ammo_drop = "seçilen silahın şarjöründen cephane çıkar"
+
+-- 2023-11-18
+--L.entity_pickup_owner_only = "Only the owner can pick this up"

--- a/lua/terrortown/lang/tr.lua
+++ b/lua/terrortown/lang/tr.lua
@@ -914,7 +914,6 @@ L.target_switch_drop_weapon_info_noslot = "{slot} yuvasında düşürülebilir s
 L.corpse_searched_by_detective = "Bu ceset bir dedektif tarafından arandı"
 L.corpse_too_far_away = "Ceset çok uzakta."
 
-L.radio_pickup_wrong_team = "Radyoyu başka bir takımdan alamazsın."
 L.radio_short_desc = "Silah sesleri benim için müziktir"
 
 L.hstation_subtitle = "Sağlık almak için [{usekey}] tuşuna basın."

--- a/lua/terrortown/lang/uk.lua
+++ b/lua/terrortown/lang/uk.lua
@@ -914,7 +914,6 @@ L.idle_popup_title = "Бездіяльність"
 --L.corpse_searched_by_detective = "This corpse was searched by a public policing role"
 --L.corpse_too_far_away = "The corpse is too far away."
 
---L.radio_pickup_wrong_team = "You can't pick up the radio from another team."
 --L.radio_short_desc = "Weapon sounds are music to me"
 
 --L.hstation_subtitle = "Press [{usekey}] to receive health."

--- a/lua/terrortown/lang/uk.lua
+++ b/lua/terrortown/lang/uk.lua
@@ -2072,3 +2072,6 @@ L.search_eyes = "Використовуючи свої навички детек
 --L.label_keyhelper_possession_dash = "prop: dash in view direction"
 --L.label_keyhelper_weapon_drop = "drop selected weapon if possible"
 --L.label_keyhelper_ammo_drop = "drop ammo from selected weapon out of clip"
+
+-- 2023-11-18
+--L.entity_pickup_owner_only = "Only the owner can pick this up"

--- a/lua/terrortown/lang/zh_hans.lua
+++ b/lua/terrortown/lang/zh_hans.lua
@@ -2072,3 +2072,6 @@ L.label_spec_prop_dash = "冲刺力倍增器"
 L.label_keyhelper_possession_dash = "prop：向视线方向冲刺"
 L.label_keyhelper_weapon_drop = "尽可能丢出所选武器"
 L.label_keyhelper_ammo_drop = "将选定武器的弹药从弹夹中取出"
+
+-- 2023-11-18
+--L.entity_pickup_owner_only = "Only the owner can pick this up"

--- a/lua/terrortown/lang/zh_hans.lua
+++ b/lua/terrortown/lang/zh_hans.lua
@@ -914,7 +914,6 @@ L.target_switch_drop_weapon_info_noslot = "槽位 {slot} 没有可丢弃的武�
 --L.corpse_searched_by_detective = "This corpse was searched by a public policing role"
 L.corpse_too_far_away = "这个尸体太远了。"
 
-L.radio_pickup_wrong_team = "你不能捡起其他队伍的收音机"
 L.radio_short_desc = "武器声音，悦耳动听"
 
 L.hstation_subtitle = "按 [{usekey}] 恢复生命值"

--- a/lua/terrortown/lang/zh_tw.lua
+++ b/lua/terrortown/lang/zh_tw.lua
@@ -914,7 +914,6 @@ L.target_switch_drop_weapon_info_noslot = "槽位 {slot} 沒有可丟棄的武�
 --L.corpse_searched_by_detective = "This corpse was searched by a public policing role"
 L.corpse_too_far_away = "這個屍體太遠了。"
 
-L.radio_pickup_wrong_team = "你不能撿起其他隊伍的收音機"
 L.radio_short_desc = "武器聲音，悅耳動聽"
 
 L.hstation_subtitle = "按 [{usekey}] 恢復生命"

--- a/lua/terrortown/lang/zh_tw.lua
+++ b/lua/terrortown/lang/zh_tw.lua
@@ -2072,3 +2072,6 @@ L.search_eyes = "透過你的探查技能，你確信他臨死前見到的最後
 --L.label_keyhelper_possession_dash = "prop: dash in view direction"
 --L.label_keyhelper_weapon_drop = "drop selected weapon if possible"
 --L.label_keyhelper_ammo_drop = "drop ammo from selected weapon out of clip"
+
+-- 2023-11-18
+--L.entity_pickup_owner_only = "Only the owner can pick this up"


### PR DESCRIPTION
Old PR: [Removed restriction that only team can pickup Radio](https://github.com/TTT-2/TTT2/pull/1204) 
Original issue: #1125

## Made a new branch and PR with the suggestions
- [x] make sure only the owner can pick it up
- [x] add a generic string to the language file that says "only the owner is able to pick up this entity" that is displayed as targetID subtitle if the focusing player is not the owner
> - replace the key in that case with a radio icon, feel free to hit me up for an icon

I feel this should be the +use key crossed out, to show that it can be picked up, just you cannot pick it up

