### PR TITLE
RADAR: Clear when removed, fixes #1070

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 - Fixed and updated the Turkish localization file (by @NovaDiablox)
 - Radio can now only be picked up by placer
+- Radar now clears existing waypoints when removed or on changing role (by @EntranceJew)
 
 ### Fixed
 

--- a/lua/terrortown/entities/items/item_ttt_radar/shared.lua
+++ b/lua/terrortown/entities/items/item_ttt_radar/shared.lua
@@ -28,4 +28,7 @@ function ITEM:Reset(buyer)
 	end
 
 	buyer.radar_charge = 0
+	if CLIENT then
+		RADAR:Clear()
+	end
 end


### PR DESCRIPTION
seems to work fine,
https://github.com/TTT-2/TTT2/assets/5711436/3c0b26e4-b48c-46a7-985a-cbc0d755f5b9
i don't think there's a way to trigger a decayed removal 'cause all the timer logic is server-sided, and there's not a net message to wipe it later

