### PR TITLE
ttt_game_text mode 4 correction (fixes #972)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Translation strings not rendering on detective's body search mode combobox
 - C4 defusal prompt now suggesting the right key
 - Disable to unscope from weapons without ironsights
+- `ttt_game_text` can now properly send to "All except traitors", as described.
 
 ## [v0.12.1b](https://github.com/TTT-2/TTT2/tree/v0.12.1b) (2023-12-12)
 

--- a/gamemodes/terrortown/entities/entities/ttt_game_text.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_game_text.lua
@@ -66,6 +66,9 @@ function ENT:AcceptInput(name, activator)
 	elseif inputReceiver == RECEIVE_TRAITOR then
 		messageReceiver = GetTeamChatFilter(TEAM_TRAITOR)
 	elseif inputReceiver == RECEIVE_INNOCENT then
+		-- TTT originally defined this as "All except traitors" even though it is labeled as "RECEIVE_INNOCENT",
+		-- but the implementation literally only checked that a player was not a traitor, therefore the intent is
+		-- preserved here since maps aren't likely to be updated
 		messageReceiver = GetPlayerFilter(function(p)
 			local plyRoleData = ply:GetSubRoleData()
 			return p:GetTeam() ~= TEAM_TRAITOR and not plyRoleData.disabledTeamChatRecv

--- a/gamemodes/terrortown/entities/entities/ttt_game_text.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_game_text.lua
@@ -66,7 +66,10 @@ function ENT:AcceptInput(name, activator)
 	elseif inputReceiver == RECEIVE_TRAITOR then
 		messageReceiver = GetTeamChatFilter(TEAM_TRAITOR)
 	elseif inputReceiver == RECEIVE_INNOCENT then
-		messageReceiver = GetTeamChatFilter(TEAM_INNOCENT)
+		messageReceiver = GetPlayerFilter(function(p)
+			local plyRoleData = ply:GetSubRoleData()
+			return p:GetTeam() ~= TEAM_TRAITOR and not plyRoleData.disabledTeamChatRecv
+		end)
 	elseif inputReceiver == RECEIVE_ACTIVATOR then
 		if not IsValid(activator) or not activator:IsPlayer() then
 			ErrorNoHalt("ttt_game_text tried to show message to invalid !activator\n")


### PR DESCRIPTION
logically, it doesn't address innocents

it has always referred to everyone but traitors

refer to:
https://github.com/Facepunch/garrysmod/blob/master/garrysmod/gamemodes/terrortown/entities/entities/ttt_game_text.lua#L48-L49

https://github.com/Facepunch/garrysmod/blob/master/garrysmod/gamemodes/terrortown/gamemode/gamemsg.lua#L83-L85

https://github.com/Facepunch/garrysmod/blob/master/garrysmod/gamemodes/terrortown/gamemode/player_ext_shd.lua#L14-L17