### PR TITLE
Changelog: Move entry to correct position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ## Unreleased
 
+### Added
+
+- Added debug.print(message)
+  - This puts quotation marks around print statements
+  - Can handle single values or a sequential table to be printed
+
 ## [v0.12.2b](https://github.com/TTT-2/TTT2/tree/v0.12.2b) (2023-12-20)
 
 ### Added
@@ -17,9 +23,6 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
   - Added tooltip to `F1 > Edit Equipment` menu with the equipment's class name.
   - `F1 > Role Settings` now has `builtin` indicators for roles
   - `F1 > Edit Shops` now has `builtin` indicators for roles
-- Added debug.print(message)
-  - This puts quotation marks around print statements
-  - Can handle single values or a sequential table to be printed
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
   - This puts quotation marks around print statements
   - Can handle single values or a sequential table to be printed
 
+### Changed
+
+### Fixed
+
 ## [v0.12.2b](https://github.com/TTT-2/TTT2/tree/v0.12.2b) (2023-12-20)
 
 ### Added


### PR DESCRIPTION
Well, I made a mistake with the last merge. I resolved the conflict, but the entry was still for the old release. Added the other categories as well.