### PR TITLE
Keyhelp: Fixed nil-table indexing

### DIFF
--- a/lua/ttt2/libraries/keyhelp.lua
+++ b/lua/ttt2/libraries/keyhelp.lua
@@ -158,19 +158,19 @@ function keyhelp.Draw()
 	end
 
 	if not util.EditingModeActive(client) then
-		if cvEnableCore:GetBool() or scoreboardShown then
+		if keyhelp.keyHelpers[KEYHELP_CORE] and (cvEnableCore:GetBool() or scoreboardShown) then
 			for i = 1, #keyhelp.keyHelpers[KEYHELP_CORE] do
 				xBase = DrawKey(client, xBase, yBase, keyhelp.keyHelpers[KEYHELP_CORE][i], scoreboardShown) or xBase
 			end
 		end
 
-		if cvEnableEquipment:GetBool() or scoreboardShown then
+		if keyhelp.keyHelpers[KEYHELP_EQUIPMENT] and (cvEnableEquipment:GetBool() or scoreboardShown) then
 			for i = 1, #keyhelp.keyHelpers[KEYHELP_EQUIPMENT] do
 				xBase = DrawKey(client, xBase, yBase, keyhelp.keyHelpers[KEYHELP_EQUIPMENT][i], scoreboardShown) or xBase
 			end
 		end
 
-		if cvEnableExtra:GetBool() or scoreboardShown then
+		if keyhelp.keyHelpers[KEYHELP_EXTRA] and (cvEnableExtra:GetBool() or scoreboardShown) then
 			for i = 1, #keyhelp.keyHelpers[KEYHELP_EXTRA] do
 				xBase = DrawKey(client, xBase, yBase, keyhelp.keyHelpers[KEYHELP_EXTRA][i], scoreboardShown) or xBase
 			end


### PR DESCRIPTION
The current code fails when no element is in any of the key help tables. This went unnoticed when testing, because all tables have enties by default.

This is still bad because the UI code fails if a user decides to remove the disguiser from the sourcecode for example.