### PR TITLE
targetid show role of named corpses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ### Fixed
 
+- targetid wasn't showing named corpse's role, information which was already present on the scoreboard (by @EntranceJew)
+
 ## [v0.12.2b](https://github.com/TTT-2/TTT2/tree/v0.12.2b) (2023-12-20)
 
 ### Added

--- a/lua/ttt2/libraries/targetid.lua
+++ b/lua/ttt2/libraries/targetid.lua
@@ -472,9 +472,10 @@ function targetid.HUDDrawTargetIDRagdolls(tData)
 	if not CORPSE.GetPlayerNick(ent, false) then return end
 
 	local corpse_found = CORPSE.GetFound(ent, false) or not DetectiveMode()
-	local role_found = corpse_found and ent.bodySearchResult and ent.bodySearchResult.subrole
+	local corpse_ply = corpse_found and CORPSE.GetPlayer(ent) or false
+	local role_found = (corpse_found and ent.bodySearchResult and ent.bodySearchResult.subrole) or (corpse_ply and corpse_ply:GetSubRole())
 	local binoculars_useable = IsValid(c_wep) and c_wep:GetClass() == "weapon_ttt_binoculars" or false
-	local roleData = roles.GetByIndex(role_found and ent.bodySearchResult.subrole or ROLE_INNOCENT)
+	local roleData = (corpse_ply and corpse_ply:GetSubRoleData()) or roles.GetByIndex(role_found and ent.bodySearchResult.subrole or ROLE_INNOCENT)
 	local roleDataClient = client:GetSubRoleData()
 
 	-- enable targetID rendering


### PR DESCRIPTION
designed to fix situations like this one:
![image](https://github.com/TTT-2/TTT2/assets/5711436/53da9871-2062-4d37-9474-f2c94d60226a)
![image](https://github.com/TTT-2/TTT2/assets/5711436/6d4a6a66-2cea-4989-b4ef-21f6b2d89918)
(normally it'd show a yellow toetag because i didn't search it, and the police didn't search it)