### PR TITLE
bugfix/viewmodel idle recenter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
   - This puts quotation marks around print statements
   - Can handle single values or a sequential table to be printed
 - Added new hooks `TTT2BeaconDetectPlayer` and `TTT2BeaconDeathNotify` to allow preventing / overriding a beacon's player detection & alerts (by @spanospy)
+- `weapon_tttbase` changes to correct non-looping animations which affected ADS scoping:
+  - Added `SWEP.IdleAnim` to allow specifying an idle animation.
+  - Added `SWEP.idleResetFix` to allow the animations for CS:S weapons to automatically be returned to an idle position.
 
 ### Changed
 


### PR DESCRIPTION
makes it so that your weapon doesn't get in the way as much, or go wonk

in order to really be fully functional, i think the sipistol should be brought down from upstream so that all weapons can be tagged accordingly and the extra stuff in this commit can be dropped

alternatively we just force it across all CS:S viewmodels because the effect of one broken weapon (silent pistol) can knock on other weapons that ordinarily don't have problems centering (the TMP)