### PR TITLE
HUD-help Elements: Use global scale factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ### Changed
 
 - Updated the Turkish localization file (by @NovaDiablox)
+- Keyhelp and weapon HUD Help now use the global scale factor
 
 ### Fixed
 

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -240,6 +240,7 @@ local ttt2_hold_aim = CLIENT and CreateConVar("ttt2_hold_aim", 0, FCVAR_ARCHIVE,
 if CLIENT then
 	local GetPTranslation = LANG.GetParamTranslation
 	local TryT = LANG.TryTranslation
+	local mathRound = math.Round
 
 	---
 	-- @realm client
@@ -364,13 +365,11 @@ if CLIENT then
 	local colorBox = Color(0, 0, 0, 100)
 	local colorDarkBox = Color(0, 0, 0, 150)
 
-	local padding = 10
 	local sizeIcon = 16
 	local padYKey = 3
 	local padXKey = 5
-	local hLine = 23
 
-	local function ProcessHelpText(lines)
+	local function ProcessHelpText(lines, scale)
 		local width, center = 0, 0
 		local processedData = {}
 
@@ -383,21 +382,21 @@ if CLIENT then
 			local isIcon = false
 
 			if isstring(binding) then
-				local wKey, hKey = draw.GetTextSize(binding, "weapon_hud_help_key")
+				local wKey, hKey = draw.GetTextSize(binding, "weapon_hud_help_key", scale)
 
-				wBinding = wKey + 2 * padXKey
-				hBinding = hKey + 2 * padYKey
+				wBinding = wKey + 2 * padXKey * scale
+				hBinding = hKey + 2 * padYKey * scale
 				isIcon = false
 			elseif binding then
-				wBinding = sizeIcon
-				hBinding = sizeIcon
+				wBinding = sizeIcon * scale
+				hBinding = sizeIcon * scale
 				isIcon = true
 			else
 				continue
 			end
 
 			local translatedDescription = TryT(description)
-			local wDescription = draw.GetTextSize(translatedDescription, "weapon_hud_help")
+			local wDescription = draw.GetTextSize(translatedDescription, "weapon_hud_help", scale)
 
 			processedData[i] = {
 				w = wBinding,
@@ -419,7 +418,12 @@ if CLIENT then
 	-- Draws the help text to the bottom of the screen
 	-- @realm client
 	function SWEP:DrawHelp()
-		local baseWidth, baseCenter, processedData = ProcessHelpText(self.HUDHelp.bindingLines)
+		local scale = appearance.GetGlobalScale()
+
+		local baseWidth, baseCenter, processedData = ProcessHelpText(self.HUDHelp.bindingLines, scale)
+
+		local padding = 10 * scale
+		local hLine = 23 * scale
 
 		local wBox = baseWidth + 5 * padding
 		local hBox = hLine * #processedData + 2 * padding
@@ -427,19 +431,18 @@ if CLIENT then
 		local yBox = ScrH() - hBox
 		local xDivider = xBox + baseCenter + 2.5 * padding
 		local yDividerStart = yBox + padding
-		local yDividerEnd = yBox + hBox - padding
-		local yLine = yDividerStart + 10
+		local yLine = yDividerStart + 10 * scale
 		local xDescription = xDivider + padding
 
 		if GetConVar("ttt2_hud_enable_box_blur"):GetBool() then
 			draw.BlurredBox(xBox, yBox, wBox, hBox)
 			draw.Box(xBox, yBox, wBox, hBox, colorBox) -- background color
-			draw.Box(xBox, yBox, wBox, 1, colorBox) -- top line shadow
-			draw.Box(xBox, yBox, wBox, 2, colorBox) -- top line shadow
-			draw.Box(xBox, yBox - 2, wBox, 2, COLOR_WHITE) -- white top line
+			draw.Box(xBox, yBox, wBox, mathRound(1 * scale), colorBox) -- top line shadow
+			draw.Box(xBox, yBox, wBox, mathRound(2 * scale), colorBox) -- top line shadow
+			draw.Box(xBox, yBox - mathRound(2 * scale), wBox, mathRound(2 * scale), COLOR_WHITE) -- white top line
 		end
 
-		draw.ShadowedLine(xDivider, yDividerStart, xDivider, yDividerEnd, COLOR_WHITE)
+		draw.ShadowedBox(xDivider, yDividerStart, mathRound(scale), hBox - 2 * padding, COLOR_WHITE, scale)
 
 		for i = 1, #processedData do
 			local line = processedData[i]
@@ -450,15 +453,35 @@ if CLIENT then
 			local yBinding = yLine - 0.5 * h
 
 			if line.isIcon then
-				draw.FilteredShadowedTexture(xBinding, yBinding, w, h, line.binding, 255, COLOR_WHITE)
+				draw.FilteredShadowedTexture(xBinding, yBinding, w, h, line.binding, 255, COLOR_WHITE, scale)
 			else
 				draw.Box(xBinding, yBinding + 1, w, h, colorDarkBox)
 				draw.OutlinedShadowedBox(xBinding, yBinding + 1, w, h, 1, COLOR_WHITE)
 
-				draw.ShadowedText(line.binding, "weapon_hud_help_key", xBinding + 0.5 * w, yLine, COLOR_WHITE, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER)
+				draw.AdvancedText(
+					line.binding,
+					"weapon_hud_help_key",
+					xBinding + 0.5 * w,
+					yLine,
+					COLOR_WHITE,
+					TEXT_ALIGN_CENTER,
+					TEXT_ALIGN_CENTER,
+					true,
+					scale
+				)
 			end
 
-			draw.ShadowedText(line.description, "weapon_hud_help", xDescription, yLine, COLOR_WHITE, TEXT_ALIGN_LEFT, TEXT_ALIGN_CENTER)
+			draw.AdvancedText(
+				line.description,
+				"weapon_hud_help",
+				xDescription,
+				yLine,
+				COLOR_WHITE,
+				TEXT_ALIGN_LEFT,
+				TEXT_ALIGN_CENTER,
+				true,
+				scale
+			)
 
 			yLine = yLine + hLine
 		end

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -17,8 +17,8 @@ if SERVER then
 	AddCSLuaFile()
 else -- CLIENT
 	-- hud help font
-	surface.CreateFont("weapon_hud_help", {font = "Trebuchet24", size = 16, weight = 600})
-	surface.CreateFont("weapon_hud_help_key", {font = "Trebuchet24", size = 13, weight = 1200})
+	surface.CreateAdvancedFont("weapon_hud_help", {font = "Trebuchet24", size = 16, weight = 600})
+	surface.CreateAdvancedFont("weapon_hud_help_key", {font = "Trebuchet24", size = 13, weight = 1200})
 end
 
 --   TTT SPECIAL EQUIPMENT FIELDS

--- a/lua/ttt2/extensions/draw.lua
+++ b/lua/ttt2/extensions/draw.lua
@@ -105,7 +105,7 @@ function draw.ShadowedBox(x, y, w, h, color, scale)
 	scale = scale or 1
 
 	local shift1 = mathRound(scale)
-	local shift2 = mathRound(scale * 2)
+	local shift2 = shift1 * 2
 
 	local tmpCol = GetShadowColor(color)
 
@@ -187,7 +187,7 @@ function draw.ShadowedCircle(x, y, radius, color, scale)
 	scale = scale or 1
 
 	local shift1 = mathRound(scale)
-	local shift2 = mathRound(scale * 2)
+	local shift2 = shift1 * 2
 
 	local tmpCol = GetShadowColor(color)
 
@@ -276,7 +276,7 @@ function draw.ShadowedTexture(x, y, w, h, material, alpha, color, scale)
 	local tmpCol = GetShadowColor(color)
 
 	local shift_tex_1 = mathRound(scale)
-	local shift_tex_2 = mathRound(2 * scale)
+	local shift_tex_2 = 2 * shift_tex_1
 
 	drawTexture(x + shift_tex_2, y + shift_tex_2, w, h, material, tmpCol.a, tmpCol)
 	drawTexture(x + shift_tex_1, y + shift_tex_1, w, h, material, tmpCol.a, tmpCol)
@@ -383,7 +383,7 @@ function draw.ShadowedText(text, font, x, y, color, xalign, yalign, scale)
 	local tmpCol = GetShadowColor(color)
 
 	local shift1 = mathRound(scale)
-	local shift2 = mathRound(scale * 2)
+	local shift2 = shift1 * 2
 
 	drawSimpleText(text, font, x + shift2, y + shift2, tmpCol, xalign, yalign)
 	drawSimpleText(text, font, x + shift1, y + shift1, tmpCol, xalign, yalign)
@@ -654,12 +654,17 @@ end
 -- Returns the size of a inserted string
 -- @param string text The text that the length should be calculated
 -- @param[default="DefaultBold"] string font The font ID
--- @warning This function changes the font to the passed font
+-- @param[default=1.0] number scale The UI scale factor
 -- @return number,number w, h The size of the given text
+-- @warning This function changes the font in surface to the passed font
 -- @2D
 -- @realm client
-function draw.GetTextSize(text, font)
+function draw.GetTextSize(text, font, scale)
+	scale = scale or 1.0
+
 	surface.SetFont(font or "DefaultBold")
 
-	return surface.GetTextSize(text)
+	local w, h = surface.GetTextSize(text)
+
+	return w * scale, h * scale
 end

--- a/lua/ttt2/libraries/keyhelp.lua
+++ b/lua/ttt2/libraries/keyhelp.lua
@@ -16,9 +16,15 @@ local inputGetKeyName = input.GetKeyName
 local bindFind = bind.Find
 
 local offsetCenter = 230
-local offsetHeight = 48
+local height = 48
 local width = 18
 local padding = 5
+local thicknessLine = 2
+
+local heightScaled = 0
+local widthScaled = 0
+local paddingScaled = 0
+local thicknessLineScaled = 0
 
 local colorBox = Color(0, 0, 0, 100)
 
@@ -73,35 +79,47 @@ local cvEnableDescription = CreateConVar("ttt2_hud_enable_description", "1", FCV
 keyhelp = keyhelp or {}
 keyhelp.keyHelpers = {}
 
-local function DrawKeyContent(x, y, size, keyString, iconMaterial, bindingName, scoreboardShown, scale)
+local function DrawKeyContent(x, y, keyString, iconMaterial, bindingName, scoreboardShown, scale)
 	local wKeyString = draw.GetTextSize(keyString, "weapon_hud_help_key")
-	local wBox = math.max(size, wKeyString) + 2 * padding
-	local xIcon = x + 0.5 * (wBox - size)
-	local yIcon = y + padding + 2
+	local wBox = math.max(widthScaled, wKeyString) + 2 * paddingScaled
+	local xIcon = x + 0.5 * (wBox - widthScaled)
+	local yIcon = y + paddingScaled + thicknessLineScaled
 	local xKeyString = x + math.floor(0.5 * wBox)
-	local yKeyString = yIcon + size + padding
+	local yKeyString = yIcon + widthScaled + paddingScaled
 
 	if cvEnableBoxBlur:GetBool() then
-		draw.BlurredBox(x, y, wBox, offsetHeight + padding)
-		draw.Box(x, y, wBox, offsetHeight + padding, colorBox) -- background color
-		draw.Box(x, y, wBox, 1, colorBox) -- top line shadow
-		draw.Box(x, y, wBox, 2, colorBox) -- top line shadow
-		draw.Box(x, y - 2, wBox, 2, COLOR_WHITE) -- white top line
+		draw.BlurredBox(x, y, wBox, heightScaled + paddingScaled)
+		draw.Box(x, y, wBox, heightScaled + paddingScaled, colorBox) -- background color
+		draw.Box(x, y, wBox, 0.5 * thicknessLineScaled, colorBox) -- top line shadow
+		draw.Box(x, y, wBox, thicknessLineScaled, colorBox) -- top line shadow
+		draw.Box(x, y - thicknessLineScaled, wBox, thicknessLineScaled, COLOR_WHITE) -- white top line
 	end
 
-	draw.FilteredShadowedTexture(xIcon, yIcon, size, size, iconMaterial, 255, COLOR_WHITE)
-	draw.ShadowedText(keyString, "weapon_hud_help_key", xKeyString, yKeyString, COLOR_WHITE, TEXT_ALIGN_CENTER, TEXT_ALIGN_TOP)
+	draw.FilteredShadowedTexture(xIcon, yIcon, widthScaled, widthScaled, iconMaterial, 255, COLOR_WHITE, scale)
+	draw.AdvancedText(
+		keyString,
+		"weapon_hud_help_key",
+		xKeyString,
+		yKeyString,
+		COLOR_WHITE,
+		TEXT_ALIGN_CENTER,
+		TEXT_ALIGN_TOP,
+		true,
+		scale
+	)
 
 	if scoreboardShown and cvEnableDescription:GetBool() then
 		draw.AdvancedText(
 			LANG.TryTranslation(bindingName),
 			"weapon_hud_help",
 			xKeyString,
-			y - 3 * padding,
+			y - 3 * paddingScaled,
 			COLOR_WHITE,
 			TEXT_ALIGN_LEFT,
 			TEXT_ALIGN_CENTER,
-			true, 1.0, -45
+			true,
+			scale,
+			-45
 		)
 	end
 
@@ -116,7 +134,16 @@ local function DrawKey(client, xBase, yBase, keyHelper, scoreboardShown, scale)
 
 	if not key then return end
 
-	return xBase + padding + DrawKeyContent(xBase, yBase, width, stringUpper(key), keyHelper.iconMaterial, keyHelper.bindingName, scoreboardShown, scale)
+	return xBase + paddingScaled
+		+ DrawKeyContent(
+			xBase,
+			yBase,
+			stringUpper(key),
+			keyHelper.iconMaterial,
+			keyHelper.bindingName,
+			scoreboardShown,
+			scale
+		)
 end
 
 ---
@@ -148,41 +175,82 @@ function keyhelp.Draw()
 	local client = LocalPlayer()
 	local scoreboardShown = GAMEMODE.ShowScoreboard
 
-	local xBase = 0.5 * ScrW() + offsetCenter
-	local yBase = ScrH() - offsetHeight
-
 	local scale = appearance.GetGlobalScale()
+
+	local xBase = 0.5 * ScrW() + offsetCenter * scale
+	local yBase = ScrH() - height * scale
+
+	heightScaled = height * scale
+	widthScaled = width * scale
+	paddingScaled = padding * scale
+	thicknessLineScaled = thicknessLine * scale
 
 	if cvEnableCore:GetBool() or scoreboardShown then
 		for i = 1, #keyhelp.keyHelpers[KEYHELP_INTERNAL] do
-			xBase = DrawKey(client, xBase, yBase, keyhelp.keyHelpers[KEYHELP_INTERNAL][i], scoreboardShown, scale) or xBase
+			xBase = DrawKey(
+				client,
+				xBase,
+				yBase,
+				keyhelp.keyHelpers[KEYHELP_INTERNAL][i],
+				scoreboardShown,
+				scale
+			) or xBase
 		end
 	end
 
 	if not util.EditingModeActive(client) then
 		if cvEnableCore:GetBool() or scoreboardShown then
 			for i = 1, #keyhelp.keyHelpers[KEYHELP_CORE] do
-				xBase = DrawKey(client, xBase, yBase, keyhelp.keyHelpers[KEYHELP_CORE][i], scoreboardShown, scale) or xBase
+				xBase = DrawKey(
+					client,
+					xBase,
+					yBase,
+					keyhelp.keyHelpers[KEYHELP_CORE][i],
+					scoreboardShown,
+					scale
+				) or xBase
 			end
 		end
 
 		if cvEnableEquipment:GetBool() or scoreboardShown then
 			for i = 1, #keyhelp.keyHelpers[KEYHELP_EQUIPMENT] do
-				xBase = DrawKey(client, xBase, yBase, keyhelp.keyHelpers[KEYHELP_EQUIPMENT][i], scoreboardShown, scale) or xBase
+				xBase = DrawKey(
+					client,
+					xBase,
+					yBase,
+					keyhelp.keyHelpers[KEYHELP_EQUIPMENT][i],
+					scoreboardShown,
+					scale
+				) or xBase
 			end
 		end
 
 		if cvEnableExtra:GetBool() or scoreboardShown then
 			for i = 1, #keyhelp.keyHelpers[KEYHELP_EXTRA] do
-				xBase = DrawKey(client, xBase, yBase, keyhelp.keyHelpers[KEYHELP_EXTRA][i], scoreboardShown, scale) or xBase
+				xBase = DrawKey(
+					client,
+					xBase,
+					yBase,
+					keyhelp.keyHelpers[KEYHELP_EXTRA][i],
+					scoreboardShown,
+					scale
+				) or xBase
 			end
 		end
 	end
 
 	-- if anyone of them is disabled, but not all, the show more option is shown
 	local enbCount = cvEnableCore:GetInt() + cvEnableEquipment:GetInt() + cvEnableExtra:GetInt()
+
 	if not scoreboardShown and enbCount > 0 and enbCount < 3 then
-		DrawKey(client, xBase, yBase, keyhelp.keyHelpers[KEYHELP_SCOREBOARD][1], scoreboardShown, scale)
+		xBase = DrawKey(
+			client,
+			xBase,
+			yBase,
+			keyhelp.keyHelpers[KEYHELP_SCOREBOARD][1],
+			scoreboardShown,
+			scale
+		) or xBase
 	end
 end
 

--- a/lua/ttt2/libraries/keyhelp.lua
+++ b/lua/ttt2/libraries/keyhelp.lua
@@ -73,7 +73,7 @@ local cvEnableDescription = CreateConVar("ttt2_hud_enable_description", "1", FCV
 keyhelp = keyhelp or {}
 keyhelp.keyHelpers = {}
 
-local function DrawKeyContent(x, y, size, keyString, iconMaterial, bindingName, scoreboardShown)
+local function DrawKeyContent(x, y, size, keyString, iconMaterial, bindingName, scoreboardShown, scale)
 	local wKeyString = draw.GetTextSize(keyString, "weapon_hud_help_key")
 	local wBox = math.max(size, wKeyString) + 2 * padding
 	local xIcon = x + 0.5 * (wBox - size)
@@ -108,7 +108,7 @@ local function DrawKeyContent(x, y, size, keyString, iconMaterial, bindingName, 
 	return wBox
 end
 
-local function DrawKey(client, xBase, yBase, keyHelper, scoreboardShown)
+local function DrawKey(client, xBase, yBase, keyHelper, scoreboardShown, scale)
 	if not isfunction(keyHelper.callback) or not keyHelper.callback(client) then return end
 
 	-- handles both internal GMod bindings and TTT2 bindings
@@ -116,7 +116,7 @@ local function DrawKey(client, xBase, yBase, keyHelper, scoreboardShown)
 
 	if not key then return end
 
-	return xBase + padding + DrawKeyContent(xBase, yBase, width, stringUpper(key), keyHelper.iconMaterial, keyHelper.bindingName, scoreboardShown)
+	return xBase + padding + DrawKeyContent(xBase, yBase, width, stringUpper(key), keyHelper.iconMaterial, keyHelper.bindingName, scoreboardShown, scale)
 end
 
 ---
@@ -151,28 +151,30 @@ function keyhelp.Draw()
 	local xBase = 0.5 * ScrW() + offsetCenter
 	local yBase = ScrH() - offsetHeight
 
+	local scale = appearance.GetGlobalScale()
+
 	if cvEnableCore:GetBool() or scoreboardShown then
 		for i = 1, #keyhelp.keyHelpers[KEYHELP_INTERNAL] do
-			xBase = DrawKey(client, xBase, yBase, keyhelp.keyHelpers[KEYHELP_INTERNAL][i], scoreboardShown) or xBase
+			xBase = DrawKey(client, xBase, yBase, keyhelp.keyHelpers[KEYHELP_INTERNAL][i], scoreboardShown, scale) or xBase
 		end
 	end
 
 	if not util.EditingModeActive(client) then
 		if cvEnableCore:GetBool() or scoreboardShown then
 			for i = 1, #keyhelp.keyHelpers[KEYHELP_CORE] do
-				xBase = DrawKey(client, xBase, yBase, keyhelp.keyHelpers[KEYHELP_CORE][i], scoreboardShown) or xBase
+				xBase = DrawKey(client, xBase, yBase, keyhelp.keyHelpers[KEYHELP_CORE][i], scoreboardShown, scale) or xBase
 			end
 		end
 
 		if cvEnableEquipment:GetBool() or scoreboardShown then
 			for i = 1, #keyhelp.keyHelpers[KEYHELP_EQUIPMENT] do
-				xBase = DrawKey(client, xBase, yBase, keyhelp.keyHelpers[KEYHELP_EQUIPMENT][i], scoreboardShown) or xBase
+				xBase = DrawKey(client, xBase, yBase, keyhelp.keyHelpers[KEYHELP_EQUIPMENT][i], scoreboardShown, scale) or xBase
 			end
 		end
 
 		if cvEnableExtra:GetBool() or scoreboardShown then
 			for i = 1, #keyhelp.keyHelpers[KEYHELP_EXTRA] do
-				xBase = DrawKey(client, xBase, yBase, keyhelp.keyHelpers[KEYHELP_EXTRA][i], scoreboardShown) or xBase
+				xBase = DrawKey(client, xBase, yBase, keyhelp.keyHelpers[KEYHELP_EXTRA][i], scoreboardShown, scale) or xBase
 			end
 		end
 	end
@@ -180,7 +182,7 @@ function keyhelp.Draw()
 	-- if anyone of them is disabled, but not all, the show more option is shown
 	local enbCount = cvEnableCore:GetInt() + cvEnableEquipment:GetInt() + cvEnableExtra:GetInt()
 	if not scoreboardShown and enbCount > 0 and enbCount < 3 then
-		DrawKey(client, xBase, yBase, keyhelp.keyHelpers[KEYHELP_SCOREBOARD][1], scoreboardShown)
+		DrawKey(client, xBase, yBase, keyhelp.keyHelpers[KEYHELP_SCOREBOARD][1], scoreboardShown, scale)
 	end
 end
 

--- a/lua/ttt2/libraries/keyhelp.lua
+++ b/lua/ttt2/libraries/keyhelp.lua
@@ -80,7 +80,7 @@ keyhelp = keyhelp or {}
 keyhelp.keyHelpers = {}
 
 local function DrawKeyContent(x, y, keyString, iconMaterial, bindingName, scoreboardShown, scale)
-	local wKeyString = draw.GetTextSize(keyString, "weapon_hud_help_key")
+	local wKeyString = draw.GetTextSize(keyString, "weapon_hud_help_key", scale)
 	local wBox = math.max(widthScaled, wKeyString) + 2 * paddingScaled
 	local xIcon = x + 0.5 * (wBox - widthScaled)
 	local yIcon = y + paddingScaled + thicknessLineScaled
@@ -90,7 +90,7 @@ local function DrawKeyContent(x, y, keyString, iconMaterial, bindingName, scoreb
 	if cvEnableBoxBlur:GetBool() then
 		draw.BlurredBox(x, y, wBox, heightScaled + paddingScaled)
 		draw.Box(x, y, wBox, heightScaled + paddingScaled, colorBox) -- background color
-		draw.Box(x, y, wBox, 0.5 * thicknessLineScaled, colorBox) -- top line shadow
+		draw.Box(x, y, wBox, math.Round(0.5 * thicknessLineScaled), colorBox) -- top line shadow
 		draw.Box(x, y, wBox, thicknessLineScaled, colorBox) -- top line shadow
 		draw.Box(x, y - thicknessLineScaled, wBox, thicknessLineScaled, COLOR_WHITE) -- white top line
 	end
@@ -183,7 +183,7 @@ function keyhelp.Draw()
 	heightScaled = height * scale
 	widthScaled = width * scale
 	paddingScaled = padding * scale
-	thicknessLineScaled = thicknessLine * scale
+	thicknessLineScaled = math.Round(thicknessLine * scale)
 
 	if cvEnableCore:GetBool() or scoreboardShown then
 		for i = 1, #keyhelp.keyHelpers[KEYHELP_INTERNAL] do


### PR DESCRIPTION
Added scaling to keyhelp and weapon HUD help elements. I also slightly tweaked how shadows are calculated in the draw library to prevent weird glitches at some scale values