### PR TITLE
Corpses: Fix looking at disconnected player's corpses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Coerced ammo types to lowercase for better matching in HUD
 - The binocular zoom now uses a DataTable that is not already used by its weaponbase
 - Fixed round scoreboard tooltips not being wide enough for their strings (by @EntranceJew)
+- Errors when looking at a player's corpse that disconnected (by @EntranceJew)
 
 ## [v0.12.2b](https://github.com/TTT-2/TTT2/tree/v0.12.2b) (2023-12-20)
 

--- a/lua/ttt2/libraries/targetid.lua
+++ b/lua/ttt2/libraries/targetid.lua
@@ -473,9 +473,9 @@ function targetid.HUDDrawTargetIDRagdolls(tData)
 
 	local corpse_found = CORPSE.GetFound(ent, false) or not DetectiveMode()
 	local corpse_ply = corpse_found and CORPSE.GetPlayer(ent) or false
-	local role_found = (corpse_found and ent.bodySearchResult and ent.bodySearchResult.subrole) or (corpse_ply and corpse_ply:GetSubRole())
 	local binoculars_useable = IsValid(c_wep) and c_wep:GetClass() == "weapon_ttt_binoculars" or false
-	local roleData = (corpse_ply and corpse_ply:GetSubRoleData()) or roles.GetByIndex(role_found and ent.bodySearchResult.subrole or ROLE_INNOCENT)
+	local role_found = (corpse_found and ent.bodySearchResult and ent.bodySearchResult.subrole) or (corpse_ply and IsValid(corpse_ply) and corpse_ply:GetSubRole())
+	local roleData = (corpse_ply and IsValid(corpse_ply) and corpse_ply:GetSubRoleData()) or roles.GetByIndex(role_found and ent.bodySearchResult.subrole or ROLE_INNOCENT)
 	local roleDataClient = client:GetSubRoleData()
 
 	-- enable targetID rendering

--- a/lua/ttt2/libraries/targetid.lua
+++ b/lua/ttt2/libraries/targetid.lua
@@ -474,8 +474,8 @@ function targetid.HUDDrawTargetIDRagdolls(tData)
 	local corpse_found = CORPSE.GetFound(ent, false) or not DetectiveMode()
 	local corpse_ply = corpse_found and CORPSE.GetPlayer(ent) or false
 	local binoculars_useable = IsValid(c_wep) and c_wep:GetClass() == "weapon_ttt_binoculars" or false
-	local role_found = (corpse_found and ent.bodySearchResult and ent.bodySearchResult.subrole) or (corpse_ply and IsValid(corpse_ply) and corpse_ply:GetSubRole())
-	local roleData = (corpse_ply and IsValid(corpse_ply) and corpse_ply:GetSubRoleData()) or roles.GetByIndex(role_found and ent.bodySearchResult.subrole or ROLE_INNOCENT)
+	local role_found = (corpse_found and ent.bodySearchResult and ent.bodySearchResult.subrole) or (IsValid(corpse_ply) and corpse_ply:GetSubRole())
+	local roleData = (IsValid(corpse_ply) and corpse_ply:GetSubRoleData()) or roles.GetByIndex(role_found and ent.bodySearchResult.subrole or ROLE_INNOCENT)
 	local roleDataClient = client:GetSubRoleData()
 
 	-- enable targetID rendering


### PR DESCRIPTION
you still can't check their roles from the `was_role` property because someone has to make that info available to the client

demo of the difference, the 2nd corpse would cause a crash:
https://github.com/TTT-2/TTT2/assets/5711436/23bb4363-886b-4b4c-8510-606f17add8ed

