### PR TITLE
Fixed TTT2FinishedLoading hook not called on server on hot reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - The binocular zoom now uses a DataTable that is not already used by its weaponbase
 - Fixed round scoreboard tooltips not being wide enough for their strings (by @EntranceJew)
 - Errors when looking at a player's corpse that disconnected (by @EntranceJew)
+- Fixed `TTT2FinishedLoading` hook not called on server on hot reload (by @TimGoll)
 
 ## [v0.12.2b](https://github.com/TTT-2/TTT2/tree/v0.12.2b) (2023-12-20)
 

--- a/gamemodes/terrortown/gamemode/client/cl_main.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_main.lua
@@ -190,7 +190,7 @@ function GM:Initialize()
 	keyhelp.InitializeBasicKeys()
 
 	---
-	-- @realm client
+	-- @realm shared
 	hook.Run("TTT2FinishedLoading")
 
 	---
@@ -360,7 +360,7 @@ function GM:OnReloaded()
 	keyhelp.InitializeBasicKeys()
 
 	---
-	-- @realm client
+	-- @realm shared
 	hook.Run("TTT2FinishedLoading")
 end
 

--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -1363,6 +1363,10 @@ function GM:OnReloaded()
 	---
 	-- @realm shared
 	hook.Run("TTT2BaseRoleInit")
+
+	---
+	-- @realm shared
+	hook.Run("TTT2FinishedLoading")
 end
 
 ---

--- a/gamemodes/terrortown/gamemode/shared/sh_main.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_main.lua
@@ -188,6 +188,7 @@ function GM:TTT2Initialize()
 end
 
 ---
+-- Called when TTT2 is finished loading on startup and hotreload.
 -- @hook
 -- @realm shared
 function GM:TTT2FinishedLoading()


### PR DESCRIPTION
Fixed `TTT2FinishedLoading` hook not called on server on hot reload, also added a docstring.