### PR TITLE
Indent Subsettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
   - This puts quotation marks around print statements
   - Can handle single values or a sequential table to be printed
 - Added new hooks `TTT2BeaconDetectPlayer` and `TTT2BeaconDeathNotify` to allow preventing / overriding a beacon's player detection & alerts (by @spanospy)
+- Added indentation to subsettings in F1 menu (by @TimGoll)
 
 ### Changed
 

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/default_skin.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/default_skin.lua
@@ -791,8 +791,18 @@ end
 -- @param number h
 -- @realm client
 function SKIN:PaintHelpLabelTTT2(panel, w, h)
-	drawBox(0, 0, w, h, colors.helpBox)
-	drawBox(0, 0, 4, h, colors.helpBar)
+	local colorBox = colors.helpBox
+	local colorBar = colors.helpBar
+	local colorText = colors.helpText
+
+	if not panel:IsEnabled() then
+		colorBox = ColorAlpha(colorBox, alphaDisabled)
+		colorBar = ColorAlpha(colorBar, alphaDisabled)
+		colorText = ColorAlpha(colorText, 0.5 * alphaDisabled)
+	end
+
+	drawBox(0, 0, w, h, colorBox)
+	drawBox(0, 0, 4, h, colorBar)
 
 	local textTranslated = ParT(panel:GetText(), TryT(panel:GetTextParams()))
 	local textWrapped = drawGetWrappedText(
@@ -810,7 +820,7 @@ function SKIN:PaintHelpLabelTTT2(panel, w, h)
 			panel:GetFont(),
 			panel.paddingX,
 			posY,
-			colors.helpText,
+			colorText,
 			TEXT_ALIGN_LEFT,
 			TEXT_ALIGN_TOP
 		)

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dform_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dform_ttt2.lua
@@ -223,8 +223,13 @@ function PANEL:MakeCheckBox(data)
 	self:AddItem(left, nil, reset)
 
 	if IsValid(data.master) and isfunction(data.master.AddSlave) then
+		left:SetMaster(data.master)
+		reset:SetMaster(data.master)
+
 		data.master:AddSlave(left)
 		data.master:AddSlave(reset)
+
+		left:DockMargin(left:GetMargin(), 0, 0, 0)
 	end
 
 	return left
@@ -283,6 +288,12 @@ function PANEL:MakeSlider(data)
 		data.master:AddSlave(left)
 		data.master:AddSlave(right)
 		data.master:AddSlave(reset)
+
+		left:SetMaster(data.master)
+		right:SetMaster(data.master)
+		reset:SetMaster(data.master)
+
+		left:DockMargin(left:GetMargin(), 0, 0, 0)
 	end
 
 	return left
@@ -364,6 +375,12 @@ function PANEL:MakeComboBox(data)
 		data.master:AddSlave(left)
 		data.master:AddSlave(right)
 		data.master:AddSlave(reset)
+
+		left:SetMaster(data.master)
+		right:SetMaster(data.master)
+		reset:SetMaster(data.master)
+
+		left:DockMargin(left:GetMargin(), 0, 0, 0)
 	end
 
 	return right, left
@@ -423,6 +440,12 @@ function PANEL:MakeBinder(data)
 		data.master:AddSlave(left)
 		data.master:AddSlave(right)
 		data.master:AddSlave(reset)
+
+		left:SetMaster(data.master)
+		right:SetMaster(data.master)
+		reset:SetMaster(data.master)
+
+		left:DockMargin(left:GetMargin(), 0, 0, 0)
 	end
 
 	return right, left
@@ -465,6 +488,14 @@ function PANEL:MakeHelp(data)
 	end
 
 	self:AddItem(left, nil)
+
+	if IsValid(data.master) and isfunction(data.master.AddSlave) then
+		data.master:AddSlave(left)
+
+		left:SetMaster(data.master)
+
+		left:DockMargin(left:GetMargin(), 0, 0, 0)
+	end
 
 	left:InvalidateLayout(true)
 

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dform_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dform_ttt2.lua
@@ -229,7 +229,7 @@ function PANEL:MakeCheckBox(data)
 		data.master:AddSlave(left)
 		data.master:AddSlave(reset)
 
-		left:DockMargin(left:GetMargin(), 0, 0, 0)
+		left:DockMargin(left:GetIndentationMargin(), 0, 0, 0)
 	end
 
 	return left
@@ -293,7 +293,7 @@ function PANEL:MakeSlider(data)
 		right:SetMaster(data.master)
 		reset:SetMaster(data.master)
 
-		left:DockMargin(left:GetMargin(), 0, 0, 0)
+		left:DockMargin(left:GetIndentationMargin(), 0, 0, 0)
 	end
 
 	return left
@@ -380,7 +380,7 @@ function PANEL:MakeComboBox(data)
 		right:SetMaster(data.master)
 		reset:SetMaster(data.master)
 
-		left:DockMargin(left:GetMargin(), 0, 0, 0)
+		left:DockMargin(left:GetIndentationMargin(), 0, 0, 0)
 	end
 
 	return right, left
@@ -445,7 +445,7 @@ function PANEL:MakeBinder(data)
 		right:SetMaster(data.master)
 		reset:SetMaster(data.master)
 
-		left:DockMargin(left:GetMargin(), 0, 0, 0)
+		left:DockMargin(left:GetIndentationMargin(), 0, 0, 0)
 	end
 
 	return right, left
@@ -494,7 +494,7 @@ function PANEL:MakeHelp(data)
 
 		left:SetMaster(data.master)
 
-		left:DockMargin(left:GetMargin(), 0, 0, 0)
+		left:DockMargin(left:GetIndentationMargin(), 0, 0, 0)
 	end
 
 	left:InvalidateLayout(true)

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dlabel_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dlabel_ttt2.lua
@@ -93,6 +93,26 @@ function PANEL:Paint(w, h)
 end
 
 ---
+-- @param Panel slave
+-- @realm client
+function PANEL:SetMaster(master)
+	if not IsValid(master) then return end
+
+	self.master = master
+end
+
+---
+-- @param Panel slave
+-- @realm client
+function PANEL:GetMargin()
+	if not IsValid(self.master) then
+		return 0
+	end
+
+	return 10 + self.master:GetMargin()
+end
+
+---
 -- @param string strFont
 -- @realm client
 function PANEL:SetFont(strFont)

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dlabel_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dlabel_ttt2.lua
@@ -93,7 +93,7 @@ function PANEL:Paint(w, h)
 end
 
 ---
--- @param Panel slave
+-- @param Panel master
 -- @realm client
 function PANEL:SetMaster(master)
 	if not IsValid(master) then return end

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dlabel_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dlabel_ttt2.lua
@@ -104,12 +104,12 @@ end
 ---
 -- @return number
 -- @realm client
-function PANEL:GetMargin()
+function PANEL:GetIndentationMargin()
 	if not IsValid(self.master) then
 		return 0
 	end
 
-	return 10 + self.master:GetMargin()
+	return 10 + self.master:GetIndentationMargin()
 end
 
 ---

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dlabel_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dlabel_ttt2.lua
@@ -102,7 +102,7 @@ function PANEL:SetMaster(master)
 end
 
 ---
--- @param Panel slave
+-- @return number
 -- @realm client
 function PANEL:GetMargin()
 	if not IsValid(self.master) then

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dnumslider_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dnumslider_ttt2.lua
@@ -484,4 +484,4 @@ function PANEL:SetEnabled(b)
 	FindMetaTable("Panel").SetEnabled(self, b)
 end
 
-derma.DefineControl("DNumSliderTTT2", "", PANEL, "Panel")
+derma.DefineControl("DNumSliderTTT2", "", PANEL, "DPanelTTT2")

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dpanel_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dpanel_ttt2.lua
@@ -248,12 +248,12 @@ end
 ---
 -- @return number
 -- @realm client
-function PANEL:GetMargin()
+function PANEL:GetIndentationMargin()
 	if not IsValid(self.master) then
 		return 0
 	end
 
-	return 10 + self.master:GetMargin()
+	return 10 + self.master:GetIndentationMargin()
 end
 
 derma.DefineControl("DPanelTTT2", "", PANEL, "Panel")

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dpanel_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dpanel_ttt2.lua
@@ -236,4 +236,24 @@ function PANEL:GetTooltipFont()
 	return self.tooltip.font
 end
 
+---
+-- @param Panel slave
+-- @realm client
+function PANEL:SetMaster(master)
+	if not IsValid(master) then return end
+
+	self.master = master
+end
+
+---
+-- @param Panel slave
+-- @realm client
+function PANEL:GetMargin()
+	if not IsValid(self.master) then
+		return 0
+	end
+
+	return 10 + self.master:GetMargin()
+end
+
 derma.DefineControl("DPanelTTT2", "", PANEL, "Panel")

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dpanel_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dpanel_ttt2.lua
@@ -237,7 +237,7 @@ function PANEL:GetTooltipFont()
 end
 
 ---
--- @param Panel slave
+-- @param Panel master
 -- @realm client
 function PANEL:SetMaster(master)
 	if not IsValid(master) then return end

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dpanel_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dpanel_ttt2.lua
@@ -246,7 +246,7 @@ function PANEL:SetMaster(master)
 end
 
 ---
--- @param Panel slave
+-- @return number
 -- @realm client
 function PANEL:GetMargin()
 	if not IsValid(self.master) then

--- a/lua/terrortown/menus/gamemode/administration/entspawn.lua
+++ b/lua/terrortown/menus/gamemode/administration/entspawn.lua
@@ -49,6 +49,10 @@ end)
 function CLGAMEMODESUBMENU:Populate(parent)
 	local form = vgui.CreateTTT2Form(parent, "header_entspawn_settings")
 
+	form:MakeHelp({
+		label = "help_spawn_editor_info"
+	})
+
 	-- store the reference to the checkbox in a variable
 	-- because the other settings are enabled based on
 	-- the state of this checkbox
@@ -62,11 +66,8 @@ function CLGAMEMODESUBMENU:Populate(parent)
 	})
 
 	form:MakeHelp({
-		label = "help_spawn_editor_info"
-	})
-
-	form:MakeHelp({
-		label = "help_spawn_editor_enable"
+		label = "help_spawn_editor_enable",
+		master = dynSpawnEnable
 	})
 
 	updateCheckBoxes[1] = form:MakeCheckBox({
@@ -80,7 +81,8 @@ function CLGAMEMODESUBMENU:Populate(parent)
 	})
 
 	form:MakeHelp({
-		label = "help_spawn_editor_hint"
+		label = "help_spawn_editor_hint",
+		master = dynSpawnEnable
 	})
 
 	updateHelpBox = form:MakeHelp({
@@ -104,7 +106,8 @@ function CLGAMEMODESUBMENU:Populate(parent)
 			ammorifle = ttt2net.Get({"entspawnscript", "spawnamount", "ammorifle"}) or 0,
 			ammoshotgun = ttt2net.Get({"entspawnscript", "spawnamount", "ammoshotgun"}) or 0,
 			playerrandom = ttt2net.Get({"entspawnscript", "spawnamount", "playerrandom"}) or 0
-		}
+		},
+		master = dynSpawnEnable
 	})
 
 	local form2 = vgui.CreateTTT2Form(parent, "header_entspawn_plyspawn")

--- a/lua/terrortown/menus/gamemode/administration/karma.lua
+++ b/lua/terrortown/menus/gamemode/administration/karma.lua
@@ -18,7 +18,8 @@ function CLGAMEMODESUBMENU:Populate(parent)
 	})
 
 	form:MakeHelp({
-		label = "help_karma_strict"
+		label = "help_karma_strict",
+		master = enbKma
 	})
 
 	form:MakeCheckBox({
@@ -37,7 +38,8 @@ function CLGAMEMODESUBMENU:Populate(parent)
 	})
 
 	form:MakeHelp({
-		label = "help_karma_max"
+		label = "help_karma_max",
+		master = enbKma
 	})
 
 	form:MakeSlider({
@@ -50,7 +52,8 @@ function CLGAMEMODESUBMENU:Populate(parent)
 	})
 
 	form:MakeHelp({
-		label = "help_karma_ratio"
+		label = "help_karma_ratio",
+		master = enbKma
 	})
 
 	form:MakeSlider({
@@ -72,7 +75,8 @@ function CLGAMEMODESUBMENU:Populate(parent)
 	})
 
 	form:MakeHelp({
-		label = "help_karma_traitordmg_ratio"
+		label = "help_karma_traitordmg_ratio",
+		master = enbKma
 	})
 
 	form:MakeSlider({
@@ -94,7 +98,8 @@ function CLGAMEMODESUBMENU:Populate(parent)
 	})
 
 	form:MakeHelp({
-		label = "help_karma_bonus"
+		label = "help_karma_bonus",
+		master = enbKma
 	})
 
 	form:MakeSlider({
@@ -116,7 +121,8 @@ function CLGAMEMODESUBMENU:Populate(parent)
 	})
 
 	form:MakeHelp({
-		label = "help_karma_clean_half"
+		label = "help_karma_clean_half",
+		master = enbKma
 	})
 
 	form:MakeSlider({

--- a/lua/terrortown/menus/gamemode/administration/mapentities.lua
+++ b/lua/terrortown/menus/gamemode/administration/mapentities.lua
@@ -63,7 +63,8 @@ function CLGAMEMODESUBMENU:Populate(parent)
 	})
 
 	form:MakeHelp({
-		label = "help_prop_spec_dash"
+		label = "help_prop_spec_dash",
+		master = enbPP
 	})
 
 	form:MakeSlider({

--- a/lua/terrortown/menus/gamemode/administration/playersettings.lua
+++ b/lua/terrortown/menus/gamemode/administration/playersettings.lua
@@ -46,7 +46,8 @@ function CLGAMEMODESUBMENU:Populate(parent)
 	})
 
 	form2:MakeHelp({
-		label = "help_item_armor_dynamic"
+		label = "help_item_armor_dynamic",
+		master = enbDyn
 	})
 
 	form2:MakeSlider({
@@ -95,11 +96,12 @@ function CLGAMEMODESUBMENU:Populate(parent)
 		min = 0,
 		max = 1500,
 		decimal = 0,
-		parent = enbFallDmg
+		master = enbFallDmg
 	})
 
 	formFallDmg:MakeHelp({
-		label = "help_falldmg_exponent"
+		label = "help_falldmg_exponent",
+		master = enbFallDmg
 	})
 
 	formFallDmg:MakeSlider({
@@ -108,6 +110,6 @@ function CLGAMEMODESUBMENU:Populate(parent)
 		min = 0,
 		max = 5,
 		decimal = 2,
-		parent = enbFallDmg
+		master = enbFallDmg
 	})
 end

--- a/lua/terrortown/menus/gamemode/administration/roles.lua
+++ b/lua/terrortown/menus/gamemode/administration/roles.lua
@@ -14,11 +14,13 @@ function CLGAMEMODESUBMENU:Populate(parent)
 	})
 
 	form:MakeHelp({
-		label = "help_roles_advanced_warning"
+		label = "help_roles_advanced_warning",
+		master = masterEnb
 	})
 
 	form:MakeHelp({
-		label = "help_roles_max_roles"
+		label = "help_roles_max_roles",
+		master = masterEnb
 	})
 
 	form:MakeSlider({
@@ -40,7 +42,8 @@ function CLGAMEMODESUBMENU:Populate(parent)
 	})
 
 	form:MakeHelp({
-		label = "help_roles_max_baseroles"
+		label = "help_roles_max_baseroles",
+		master = masterEnb
 	})
 
 	form:MakeSlider({

--- a/lua/terrortown/menus/gamemode/administration/roundsetup.lua
+++ b/lua/terrortown/menus/gamemode/administration/roundsetup.lua
@@ -149,7 +149,8 @@ function CLGAMEMODESUBMENU:Populate(parent)
 	})
 
 	form5:MakeHelp({
-		label = "help_round_limit"
+		label = "help_round_limit",
+		master = enbSessionLimitsEnabled
 	})
 
 	form5:MakeSlider({

--- a/lua/terrortown/menus/gamemode/equipment/base_equipment.lua
+++ b/lua/terrortown/menus/gamemode/equipment/base_equipment.lua
@@ -64,8 +64,7 @@ function CLGAMEMODESUBMENU:Populate(parent)
 			{title = TryT("slot_weapon_special"), value = WEAPON_SPECIAL},
 			{title = TryT("slot_weapon_extra"), value = WEAPON_EXTRA},
 			{title = TryT("slot_weapon_class"), value = WEAPON_CLASS}
-		},
-		master = nil
+		}
 	})
 
 	form:MakeHelp({
@@ -79,7 +78,8 @@ function CLGAMEMODESUBMENU:Populate(parent)
 	})
 
 	form:MakeHelp({
-		label = "equipmenteditor_desc_not_random"
+		label = "equipmenteditor_desc_not_random",
+		master = master
 	})
 
 	form:MakeCheckBox({
@@ -89,7 +89,8 @@ function CLGAMEMODESUBMENU:Populate(parent)
 	})
 
 	form:MakeHelp({
-		label = "equipmenteditor_desc_global_limited"
+		label = "equipmenteditor_desc_global_limited",
+		master = master
 	})
 
 	form:MakeCheckBox({
@@ -99,7 +100,8 @@ function CLGAMEMODESUBMENU:Populate(parent)
 	})
 
 	form:MakeHelp({
-		label = "equipmenteditor_desc_team_limited"
+		label = "equipmenteditor_desc_team_limited",
+		master = master
 	})
 
 	form:MakeCheckBox({
@@ -109,7 +111,8 @@ function CLGAMEMODESUBMENU:Populate(parent)
 	})
 
 	form:MakeHelp({
-		label = "equipmenteditor_desc_player_limited"
+		label = "equipmenteditor_desc_player_limited",
+		master = master
 	})
 
 	form:MakeCheckBox({
@@ -124,12 +127,11 @@ function CLGAMEMODESUBMENU:Populate(parent)
 
 	form:MakeCheckBox({
 		label = "equipmenteditor_name_allow_drop",
-		database = DatabaseElement(accessName, itemName, "AllowDrop"),
-		master = nil
+		database = DatabaseElement(accessName, itemName, "AllowDrop")
 	})
 
 	form:MakeHelp({
-		label = "equipmenteditor_desc_drop_on_death_type"
+		label = "equipmenteditor_desc_drop_on_death_type",
 	})
 
 	form:MakeComboBox({
@@ -139,8 +141,7 @@ function CLGAMEMODESUBMENU:Populate(parent)
 			{title = TryT("drop_on_death_type_default"), value = DROP_ON_DEATH_TYPE_DEFAULT},
 			{title = TryT("drop_on_death_type_force"), value = DROP_ON_DEATH_TYPE_FORCE},
 			{title = TryT("drop_on_death_type_deny"), value = DROP_ON_DEATH_TYPE_DENY}
-		},
-		master = nil
+		}
 	})
 
 	form = vgui.CreateTTT2Form(parent, "header_equipment_value_setup")
@@ -150,8 +151,7 @@ function CLGAMEMODESUBMENU:Populate(parent)
 		min = 0,
 		max = 63,
 		decimal = 0,
-		database = DatabaseElement(accessName, itemName, "minPlayers"),
-		master = master
+		database = DatabaseElement(accessName, itemName, "minPlayers")
 	})
 
 	form:MakeSlider({
@@ -159,8 +159,7 @@ function CLGAMEMODESUBMENU:Populate(parent)
 		min = 0,
 		max = 20,
 		decimal = 0,
-		database = DatabaseElement(accessName, itemName, "credits"),
-		master = master
+		database = DatabaseElement(accessName, itemName, "credits")
 	})
 
 	form:MakeHelp({
@@ -172,8 +171,7 @@ function CLGAMEMODESUBMENU:Populate(parent)
 		min = 0,
 		max = 8,
 		decimal = 2,
-		database = DatabaseElement(accessName, itemName, "damageScaling"),
-		master = nil
+		database = DatabaseElement(accessName, itemName, "damageScaling")
 	})
 
 


### PR DESCRIPTION
Subsettings are now indented to make it easier to spot which settings are related. The master/slave and enable/disable system was also added to helpboxes.

![image](https://github.com/TTT-2/TTT2/assets/13639408/cd63b94e-999f-4547-a7f5-1805fc351178)
![image](https://github.com/TTT-2/TTT2/assets/13639408/aa57ed68-b5e2-4215-b7e6-5a8cdd4875ee)
![image](https://github.com/TTT-2/TTT2/assets/13639408/cd7b97a9-2d77-4ee4-b7f0-3865131e9757)
