### PR TITLE
Shopeditor: Fix missing default values for nil entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed round scoreboard tooltips not being wide enough for their strings (by @EntranceJew)
 - Errors when looking at a player's corpse that disconnected (by @EntranceJew)
 - Fixed `TTT2FinishedLoading` hook not called on server on hot reload (by @TimGoll)
-- Shopeditor now shows correct values for resetted and default tables
+- Shopeditor now correctly shows resetted and default values
 
 ## [v0.12.2b](https://github.com/TTT-2/TTT2/tree/v0.12.2b) (2023-12-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed round scoreboard tooltips not being wide enough for their strings (by @EntranceJew)
 - Errors when looking at a player's corpse that disconnected (by @EntranceJew)
 - Fixed `TTT2FinishedLoading` hook not called on server on hot reload (by @TimGoll)
+- Shopeditor now shows correct values for resetted and default tables
 
 ## [v0.12.2b](https://github.com/TTT-2/TTT2/tree/v0.12.2b) (2023-12-20)
 

--- a/lua/ttt2/libraries/database.lua
+++ b/lua/ttt2/libraries/database.lua
@@ -1092,14 +1092,18 @@ if SERVER then
 				return true, value
 			end
 
+			ConvertTable(sqlData, accessName)
+
 			local newTable = {}
 			for _key in pairs(dataTable.keys) do
+				-- Get default values if no value was saved
+				if sqlData[_key] == nil then
+					sqlData[_key] = database.GetDefaultValue(accessName, itemName, _key)
+				end
 				newTable[_key] = sqlData[_key]
 			end
 
 			sqlData = newTable
-			ConvertTable(sqlData, accessName)
-
 			dataTable.storedData[itemName] = sqlData
 		else
 			-- Get all data, convert and return it
@@ -1109,8 +1113,14 @@ if SERVER then
 				return false
 			end
 
-			for _, item in pairs(sqlData) do
-				ConvertTable(item, accessName)
+			for _, _itemName in pairs(sqlData) do
+				ConvertTable(_itemName, accessName)
+				-- Get default values if no value was saved
+				for _key in pairs(dataTable.keys) do
+					if _itemName[_key] == nil then
+						_itemName[_key] = database.GetDefaultValue(accessName, _itemName, _key)
+					end
+				end
 			end
 
 			-- Convert numerical indices to string indices with the itemName


### PR DESCRIPTION
With the new way to get all weapon stats at startup, they are automatically cached.
When accessing that cache per key, the values are `nil`, even if they are marked as received.
Thats because the new system saves default values as `nil` in the database and deletes them if the complete weapon is default.

To fix that, it now always returns the correct values in the GetValue-function.
Downside is, that tables are synchronized with values instead of `nil`/no entry for values that are defaut anyway.
That makes synchronization slower.

Better would be to abstract it further and have a separate Get-Function for internal synchronization and external retrieval.
So that in case of synchronization only changed values are synced, but when retrieving them default values are automatically inserted and not `nil` is outputted.