### PR TITLE
Debug: Enable nil entries in nearly sequential table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 - Updated the Turkish localization file (by @NovaDiablox)
 - Keyhelp and weapon HUD Help now use the global scale factor
+- debug.print can now handle `nil` entries in a nearly sequential table
 
 ### Fixed
 

--- a/lua/ttt2/extensions/debug.lua
+++ b/lua/ttt2/extensions/debug.lua
@@ -23,6 +23,32 @@ local function ConvertToString(object)
 end
 
 ---
+-- Converts nil entries in an otherwise sequential table
+-- Also directly converts all entries to strings
+-- @param table tbl The table to convert
+-- @return boolean If the table could be fully converted to a sequential table?
+-- @realm shared
+-- @internal
+local function TryConvertToSequentialTable(tbl)
+	if not istable(tbl) then return false end
+
+	-- Check that all keys are numbers
+	local largestIndex = 1
+	for key, tableContent in pairs(tbl) do
+		if not isnumber(key) then return false end
+		if largestIndex < key then
+			largestIndex = key
+		end
+	end
+
+	for i = 1, largestIndex do
+		tbl[i] = ConvertToString(tbl[i])
+	end
+
+	return true
+end
+
+---
 -- Print messages with added quotation marks to strings
 -- @param any message The message to display
 -- @note The message can be a variable or a table and even nil. In case of a table it automatically concatenates all entries and checks every object if it is a string
@@ -30,9 +56,9 @@ end
 function debug.print(message)
 	local printMessage = ""
 
-	if istable(message) and table.IsSequential(message) then
+	if TryConvertToSequentialTable(message) then
 		for i = 1, #message do
-			printMessage = printMessage .. ConvertToString(message[i]) .. " "
+			printMessage = printMessage .. message[i] .. " "
 		end
 	else
 		printMessage = ConvertToString(message)


### PR DESCRIPTION
While debugging the shopeditor, I noticed, that `nil` entries make an otherwise sequential table to be not sequential.
For example this:
`{"The value of", key, "is",value,""}`
is now shown as:
`"The value of" "Kind" "is" nil `
before it was shown with the fourth entry being empty:
```
1:"The value of"
2:"Kind"
3:"is"
5: 
```

But it still cant handle nil entries at the end of a table. So this:
`{"The value of", key, "is",value}`
will still be shown as:
`"The value of" "Kind" "is" `

