### PR TITLE
Added Delay to Weapon Select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ### Fixed
 
 - The roundendscreen can now be closed with the correct Binding
+- Fixed cached weapons not being selected after giving them back to the owner
 
 ## [v0.12.3b](https://github.com/TTT-2/TTT2/tree/v0.12.3b) (2024-01-07)
 

--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -1667,7 +1667,14 @@ function plymeta:RestoreCachedWeapons()
 	end
 
 	if self.cachedWeaponSelected then
-		self:SelectWeapon(self.cachedWeaponSelected)
+		local cachedWeaponSelected = self.cachedWeaponSelected
+
+		-- delay selection by .1 seconds to actually select the weapon
+		timer.Simple(0.1, function()
+			if not IsValid(self) then return end
+
+			self:SelectWeapon(cachedWeaponSelected)
+		end)
 	end
 
 	self:ResetCachedWeapons()


### PR DESCRIPTION
TTT2 has the ability to remove and cache a player's inventory to be later given back to the player. It is also designed to autoselect the old weapon. However this was broken all the time.

I solved this issue here with a 100ms timer. I don't like this hook, but I spend at least two hours trying to solve the underlying issue here but I was unable to. My best guess is that it has to do something with prediction as weapon selection aparantly is predicted. Adding a 100ms delay between giving and selecting weapons solved the issue for me.

Things I tried that also failed:

- running `lastinv` on the client
- using `input.SelectWeapon` on the client as this function is predicted