### PR TITLE
Improved Weapon Caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 - Binoculars now retain search progress if interrupted. Progress decays based on time since last observed (by @EntranceJew)
 - Added possibility to cache and remove items, similar to how it is already possible with weapons with `CacheAndStripItems` (by @TimGoll)
+- Added an option for weapons to hide the pickup notification by setting `SWEP.silentPickup` to `true` (by @TimGoll)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ### Added
 
 - Binoculars now retain search progress if interrupted. Progress decays based on time since last observed (by @EntranceJew)
+- Added possibility to cache and remove items, similar to how it is already possible with weapons with `CacheAndStripItems` (by @TimGoll)
 
 ### Changed
 
 - Refactored client shop logic into separate shop-class (by @ZenBre4ker)
 - dframe_ttt2 panels can now manually enable bindings while they are open (by @ZenBre4ker)
 - Binoculars now have a world model that isn't paper towels (by @EntranceJew)
+- A player whose weapons are stripped and cached will keep `weapon_ttt_unarmed` which means they keep their crosshair
 
 ### Fixed
 

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_beacon.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_beacon.lua
@@ -50,6 +50,8 @@ SWEP.Spawnable = true
 SWEP.AllowDrop = false
 SWEP.NoSights = true
 
+SWEP.builtin = true
+
 ---
 -- @realm shared
 function SWEP:OnDrop()

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_spawneditor.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_spawneditor.lua
@@ -44,6 +44,8 @@ SWEP.lastReload = 0
 
 SWEP.AllowDrop = false
 
+SWEP.builtin = true
+
 local previewData = {}
 
 if SERVER then

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_unarmed.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_unarmed.lua
@@ -1,0 +1,80 @@
+if SERVER then
+	AddCSLuaFile()
+end
+
+SWEP.HoldType = "normal"
+
+if CLIENT then
+	SWEP.PrintName = "unarmed_name"
+	SWEP.Slot = 5
+
+	SWEP.ViewModelFOV = 10
+end
+
+SWEP.Base = "weapon_tttbase"
+
+SWEP.ViewModel = "models/weapons/v_crowbar.mdl"
+SWEP.WorldModel = "models/weapons/w_crowbar.mdl"
+
+SWEP.Primary.ClipSize = -1
+SWEP.Primary.DefaultClip = -1
+SWEP.Primary.Automatic = false
+SWEP.Primary.Ammo = "none"
+
+SWEP.Secondary.ClipSize = -1
+SWEP.Secondary.DefaultClip = -1
+SWEP.Secondary.Automatic = false
+SWEP.Secondary.Ammo = "none"
+
+SWEP.Kind = WEAPON_UNARMED
+SWEP.InLoadoutFor = {ROLE_INNOCENT, ROLE_TRAITOR, ROLE_DETECTIVE}
+
+SWEP.AllowDelete = false
+SWEP.AllowDrop = false
+SWEP.NoSights = true
+
+SWEP.silentPickup = true
+
+SWEP.builtin = true
+
+function SWEP:OnDrop()
+	self:Remove()
+end
+
+function SWEP:ShouldDropOnDie()
+	return false
+end
+
+function SWEP:PrimaryAttack()
+
+end
+
+function SWEP:SecondaryAttack()
+
+end
+
+function SWEP:Reload()
+
+end
+
+function SWEP:Deploy()
+	if SERVER and IsValid(self:GetOwner()) then
+		self:GetOwner():DrawViewModel(false)
+	end
+
+	self:DrawShadow(false)
+
+	return true
+end
+
+function SWEP:Holster()
+	return true
+end
+
+function SWEP:DrawWorldModel()
+
+end
+
+function SWEP:DrawWorldModelTranslucent()
+
+end

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_unarmed.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_unarmed.lua
@@ -1,3 +1,7 @@
+---
+-- @class SWEP
+-- @section weapon_ttt_unarmed
+
 if SERVER then
 	AddCSLuaFile()
 end
@@ -37,26 +41,38 @@ SWEP.silentPickup = true
 
 SWEP.builtin = true
 
+---
+-- @ignore
 function SWEP:OnDrop()
 	self:Remove()
 end
 
+---
+-- @ignore
 function SWEP:ShouldDropOnDie()
 	return false
 end
 
+---
+-- @ignore
 function SWEP:PrimaryAttack()
 
 end
 
+---
+-- @ignore
 function SWEP:SecondaryAttack()
 
 end
 
+---
+-- @ignore
 function SWEP:Reload()
 
 end
 
+---
+-- @ignore
 function SWEP:Deploy()
 	if SERVER and IsValid(self:GetOwner()) then
 		self:GetOwner():DrawViewModel(false)
@@ -67,14 +83,20 @@ function SWEP:Deploy()
 	return true
 end
 
+---
+-- @ignore
 function SWEP:Holster()
 	return true
 end
 
+---
+-- @ignore
 function SWEP:DrawWorldModel()
 
 end
 
+---
+-- @ignore
 function SWEP:DrawWorldModelTranslucent()
 
 end

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -96,6 +96,9 @@ SWEP.IsSilent = false
 -- in close proximity to this weapon when spawned.
 SWEP.autoAmmoAmount = 0
 
+-- It this is set to true, there will be no pickup notification when receiving this weapon.
+SWEP.silentPickup = false
+
 -- Set Keys like { "HeadshotMultiplier", "Weight", { "Primary", "Recoil" }, { "Secondary", "Ammo" } } if you want the data to be persistent after hotreloads
 -- Empty it before a hotreload to reset data after a hotreload, otherwise this data keep persisting until you do a map reload or restart your server
 -- Can be useful if you have multiple instances, that rely on global variables stored via weapons.GetStored()

--- a/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
@@ -63,6 +63,8 @@ SWEP.CarryHack = nil
 SWEP.Constr = nil
 SWEP.PrevOwner = nil
 
+SWEP.builtin = true
+
 -- ConVar syncing
 if SERVER then
 

--- a/gamemodes/terrortown/gamemode/client/cl_hudpickup.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_hudpickup.lua
@@ -38,7 +38,7 @@ end
 -- @ref https://wiki.facepunch.com/gmod/GM:HUDWeaponPickedUp
 -- @local
 function GM:HUDWeaponPickedUp(wep)
-	if not IsValid(wep) then return end
+	if not IsValid(wep) or wep.silentPickup then return end
 
 	local client = LocalPlayer()
 

--- a/gamemodes/terrortown/gamemode/client/cl_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_player_ext.lua
@@ -204,7 +204,7 @@ local function UpdateEquipment()
 				item:Equip(client)
 			end
 		elseif mode == EQUIPITEMS_REMOVE then
-			table.remove(equipItems, itemName)
+			table.RemoveByValue(equipItems, itemName)
 
 			if item and isfunction(item.Reset) then
 				item:Reset(client)

--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -1047,6 +1047,8 @@ function PrepareRound()
 
 		ply:CancelRevival(nil, true)
 		ply:SendRevivalReason(nil)
+
+		ply:ResetItemAndWeaponCache()
 	end
 
 	---

--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -228,7 +228,10 @@ plymeta.RemoveEquipmentWeapon = plymeta.StripWeapon
 -- @realm server
 function plymeta:SendEquipment(mode, itemName)
 	if not mode then
-		ErrorNoHalt("[TTT2] Define an EQUIPITEMS_mode for plymeta:SendEquipment(mode, itemName) to work.")
+		ErrorNoHalt("[TTT2] Define an EQUIPITEMS_mode for plymeta:SendEquipment(mode, itemName) to work.\n")
+
+		debug.Trace()
+
 		return
 	end
 
@@ -1627,25 +1630,33 @@ end
 -- These weapons can be restored at any time.
 -- @note As long as a player has cached weapons, they are unable to pick up any weapon.
 -- @realm server
-function plymeta:CacheAndStripWeapons()
-	local cachedWeaponInventory = {}
+function plymeta:CacheAndStripWeapons(forceAll)
+	self.cachedWeaponInventory = {}
+	self.cachedWeaponSelected = WEPS.GetClass(self:GetActiveWeapon())
 
 	local weps = self:GetWeapons()
 
 	for i = 1, #weps do
 		local wep = weps[i]
+		local wepClass = WEPS.GetClass(wep)
 
-		cachedWeaponInventory[#cachedWeaponInventory + 1] = {
-			cls = WEPS.GetClass(wep),
+		if not forceAll and wepClass == "weapon_ttt_unarmed" then continue end
+
+		self.cachedWeaponInventory[#self.cachedWeaponInventory + 1] = {
+			cls = wepClass,
 			clip1 = wep:Clip1(),
 			clip2 = wep:Clip2()
 		}
 	end
 
-	self.cachedWeaponInventory = cachedWeaponInventory
-	self.cachedWeaponSelected = WEPS.GetClass(self:GetActiveWeapon())
 
+	-- we have to use this hack here instead of StripWeapon because StripWeapon calls
+	-- OnDrop which is not intended for the weapon caching
 	self:StripWeapons()
+
+	if not forceAll then
+		self:Give("weapon_ttt_unarmed")
+	end
 end
 
 ---
@@ -1671,6 +1682,68 @@ function plymeta:RestoreCachedWeapons()
 	end
 
 	self:ResetCachedWeapons()
+end
+
+function plymeta:RemoveCachedWeapon(wep)
+	if not self:HasCachedWeapons() then return end
+
+	for i = 1, #self.cachedWeaponInventory do
+		local cachedWeapon = self.cachedWeaponInventory[i]
+
+		if cachedWeapon ~= wep then continue end
+
+		table.remove(self.cachedWeaponInventory, i)
+
+		return
+	end
+end
+
+function plymeta:HasCachedItems()
+	return self.cachedItemInventory ~= nil
+end
+
+function plymeta:CacheAndStripItems()
+	if self:HasCachedItems() then return end
+
+	self.cachedItemInventory = self:GetEquipmentItems()
+
+	self:SetEquipmentItems(nil)
+end
+
+function plymeta:RestoreCachedItems()
+	if not self:HasCachedItems() then return end
+
+	-- make sure the player keeps any items received during this period
+	table.Merge(self.cachedItemInventory, self:GetEquipmentItems())
+
+	self:SetEquipmentItems(self.cachedItemInventory)
+
+	self.cachedItemInventory = nil
+end
+
+function plymeta:RemoveCachedItem(item)
+	if not self:HasCachedItems() then return end
+
+	for i = 1, #self.cachedItemInventory do
+		local cachedItem = self.cachedItemInventory[i]
+
+		if cachedItem ~= item then continue end
+
+		table.remove(self.cachedItemInventory, i)
+
+		-- make sure equipment remove functions are called
+		items.GetStored(item):Reset(self)
+		self:SendEquipment(EQUIPITEMS_REMOVE, item)
+
+		return
+	end
+end
+
+function plymeta:ResetItemAndWeaponCache()
+	self.cachedWeaponInventory = nil
+	self.cachedWeaponSelected = nil
+
+	self.cachedItemInventory = nil
 end
 
 ---

--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -228,9 +228,7 @@ plymeta.RemoveEquipmentWeapon = plymeta.StripWeapon
 -- @realm server
 function plymeta:SendEquipment(mode, itemName)
 	if not mode then
-		ErrorNoHalt("[TTT2] Define an EQUIPITEMS_mode for plymeta:SendEquipment(mode, itemName) to work.\n")
-
-		debug.Trace()
+		ErrorNoHaltWithStack("[TTT2] Define an EQUIPITEMS_mode for plymeta:SendEquipment(mode, itemName) to work.\n")
 
 		return
 	end

--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -1628,6 +1628,7 @@ end
 ---
 -- Caches the weapons currently in the player inventory and removes them.
 -- These weapons can be restored at any time.
+-- @param boolean forceAll force all weapons to be removed, including weapon_ttt_unarmed
 -- @note As long as a player has cached weapons, they are unable to pick up any weapon.
 -- @realm server
 function plymeta:CacheAndStripWeapons(forceAll)
@@ -1684,13 +1685,17 @@ function plymeta:RestoreCachedWeapons()
 	self:ResetCachedWeapons()
 end
 
+---
+-- Removes a cached weapon from the cache list.
+-- @param string wep The weapon class
+-- @realm server
 function plymeta:RemoveCachedWeapon(wep)
 	if not self:HasCachedWeapons() then return end
 
 	for i = 1, #self.cachedWeaponInventory do
 		local cachedWeapon = self.cachedWeaponInventory[i]
 
-		if cachedWeapon ~= wep then continue end
+		if cachedWeapon.cls ~= wep then continue end
 
 		table.remove(self.cachedWeaponInventory, i)
 
@@ -1698,10 +1703,18 @@ function plymeta:RemoveCachedWeapon(wep)
 	end
 end
 
+---
+-- Checks wether a player has cached items that can be restored.
+-- @return boolean Returns wether the player has a cached inventory
+-- @realm server
 function plymeta:HasCachedItems()
 	return self.cachedItemInventory ~= nil
 end
 
+---
+-- Caches the items currently in the player inventory and removes them.
+-- These items can be restored at any time.
+-- @realm server
 function plymeta:CacheAndStripItems()
 	if self:HasCachedItems() then return end
 
@@ -1710,6 +1723,10 @@ function plymeta:CacheAndStripItems()
 	self:SetEquipmentItems(nil)
 end
 
+---
+-- Restores the cached items if there are any cached items. Does nothing if
+-- no items are cached.
+-- @realm server
 function plymeta:RestoreCachedItems()
 	if not self:HasCachedItems() then return end
 
@@ -1721,6 +1738,10 @@ function plymeta:RestoreCachedItems()
 	self.cachedItemInventory = nil
 end
 
+---
+-- Removes a cached item from the cache list.
+-- @param string item The item class
+-- @realm server
 function plymeta:RemoveCachedItem(item)
 	if not self:HasCachedItems() then return end
 
@@ -1739,6 +1760,10 @@ function plymeta:RemoveCachedItem(item)
 	end
 end
 
+---
+-- Used to reset the weapon cache at round restart.
+-- @internal
+-- @realm server
 function plymeta:ResetItemAndWeaponCache()
 	self.cachedWeaponInventory = nil
 	self.cachedWeaponSelected = nil

--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -1628,10 +1628,10 @@ end
 ---
 -- Caches the weapons currently in the player inventory and removes them.
 -- These weapons can be restored at any time.
--- @param boolean forceAll force all weapons to be removed, including weapon_ttt_unarmed
+-- @param boolean removeUnarmed force all weapons to be removed, including weapon_ttt_unarmed
 -- @note As long as a player has cached weapons, they are unable to pick up any weapon.
 -- @realm server
-function plymeta:CacheAndStripWeapons(forceAll)
+function plymeta:CacheAndStripWeapons(removeUnarmed)
 	self.cachedWeaponInventory = {}
 	self.cachedWeaponSelected = WEPS.GetClass(self:GetActiveWeapon())
 
@@ -1641,7 +1641,7 @@ function plymeta:CacheAndStripWeapons(forceAll)
 		local wep = weps[i]
 		local wepClass = WEPS.GetClass(wep)
 
-		if not forceAll and wepClass == "weapon_ttt_unarmed" then continue end
+		if not removeUnarmed and wepClass == "weapon_ttt_unarmed" then continue end
 
 		self.cachedWeaponInventory[#self.cachedWeaponInventory + 1] = {
 			cls = wepClass,
@@ -1655,7 +1655,7 @@ function plymeta:CacheAndStripWeapons(forceAll)
 	-- OnDrop which is not intended for the weapon caching
 	self:StripWeapons()
 
-	if not forceAll then
+	if not removeUnarmed then
 		self:Give("weapon_ttt_unarmed")
 	end
 end

--- a/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
@@ -788,6 +788,26 @@ function plymeta:GetEquipmentItems()
 end
 
 ---
+-- Resets the equipment item table to the provided one
+-- @param[opt] table items The table with the item entities
+-- @realm shared
+function plymeta:SetEquipmentItems(items)
+	self.equipmentItems = items or {}
+
+	if SERVER then
+		-- we use this instead of SendEquipment here to prevent any of the
+		-- equipment reset functions to be triggered
+		net.SendStream("TTT2_SetEquipmentItems", self.equipmentItems, self)
+	end
+end
+
+if CLIENT then
+	net.ReceiveStream("TTT2_SetEquipmentItems", function(equipmentItems)
+		LocalPlayer():SetEquipmentItems(equipmentItems)
+	end)
+end
+
+---
 -- Given an equipment id, returns if @{Player} owns this. Given nil, returns if
 -- @{Player} has any equipment item.
 -- @param[opt] string id

--- a/lua/ttt2/libraries/entspawnscript.lua
+++ b/lua/ttt2/libraries/entspawnscript.lua
@@ -1003,7 +1003,8 @@ function entspawnscript.StartEditing(ply)
 	else
 		if entspawnscript.IsEditing(ply) then return end
 
-		ply:CacheAndStripWeapons()
+		ply:CacheAndStripWeapons(true)
+		ply:CacheAndStripItems()
 
 		timer.Simple(0, function()
 			if not IsValid(ply) then return end
@@ -1031,6 +1032,7 @@ function entspawnscript.StopEditing(ply)
 		if not entspawnscript.IsEditing(ply) then return end
 
 		ply:RestoreCachedWeapons()
+		ply:RestoreCachedItems()
 		ply:StripWeapon("weapon_ttt_spawneditor")
 
 		entspawnscript.SetEditing(ply, false)


### PR DESCRIPTION
While working on TTTC I noticed some issues with weapon caching and fixed them in this PR. I also added the same caching for items.

Things I did in this PR:

- fixed weapon caching
- set missing `builtin` flag
- fixed an item syncing issue with table remove
- added `weapon_ttt_unarmed` to base
- made sure that by default a player keeps `weapon_ttt_unarmed` when removing all their weapons to keep the crosshair etc
- added flag for weapons to hide pickup notification and added this flag to `weapon_ttt_unarmed`