### PR TITLE
Added Circle Draw Code from TTTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ### Added
 
 - Binoculars now retain search progress if interrupted. Progress decays based on time since last observed (by @EntranceJew)
+- Added `draw.Arc` and `draw.ShadowedArc` from TTTC to TTT2 to draw arcs (by @TimGoll und @Alf21)
 
 ### Changed
 

--- a/lua/ttt2/extensions/draw.lua
+++ b/lua/ttt2/extensions/draw.lua
@@ -677,8 +677,7 @@ end
 
 local cachedArcs = {}
 
--- Currently caching is only searched for changed angleStart and angleEnd. We only modify these
--- parameters, so this will lead to the best possible performance
+-- Generates an arc out of triangles that is cached in a table to reduce rendering time
 local function PrecacheArc(id, x, y, radius, thickness, angleStart, angleEnd, roughness)
 	if cachedArcs[id]
 		and cachedArcs[id].x == x

--- a/lua/ttt2/extensions/surface.lua
+++ b/lua/ttt2/extensions/surface.lua
@@ -22,7 +22,7 @@ end
 ---
 -- A function that takes a table with triangles and draws them to the screen.
 -- @note The draw color has to be set beforehand
--- @parame table tbl A table with triangles
+-- @param table tbl A table with triangles
 -- @realm client
 function surface.DrawPolyTable(tbl)
 	for i = 1, #tbl do

--- a/lua/ttt2/extensions/surface.lua
+++ b/lua/ttt2/extensions/surface.lua
@@ -18,3 +18,14 @@ end
 function surface.CreateAdvancedFont(fontName, fontData)
 	fonts.AddFont(fontName, fontData.size, fontData)
 end
+
+---
+-- A function that takes a table with triangles and draws them to the screen.
+-- @note The draw color has to be set beforehand
+-- @parame table tbl A table with triangles
+-- @realm client
+function surface.DrawPolyTable(tbl)
+	for i = 1, #tbl do
+		surface.DrawPoly(tbl[i])
+	end
+end


### PR DESCRIPTION
I added the circle draw code from TTTC to TTT2, cleaned it a bit up, added docs and support for shadowed arcs.

Circle draw Code in TTTC: https://github.com/TTT-2/TTTC/blob/15b34a8d75067550a46811af687ab4979ef34847/lua/terrortown/autorun/client/cl_classes_hud.lua#L132-L233