### PR TITLE
prevent dropping weapons that ordinarily are not droppable on death

### DIFF
--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_unarmed.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_unarmed.lua
@@ -41,6 +41,7 @@ SWEP.InLoadoutFor = {ROLE_INNOCENT, ROLE_TRAITOR, ROLE_DETECTIVE}
 
 SWEP.AllowDelete = false
 SWEP.AllowDrop = false
+SWEP.overrideDropOnDeath = DROP_ON_DEATH_TYPE_DENY
 SWEP.NoSights = true
 SWEP.InvisibleViewModel = true
 

--- a/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
@@ -56,6 +56,7 @@ SWEP.Kind = WEAPON_CARRY
 
 SWEP.AllowDelete = false
 SWEP.AllowDrop = false
+SWEP.overrideDropOnDeath = DROP_ON_DEATH_TYPE_DENY
 SWEP.NoSights = true
 
 SWEP.EntHolding = nil

--- a/gamemodes/terrortown/entities/weapons/weapon_zm_improvised.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_zm_improvised.lua
@@ -66,6 +66,7 @@ SWEP.AutoSpawnable = false
 
 SWEP.AllowDelete = false -- never removed for weapon reduction
 SWEP.AllowDrop = false
+SWEP.overrideDropOnDeath = DROP_ON_DEATH_TYPE_DENY
 
 local sound_single = Sound("Weapon_Crowbar.Single")
 


### PR DESCRIPTION
this is a stopgap until either:
1. AllowDrop controls all droppability such as idle drop, death drop, and most significantly, swappability (you cannot swap melee weapons unless you either have 2 melee slots or enable AlowDrop on the crowbar)
2. overrideDropOnDeath overrides all drop situations including idle drop , in addition to death drop
3. AllowDropOnDeath flag implemented preventing weapons from dropping on death but still being swappable/droppable
4. a more robust solution that involves some hierarchy of DROP/SWAP /REPLACE (allow picking up a melee slot item, but destroying the original crowbar)/DESTROY/ON_DEATH that i can't articulate

there is also the potential restriction that default-loadout items should be destroyed instead of dropped but that would potentially impact TTTC more than it would most roles