### PR TITLE
Database: Fix boolean conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ### Fixed
 
+- Fixed database now properly saving boolean `false` values
 - Fixed cached weapons not being selected after giving them back to the owner (by @TimGoll)
 - The roundendscreen can now be closed with the correct Binding (by @ZenBre4ker)
 - Fixed last seen player being wrongly visible for every search instead of only public policing role search (by @TimGoll)

--- a/lua/ttt2/libraries/database.lua
+++ b/lua/ttt2/libraries/database.lua
@@ -378,7 +378,7 @@ end
 -- @realm shared
 -- @internal
 local function ConvertValueWithKey(value, accessName, key)
-	if not value or value == "nil" or value == "NULL" then return end
+	if value == nil or value == "nil" or value == "NULL" then return end
 
 	local index = nameToIndex[accessName]
 


### PR DESCRIPTION
Apparently I forgot to properly check if all settings are saved to the database.
When saving false values, they got converted to nil, which got interpreted by the database as default value.