### PR TITLE
do not leak SendFullStateUpdate events happen

### DIFF
--- a/gamemodes/terrortown/gamemode/client/cl_main.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_main.lua
@@ -493,9 +493,6 @@ local function ReceiveRole()
 	if not isfunction(client.SetRole) then return end
 
 	client:SetRole(subrole, team)
-
-	Msg("You are: ")
-	MsgN(string.upper(roles.GetByIndex(subrole).name))
 end
 net.Receive("TTT_Role", ReceiveRole)
 


### PR DESCRIPTION
if someone has developer 1 on then they can see that an event which triggered a full state rebroadcast, aka, someone's role changed