### PR TITLE
Fix issues with marks library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed last seen player being wrongly visible for every search instead of only public policing role search (by @TimGoll)
 - Fixed the crosshair being offcenter on some UI scales (by @TimGoll)
 - Fixed to wrong line calculations for wrapped text (by @NickCloudAT)
+- Fixed marks library having self zfailing and color issues (by @WardenPotato)
 
 ### Removed
 

--- a/lua/ttt2/libraries/marks.lua
+++ b/lua/ttt2/libraries/marks.lua
@@ -9,8 +9,6 @@
 local render = render
 local table = table
 local IsValid = IsValid
-local cam = cam
-local surface = surface
 local hook = hook
 local pairs = pairs
 
@@ -25,14 +23,48 @@ marks = {}
 local marksList = {}
 local marksHookInstalled = false
 
+-- reuse the same memory for each render
+local oldR, oldG, oldB = 1, 1, 1
+local oldBlend = 1
+local markedEnt = NULL
+local markedColor = color_white
+
+---
+-- Renders marked models, this is a sub function for Render
+-- @param table ents list of @{Entity}
+-- @param Color col color of rendering
+-- @param number size size of ents table
+-- @realm client
+local function RenderMarkedModels(ents, col, size)
+	for i = 1, size do
+		markedEnt = ents[i]
+
+		-- prevent messing up materials
+		markedEnt:SetNoDraw(true)
+		-- get/set the color of our marked entity
+		markedColor = markedEnt:GetColor()
+		oldR, oldG, oldB = render.GetColorModulation()
+		render.SetColorModulation(markedColor.r / 255, markedColor.g / 255, markedColor.b / 255)
+		-- get/set the transparency of our marked entity
+		oldBlend = render.GetBlend()
+		render.SetBlend(markedColor.a / 255)
+
+		-- draw the entity
+		markedEnt:DrawModel()
+
+		-- reset the values back to what they were
+		markedEnt:SetNoDraw(false)
+		render.SetColorModulation(oldR, oldG, oldB)
+		render.SetBlend(oldBlend)
+	end
+end
+
 ---
 -- Renders the entity based on the color
 -- @param table ents list of @{Entity}
 -- @param Color col color of rendering
--- @param Vector pos position of client's view the rendering starts from
--- @param Angle ang angle of client's view the rendering starts from
 -- @realm client
-local function Render(ents, col, pos, ang, w, h)
+local function Render(ents, col)
 	-- check for valid data
 	local tmp = {}
 	local index = 1
@@ -73,38 +105,41 @@ local function Render(ents, col, pos, ang, w, h)
 	local size = #tmp
 	if size == 0 then return end
 
+	-- reset everything to known good values
+	render.SetStencilWriteMask(0xFF)
+	render.SetStencilTestMask(0xFF)
+	render.SetStencilReferenceValue(0)
+	render.SetStencilCompareFunction(STENCIL_ALWAYS)
+	render.SetStencilPassOperation(STENCIL_KEEP)
+	render.SetStencilFailOperation(STENCIL_KEEP)
+	render.SetStencilZFailOperation(STENCIL_KEEP)
 	render.ClearStencil()
+
+	-- enable stencils
 	render.SetStencilEnable(true)
-	render.SetStencilWriteMask(255)
-	render.SetStencilTestMask(255)
-	render.SetStencilReferenceValue(15)
-	render.SetStencilFailOperation(STENCILOPERATION_KEEP)
-	render.SetStencilZFailOperation(STENCILOPERATION_REPLACE)
-	render.SetStencilPassOperation(STENCILOPERATION_KEEP)
-	render.SetStencilCompareFunction(STENCILCOMPARISONFUNCTION_ALWAYS)
-	render.SetBlend(0)
+	-- set the reference value to 1. This is what the compare function tests against
+	render.SetStencilReferenceValue(1)
 
-	for i = 1, size do
-		tmp[i]:DrawModel()
-	end
+	-- always draw everything, since we need the ZFail to work we cannot use STENCIL_NEVER to avoid drawing to the RT
+	render.SetStencilCompareFunction(STENCIL_ALWAYS)
+	-- if something would draw to the screen but is behind something, set the pixels it draws to 1
+	render.SetStencilZFailOperation(STENCIL_REPLACE)
 
-	render.SetBlend(1)
-	render.SetStencilCompareFunction(STENCILCOMPARISONFUNCTION_EQUAL)
+	RenderMarkedModels(tmp, col, size)
 
-	-- stencil work is done in postdrawopaquerenderables, where surface doesn't work correctly
-	-- workaround via 3D2D by Bletotum
+	-- now we basically do the same thing again but this time we set stencil values to 0 if the operation passes
+	-- this fixes the entity zfailing with itself
+	render.SetStencilZFailOperation(STENCIL_KEEP)
+	render.SetStencilPassOperation(STENCILOPERATION_ZERO)
 
-	cam.Start3D2D(pos, ang, 1)
+	RenderMarkedModels(tmp, col, size)
 
-	surface.SetDrawColor(col.r, col.g, col.b, col.a)
-	surface.DrawRect(-w, -h, w * 2, h * 2)
+	-- now, only draw things that have their pixels set to 1. This is the hidden parts of the stencil tests
+	render.SetStencilCompareFunction(STENCIL_EQUAL)
+	-- flush the screen. This will draw our color onto the screen
+	render.ClearBuffersObeyStencil(col.r, col.g, col.b, col.a, false)
 
-	cam.End3D2D()
-
-	for i = 1, size do
-		tmp[i]:DrawModel()
-	end
-
+	-- let everything render normally again
 	render.SetStencilEnable(false)
 end
 
@@ -112,17 +147,8 @@ end
 -- Hook that renders the entities with the highlighting
 -- @realm client
 local function RenderHook()
-	local client = LocalPlayer()
-	local ang = client:EyeAngles()
-	local pos = client:EyePos() + ang:Forward() * 10
-
-	ang = Angle(ang.p + 90, ang.y, 0)
-
-	local w = ScrW()
-	local h = ScrH()
-
 	for _, list in pairs(marksList) do
-		Render(list.ents, list.col, pos, ang, w, h)
+		Render(list.ents, list.col)
 	end
 end
 

--- a/lua/ttt2/libraries/marks.lua
+++ b/lua/ttt2/libraries/marks.lua
@@ -30,14 +30,14 @@ local markedEnt = NULL
 local markedColor = color_white
 
 ---
--- Renders marked models, this is a sub function for Render
--- @param table ents list of @{Entity}
+-- Renders marked models, this is a sub function for Render.
+-- @param table markedEntsTable list of @{Entity}
 -- @param Color col color of rendering
--- @param number size size of ents table
+-- @param number size size of markedEntsTable table
 -- @realm client
-local function RenderMarkedModels(ents, col, size)
+local function RenderMarkedModels(markedEntsTable, col, size)
 	for i = 1, size do
-		markedEnt = ents[i]
+		markedEnt = markedEntsTable[i]
 
 		-- prevent messing up materials
 		markedEnt:SetNoDraw(true)
@@ -60,21 +60,21 @@ local function RenderMarkedModels(ents, col, size)
 end
 
 ---
--- Renders the entity based on the color
--- @param table ents list of @{Entity}
+-- Renders the entity based on the color.
+-- @param table markedEntsTable list of @{Entity}
 -- @param Color col color of rendering
 -- @realm client
-local function Render(ents, col)
+local function Render(markedEntsTable, col)
 	-- check for valid data
 	local tmp = {}
 	local index = 1
 	local remTable = {}
 	local remSize = 0
 
-	local entsSize = #ents
+	local entsTableSize = #markedEntsTable
 
-	for i = 1, entsSize do
-		local ent = ents[i]
+	for i = 1, entsTableSize do
+		local ent = markedEntsTable[i]
 
 		if not IsValid(ent) then -- search for invalid data
 			remSize = remSize + 1
@@ -90,11 +90,11 @@ local function Render(ents, col)
 		local tableRemove = table.remove
 
 		for i = 1, remSize do
-			for x = 1, entsSize do
-				if ents[x] == remTable[i] then
-					tableRemove(ents, x)
+			for x = 1, entsTableSize do
+				if markedEntsTable[x] == remTable[i] then
+					tableRemove(markedEntsTable, x)
 
-					entsSize = entsSize - 1
+					entsTableSize = entsTableSize - 1
 
 					break
 				end


### PR DESCRIPTION
This PR addresses the marks library having self zfailing and color issues.

This originated from helping @TimGoll on the [gmod discord](discord.gg/gmod) with this issue, more context can be found [there](https://discord.com/channels/565105920414318602/567617926991970306/1200805871303786506)

For completeness sake i will also mirror his original help request here:
```
It is me again, this time with a more in depth question about stencils and rendering. It is about this part in our TTT2 codebase: https://github.com/TTT-2/TTT2/blob/master/lua/ttt2/libraries/marks.lua#L76-L108

It is used to render "marks" (or wallhacks) of an entity through a wall (see picture 1)

But there is a problem. We color the entity with ent:SetColor on spawn to the player's role color. The entity itself is white. This works fine (see image 2) if no mark/wallhack is used.

But if I combine the wallhack with ent:SetColor() the color is removed in places where the entity intersects with itself or another entity that is colored.

Do note, that this issue only exists with entities that use ent:SetColor. If the material itself is already colored, then this works fine without issues.

So my question is, does anyone here know how to resolve this? I guess it shuld be possible somehow, but I'm unable to figure it out. Thanks in advance!
```

I will also attach the original three screenshots from the help request:
![broken1](https://github.com/TTT-2/TTT2/assets/35919125/efea2a03-1fe3-476b-94c8-6ea9dd8cd822)
![broken2](https://github.com/TTT-2/TTT2/assets/35919125/66eb011f-53aa-42ed-a548-44ff8a5fe700)
![broken3](https://github.com/TTT-2/TTT2/assets/35919125/bafe20d7-2d88-4815-8915-21e02921baf6)

And one from my fix:
the test props, 4 of each are from top to bottom:
Original
Colored red
debugwhite material + red color
the mosaic texture (this was important to test funky material stuff)
![20240128142708_1](https://github.com/TTT-2/TTT2/assets/35919125/e45c2f35-0af2-4d1d-8130-876cc0fa8f82)

Heres another screenshot highlighting self zfailing on the barrel (this was done on purpose to highlight the issue, my fix does not suffer from this), its subtle but you can see it on the ridges of the barrel:
![brokenbarrel](https://github.com/TTT-2/TTT2/assets/35919125/0a44ba72-d7a0-4ee5-98b1-1358c8bed085)


Excuse the complete lack of a TTT2 dev env in my screenshot as i normally have little to do with TTT (this was tested by just copying marks.lua into my existing dev env)

