### PR TITLE
Over Head Icon improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,10 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Moved reset buttons onto the left (by @a7f3)
 - Added ammo icons to the weapon switch HUD and player status HUD elements (by @EntranceJew)
 - Changed the disguiser icon to be more fitting (by @TimGoll)
+- Changed the way the role overhead icon is rendered (by @TimGoll)
+  - It now tracks the players head position
+  - Rendering order is based on distance, no more weird visual glitches
+  - Hidden when oberserving a player in their eyes
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -247,7 +247,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Changed the way the role overhead icon is rendered (by @TimGoll)
   - It now tracks the players head position
   - Rendering order is based on distance, no more weird visual glitches
-  - Hidden when oberserving a player in their eyes
+  - Hidden when observing a player in first person view
 
 ### Fixed
 

--- a/gamemodes/terrortown/gamemode/client/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_targetid.lua
@@ -180,7 +180,7 @@ function GM:PostDrawTranslucentRenderables(bDrawingDepth, bDrawingSkybox)
 		-- @realm client
 		local shouldDraw, material, color = hook.Run("TTT2ModifyOverheadIcon", ply, shouldDrawDefault)
 
-		if shouldDraw == false or not shouldDrawDefault or (shouldDraw and not material and not color) then
+		if shouldDraw == false or not shouldDrawDefault then
 			continue
 		end
 

--- a/gamemodes/terrortown/gamemode/client/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_targetid.lua
@@ -42,7 +42,7 @@ surface.CreateFont("TargetIDSmall2", { font = "TargetID", size = 16, weight = 10
 
 -- cache colors
 local colorKeyBack = Color(0, 0, 0, 150)
-local colorSpecLabel = Color(220, 200, 0, 120)
+local colorPropSpecLabel = Color(220, 200, 0, 120)
 
 -- cached materials for overhead icons and outlines
 local materialPropspecOutline = Material("models/props_combine/portalball001_sheet")
@@ -183,7 +183,7 @@ local function DrawPropSpecLabels(client)
 		local ply = plys[i]
 
 		if ply:IsSpec() then
-			color = colorSpecLabel
+			color = colorPropSpecLabel
 
 			tgt = ply:GetObserverTarget()
 

--- a/gamemodes/terrortown/gamemode/client/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_targetid.lua
@@ -80,9 +80,9 @@ function DrawOverheadRoleIcon(client, ply, iconRole, colorRole)
 end
 
 local function DistanceSorter(a, b)
-	local client = LocalPlayer()
+	local clientPos = LocalPlayer():GetPos()
 
-	return client:GetPos():Distance(a.ply:GetPos()) > client:GetPos():Distance(b.ply:GetPos())
+	return clientPos:Distance(a.ply:GetPos()) > clientPos:Distance(b.ply:GetPos())
 end
 
 ---

--- a/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
@@ -1177,7 +1177,7 @@ function plymeta:GetHeightVector()
 		matrix = self:GetBoneMatrix(bone)
 	end
 
-	if bone and matrix then
+	if matrix then
 		local pos = matrix:GetTranslation()
 
 		-- note: the 8 is the assumed height of the head after the head bone

--- a/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
@@ -1182,7 +1182,7 @@ function plymeta:GetHeightVector()
 
 		-- note: the 8 is the assumed height of the head after the head bone
 		-- this might not work for every model
-		pos.z = pos.z + 8 * self:GetModelScale()
+		pos.z = pos.z + 8 * self:GetModelScale() * self:GetManipulateBoneScale(bone).z
 
 		return pos - self:GetPos()
 

--- a/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
@@ -1157,6 +1157,46 @@ function plymeta:WasRevivedInRound()
 	return self:HasDiedInRound()
 end
 
+---
+-- Returns the player height vector based on the curren thead bone
+-- position. X and Y move along the head bone, Z contains the actual
+-- height.
+-- @note Uses the player's bounding box as a fallback if the head
+-- bone is not defined
+-- @note Respects the model scale for the height calculation
+-- @return vector The player height
+-- @realm shared
+function plymeta:GetHeightVector()
+	local matrix
+	local bone = self:LookupBone("ValveBiped.Bip01_Head1")
+
+	-- if the bone is defined, the bone matrix is defined as well;
+	-- however on hot reloads this can momentarily break before it
+	-- fixes itself again after a short time
+	if bone then
+		matrix = self:GetBoneMatrix(bone)
+	end
+
+	if bone and matrix then
+		local pos = matrix:GetTranslation()
+
+		-- note: the 8 is the assumed height of the head after the head bone
+		-- this might not work for every model
+		pos.z = pos.z + 8 * self:GetModelScale()
+
+		return pos - self:GetPos()
+
+	-- if the model has no head bone for some reason, use the player
+	-- position as a fallback
+	else
+		local obbmMaxs = self:OBBMaxs()
+		obbmMaxs.x = 0
+		obbmMaxs.y = 0
+
+		return obbmMaxs * self:GetModelScale()
+	end
+end
+
 -- to make it hotreload safe, we have to make sure it is not
 -- called recursively by only caching the original function
 if debug.getinfo(plymeta.SetFOV, "flLnSu").what == "C" then


### PR DESCRIPTION
This PR brings multiple small and minor improvements to the over head icons:

- they track the head bone positions: This means they move with the player animation, move down when crouched and also change position when the model scale is changed (i.e. when the minifier is used)
- it now uses a proper Cam3D2D environment: This fixed some minor issues with the icon drop shadow
- rendering order is based on distance: Previously the icons were drawn in the player order which could cause icons to be rendered in front of icons that they shouldn't be; it is now sorted by distance
- when observing a player in their eyes, their icon is now hidden, it is still shown when in third person
- changed the angle the icon is drawn: the rotation is still the same, but the pitch is locked on 90 meaning that the arrow is always pointing at the head, even when looking from the top

![image](https://github.com/TTT-2/TTT2/assets/13639408/457d4594-39a9-4748-a17b-7899d180358e)
Only a trained eye can spot a visual difference here