### PR TITLE
DrawArc: Added Stencil Reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -271,7 +271,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed nil value of SetValue in `DNumSliderTTT2` , `DCheckBoxLabelTTT2`. And fix nil value for boxCache[name] in `PlayerModels` (by @sbzlzh)
 - Prevent weapon_tttbase Lua errors with NPCs (by @BuzzHaddaBig in base TTT)
 - Fix miniscoreboard HUD from showing confirmed players that switched to spectator as having been revived (by @EntranceJew)
-- Fixed draw.Arc when `gmod_mcore_test` is set to 1 (by @QWardenPotato)
+- Fixed draw.Arc when `gmod_mcore_test` is set to 1 (by @WardenPotato)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -271,6 +271,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed nil value of SetValue in `DNumSliderTTT2` , `DCheckBoxLabelTTT2`. And fix nil value for boxCache[name] in `PlayerModels` (by @sbzlzh)
 - Prevent weapon_tttbase Lua errors with NPCs (by @BuzzHaddaBig in base TTT)
 - Fix miniscoreboard HUD from showing confirmed players that switched to spectator as having been revived (by @EntranceJew)
+- Fixed draw.Arc when `gmod_mcore_test` is set to 1 (by @QWardenPotato)
 
 ### Deprecated
 

--- a/gamemodes/terrortown/gamemode/shared/sh_init.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_init.lua
@@ -553,6 +553,7 @@ include("ttt2/extensions/surface.lua")
 include("ttt2/extensions/draw.lua")
 include("ttt2/extensions/input.lua")
 include("ttt2/extensions/cvars.lua")
+include("ttt2/extensions/render.lua")
 
 -- include libraries
 include("ttt2/libraries/fastutf8.lua")

--- a/lua/ttt2/extensions/render.lua
+++ b/lua/ttt2/extensions/render.lua
@@ -1,0 +1,26 @@
+---
+-- render extension
+-- @author WardenPotato
+-- @module render
+
+if SERVER then
+	AddCSLuaFile()
+
+	return
+end
+
+---
+-- Completely resets stencils.
+-- This is useful for things near @{surface.DrawPoly} when `gmod_mcore_test` is 1,
+-- because stencils seem to act unstable across different architectures.
+-- @realm client
+function render.FullReset()
+	render.SetStencilWriteMask(0xFF)
+	render.SetStencilTestMask(0xFF)
+	render.SetStencilReferenceValue(0)
+	render.SetStencilCompareFunction(STENCIL_ALWAYS)
+	render.SetStencilPassOperation(STENCIL_KEEP)
+	render.SetStencilFailOperation(STENCIL_KEEP)
+	render.SetStencilZFailOperation(STENCIL_KEEP)
+	render.ClearStencil()
+end

--- a/lua/ttt2/extensions/surface.lua
+++ b/lua/ttt2/extensions/surface.lua
@@ -26,6 +26,8 @@ end
 -- @realm client
 function surface.DrawPolyTable(tbl)
 	for i = 1, #tbl do
+		render.FullReset()
+
 		surface.DrawPoly(tbl[i])
 	end
 end


### PR DESCRIPTION
Thanks to @WardenPotato we now know that [we have to reset the stencils](https://github.com/TTT-2/TTT2/pull/1267#issuecomment-1913711414) between each poly draw.