### PR TITLE
ci(lang-parser): Use app token instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/lang-parser.yml
+++ b/.github/workflows/lang-parser.yml
@@ -12,6 +12,9 @@ on:
 
 jobs:
   update-language-files:
+    # guard against running on forks as they are probably not setup for this
+    if: github.repository_owner == 'TTT-2'
+
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/lang-parser.yml
+++ b/.github/workflows/lang-parser.yml
@@ -29,10 +29,18 @@ jobs:
       - name: run language parser
         run: python ttt2-language_parser/parse.py --in "$GITHUB_WORKSPACE/ttt2/lua/terrortown/lang" --out "$GITHUB_WORKSPACE/ttt2/lua/terrortown/lang" --base en --ignore chef
 
+      - name: generate app token
+        uses: actions/create-github-app-token@v1
+        id: generate-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Create Pull Request
         id: ci-update-language-files
         uses: peter-evans/create-pull-request@v6
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           path: ttt2
           add-paths: "lua/terrortown/lang/*.lua"
           commit-message: Update language files


### PR DESCRIPTION
This is needed as creating a pr/pushing a commit using the GITHUB_TOKEN will not trigger other workflow runs. Which is done to prevent circular workflow runs.

Using a token generated from a github app does not have this limitation.