### PR TITLE
TargetID: Disable seeing own spectator nametag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
   - It now tracks the players head position
   - Rendering order is based on distance, no more weird visual glitches
   - Hidden when observing a player in first person view
+- Your own spectator nametag will not display when looking directly up in post-round (by @EntranceJew)
 
 ### Fixed
 

--- a/gamemodes/terrortown/gamemode/client/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_targetid.lua
@@ -231,11 +231,7 @@ local function DrawPropSpecLabels(client)
             end
         else
             local clientTarget = client:GetObserverTarget()
-            local clientObsMode = client:GetObserverMode()
-            if ply == client or (
-                clientTarget == ply
-                and IsPlayer(clientTarget)
-            ) then
+            if ply == client or (clientTarget == ply and IsPlayer(clientTarget)) then
                 continue
             end
             _, color = util.HealthToString(ply:Health(), ply:GetMaxHealth())

--- a/gamemodes/terrortown/gamemode/client/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_targetid.lua
@@ -230,6 +230,15 @@ local function DrawPropSpecLabels(client)
                 scrpos = nil
             end
         else
+            local clientTarget = client:GetObserverTarget()
+            local clientObsMode = client:GetObserverMode()
+            if ply == client or (
+                clientTarget == ply
+                and IsPlayer(clientTarget)
+                and clientObsMode == OBS_MODE_IN_EYE
+            ) then
+                continue
+            end
             _, color = util.HealthToString(ply:Health(), ply:GetMaxHealth())
 
             scrpos = ply:EyePos()

--- a/gamemodes/terrortown/gamemode/client/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_targetid.lua
@@ -235,7 +235,6 @@ local function DrawPropSpecLabels(client)
             if ply == client or (
                 clientTarget == ply
                 and IsPlayer(clientTarget)
-                and clientObsMode == OBS_MODE_IN_EYE
             ) then
                 continue
             end


### PR DESCRIPTION
![image](https://github.com/TTT-2/TTT2/assets/5711436/e1fdd9ba-09ab-4dca-9c36-b6300f31e5e2)
vs
![image](https://github.com/TTT-2/TTT2/assets/5711436/ebbb2d3f-557b-4e07-b16c-fdfb0f27cd48)

does not affect propspec nametag because that helps find the prop's origin