### PR TITLE
Grenades: Removed BaseClass init

### DIFF
--- a/gamemodes/terrortown/entities/entities/ttt_basegrenade_proj.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_basegrenade_proj.lua
@@ -25,8 +25,6 @@ end
 function ENT:Initialize()
 	self:SetModel(self.Model)
 
-	self.BaseClass.Initialize(self)
-
 	self:PhysicsInit(SOLID_VPHYSICS)
 	self:SetMoveType(MOVETYPE_VPHYSICS)
 	self:SetSolid(SOLID_BBOX)


### PR DESCRIPTION
This base class call doesn't do anything here and also causes an error.