### PR TITLE
Entity Base: Added Pickup Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
   - Added `AddCustomWorldModel` to add custom world models
   - Added an automatic fix for badly coded addons that break the view model fingers
 - Added `ttt_base_placeable` entity that is used to handle any placeable / destroyable entity (by @TimGoll)
-  - moved `ttt_c4`, `ttt_health_station`, `ttt_beacon`, `ttt_decoy`, `ttt0_radio` and `ttt_cse_proj` to that base
+  - moved `ttt_c4`, `ttt_health_station`, `ttt_beacon`, `ttt_decoy`, `ttt_radio` and `ttt_cse_proj` to that base
   - also handles pickup of those entities
 - Throwables (grenades) now have a `:GetPullTime()` accessor
 - Throwables (grenades) show UI for the amount of time remaining before detonation (fuse time) (by @EntranceJew)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
   - Added an automatic fix for badly coded addons that break the view model fingers
 - Added `ttt_base_placeable` entity that is used to handle any placeable / destroyable entity (by @TimGoll)
   - moved `ttt_c4`, `ttt_health_station`, `ttt_beacon`, `ttt_decoy`, `ttt0_radio` and `ttt_cse_proj` to that base
+  - also handles pickup of those entities
 - Throwables (grenades) now have a `:GetPullTime()` accessor
 - Throwables (grenades) show UI for the amount of time remaining before detonation (fuse time) (by @EntranceJew)
 - UI for grenade throw arcs from [colemclaren's TTT fork](https://github.com/colemclaren/ttt/blob/master/addons/moat_addons/lua/weapons/weapon_tttbasegrenade.lua#L293-L353) (integrated by @EntranceJew)

--- a/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
@@ -246,6 +246,8 @@ if SERVER then
 
         if IsValid(wep) and wep:Clip1() < wep.Primary.ClipSize then
             wep:SetClip1(wep:Clip1() + 1)
+
+            activator:SelectWeapon(self.pickupWeaponClass)
         else
             -- picks up weapon and drops blocking weapon if slot is already in use
             wep = activator:SafePickupWeaponClass(self.pickupWeaponClass, true)

--- a/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
@@ -280,7 +280,7 @@ if SERVER then
     ---
     -- Run if a valid player tries to pick up this entity to check if this pickup is accepted.
     -- @param Player activator The player that used their use key
-    -- @return boolean Return true to allow pickup
+    -- @return[default=true] boolean Return true to allow pickup
     -- @hook
     -- @realm server
     function ENT:PlayerCanPickupWeapon(activator)

--- a/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
@@ -236,7 +236,7 @@ if SERVER then
     -- @hook
     -- @realm server
     function ENT:UseOverride(activator)
-        if not IsValid(activator) or not self.pickupWeaponClass then
+        if not IsValid(activator) or not activator:IsTerror() or not self.pickupWeaponClass then
             return
         end
 

--- a/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
@@ -69,6 +69,8 @@ if SERVER then
 
     local soundDeny = Sound("HL2Player.UseDeny")
 
+    local soundWeaponPickup = Sound("items/ammo_pickup.wav")
+
     AccessorFunc(ENT, "hitNormal", "HitNormal", FORCE_VECTOR)
     AccessorFunc(ENT, "stickRotation", "StickRotation", FORCE_ANGLE)
 
@@ -252,6 +254,8 @@ if SERVER then
 
         if IsValid(wep) and wep:Clip1() < wep.Primary.ClipSize then
             wep:SetClip1(wep:Clip1() + 1)
+
+            activator:EmitSound(soundWeaponPickup)
 
             activator:SelectWeapon(self.pickupWeaponClass)
         else

--- a/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
@@ -241,6 +241,8 @@ if SERVER then
         end
 
         if not self:PlayerCanPickupWeapon(activator) then
+            LANG.Msg(activator, "pickup_fail", nil, MSG_MSTACK_WARN)
+
             self:EmitSound(soundDeny)
 
             return
@@ -258,6 +260,8 @@ if SERVER then
 
             -- if pickup has failed, the in-world entity should not be removed
             if not IsValid(wep) then
+                LANG.Msg(activator, "pickup_no_room", nil, MSG_MSTACK_WARN)
+
                 self:EmitSound(soundDeny)
 
                 return

--- a/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
@@ -67,6 +67,8 @@ if SERVER then
 
     local soundThrow = Sound("Weapon_SLAM.SatchelThrow")
 
+    local soundDeny = Sound("HL2Player.UseDeny")
+
     AccessorFunc(ENT, "hitNormal", "HitNormal", FORCE_VECTOR)
     AccessorFunc(ENT, "stickRotation", "StickRotation", FORCE_ANGLE)
 
@@ -234,11 +236,13 @@ if SERVER then
     -- @hook
     -- @realm server
     function ENT:UseOverride(activator)
-        if
-            not IsValid(activator)
-            or not self.pickupWeaponClass
-            or not self:PlayerCanPickupWeapon(activator)
-        then
+        if not IsValid(activator) or not self.pickupWeaponClass then
+            return
+        end
+
+        if not self:PlayerCanPickupWeapon(activator) then
+            self:EmitSound(soundDeny)
+
             return
         end
 
@@ -254,6 +258,8 @@ if SERVER then
 
             -- if pickup has failed, the in-world entity should not be removed
             if not IsValid(wep) then
+                self:EmitSound(soundDeny)
+
                 return
             end
         end

--- a/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
@@ -272,6 +272,8 @@ if SERVER then
             sound.Play(soundWeld, self:GetPos(), 75)
         end
 
+        self:OnPickup(activator, wep)
+
         self:Remove()
     end
 
@@ -284,6 +286,14 @@ if SERVER then
     function ENT:PlayerCanPickupWeapon(activator)
         return true
     end
+
+    ---
+    -- Called when this entity is picked up and about to be removed.
+    -- @param Player activator The player that used their use key
+    -- @param Weapon wep The weapon that is added to their inventory
+    -- @hook
+    -- @realm server
+    function ENT:OnPickup(activator, wep) end
 
     ---
     -- Helper function for a weapon that wants to throw the entity. Already handles everything.

--- a/gamemodes/terrortown/entities/entities/ttt_beacon.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_beacon.lua
@@ -128,6 +128,7 @@ if SERVER then
     end
 
     ---
+    -- @param Player activator
     -- @realm server
     function ENT:PlayerCanPickupWeapon(activator)
         return self:GetOriginator() == activator

--- a/gamemodes/terrortown/entities/entities/ttt_beacon.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_beacon.lua
@@ -18,7 +18,9 @@ ENT.Base = "ttt_base_placeable"
 ENT.Model = "models/props_lab/reciever01a.mdl"
 
 ENT.CanHavePrints = true
+
 ENT.CanUseKey = true
+ENT.pickupWeaponClass = "weapon_ttt_beacon"
 
 ENT.timeLastBeep = CurTime()
 ENT.lastPlysFound = {}
@@ -46,29 +48,6 @@ function ENT:Initialize()
         mvObject:SetVisibleFor(VISIBLE_FOR_ROLE)
         mvObject:SyncToClients()
     end
-end
-
----
--- @param Entity activator
--- @realm shared
-function ENT:UseOverride(activator)
-    if not IsValid(activator) or self:GetOriginator() ~= activator then
-        return
-    end
-
-    local wep = activator:GetWeapon("weapon_ttt_beacon")
-
-    if IsValid(wep) then
-        local pickup = wep:PickupBeacon()
-
-        if not pickup then
-            return
-        end
-    else
-        wep = activator:SafePickupWeaponClass("weapon_ttt_beacon", true)
-    end
-
-    self:Remove()
 end
 
 if SERVER then
@@ -146,6 +125,12 @@ if SERVER then
         end
 
         self:RemoveMarkerVision("beacon_owner")
+    end
+
+    ---
+    -- @realm server
+    function ENT:PlayerCanPickupWeapon(activator)
+        return self:GetOriginator() == activator
     end
 
     ---

--- a/gamemodes/terrortown/entities/entities/ttt_cse_proj.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_cse_proj.lua
@@ -193,7 +193,6 @@ if SERVER then
         local roleDataActivator = activator:GetSubRoleData()
 
         return activator:IsTerror()
-            and activator:CanCarryType(WEAPON_EQUIP)
             and roleDataActivator.isPolicingRole
             and roleDataActivator.isPublicRole
     end

--- a/gamemodes/terrortown/entities/entities/ttt_cse_proj.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_cse_proj.lua
@@ -19,6 +19,7 @@ ENT.SceneDuration = 10
 ENT.PulseDelay = 10
 
 ENT.CanUseKey = true
+ENT.pickupWeaponClass = "weapon_ttt_cse"
 
 ---
 -- @realm shared
@@ -137,31 +138,6 @@ function ENT:StopScanSound(force)
 end
 
 ---
--- @param Entity activator
--- @realm shared
-function ENT:UseOverride(activator)
-    if not IsValid(activator) or not activator:IsPlayer() then
-        return
-    end
-
-    local roleDataActivator = activator:GetSubRoleData()
-
-    if
-        activator:IsTerror()
-        and activator:CanCarryType(WEAPON_EQUIP)
-        and roleDataActivator.isPolicingRole
-        and roleDataActivator.isPublicRole
-    then
-        self:StopScanSound(true)
-        self:Remove()
-
-        activator:SafePickupWeaponClass("weapon_ttt_cse", true)
-    else
-        self:EmitSound("HL2Player.UseDeny")
-    end
-end
-
----
 -- @realm shared
 function ENT:OnRemove()
     self:StopScanSound(true)
@@ -209,6 +185,17 @@ if SERVER then
         self:NextThink(CurTime() + self.PulseDelay)
 
         return true
+    end
+
+    ---
+    -- @realm server
+    function ENT:PlayerCanPickupWeapon(activator)
+        local roleDataActivator = activator:GetSubRoleData()
+
+        return activator:IsTerror()
+            and activator:CanCarryType(WEAPON_EQUIP)
+            and roleDataActivator.isPolicingRole
+            and roleDataActivator.isPublicRole
     end
 end
 

--- a/gamemodes/terrortown/entities/entities/ttt_cse_proj.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_cse_proj.lua
@@ -192,9 +192,7 @@ if SERVER then
     function ENT:PlayerCanPickupWeapon(activator)
         local roleDataActivator = activator:GetSubRoleData()
 
-        return activator:IsTerror()
-            and roleDataActivator.isPolicingRole
-            and roleDataActivator.isPublicRole
+        return roleDataActivator.isPolicingRole and roleDataActivator.isPublicRole
     end
 end
 

--- a/gamemodes/terrortown/entities/entities/ttt_cse_proj.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_cse_proj.lua
@@ -188,6 +188,7 @@ if SERVER then
     end
 
     ---
+    -- @param Player activator
     -- @realm server
     function ENT:PlayerCanPickupWeapon(activator)
         local roleDataActivator = activator:GetSubRoleData()

--- a/gamemodes/terrortown/entities/entities/ttt_decoy.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_decoy.lua
@@ -15,7 +15,9 @@ ENT.Base = "ttt_base_placeable"
 ENT.Model = "models/props_lab/reciever01b.mdl"
 
 ENT.CanHavePrints = false
+
 ENT.CanUseKey = true
+ENT.pickupWeaponClass = "weapon_ttt_decoy"
 
 ---
 -- @realm shared
@@ -34,30 +36,6 @@ function ENT:Initialize()
     if SERVER then
         self:SetUseType(SIMPLE_USE)
     end
-end
-
----
--- @param Player activator
--- @realm shared
-function ENT:UseOverride(activator)
-    if
-        not IsValid(activator)
-        or not activator:HasTeam()
-        or self:GetNWString("decoy_owner_team", "none") ~= activator:GetTeam()
-    then
-        return
-    end
-
-    -- picks up weapon, switches if possible and needed, returns weapon if successful
-    local wep = activator:SafePickupWeaponClass("weapon_ttt_decoy", true)
-
-    if not IsValid(wep) then
-        LANG.Msg(activator, "decoy_no_room")
-
-        return
-    end
-
-    self:Remove()
 end
 
 -- @realm shared
@@ -80,6 +58,13 @@ if SERVER then
         end
 
         LANG.Msg(originator, "decoy_broken", nil, MSG_MSTACK_WARN)
+    end
+
+    ---
+    -- @realm server
+    function ENT:PlayerCanPickupWeapon(activator)
+        return activator:HasTeam()
+            and self:GetNWString("decoy_owner_team", "none") == activator:GetTeam()
     end
 end
 

--- a/gamemodes/terrortown/entities/entities/ttt_decoy.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_decoy.lua
@@ -61,6 +61,7 @@ if SERVER then
     end
 
     ---
+    -- @param Player activator
     -- @realm server
     function ENT:PlayerCanPickupWeapon(activator)
         return activator:HasTeam()

--- a/gamemodes/terrortown/entities/entities/ttt_radio.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_radio.lua
@@ -19,8 +19,11 @@ ENT.Base = "ttt_base_placeable"
 
 ENT.Model = "models/props/cs_office/radio.mdl"
 
-ENT.CanUseKey = true
 ENT.CanHavePrints = false
+
+ENT.CanUseKey = true
+ENT.pickupWeaponClass = "weapon_ttt_radio"
+
 ENT.SoundLimit = 5
 ENT.SoundDelay = 0.5
 
@@ -60,30 +63,6 @@ function ENT:Initialize()
     self.fingerprints = {}
 end
 
----
--- @param Player activator
--- @realm shared
-function ENT:UseOverride(activator)
-    if IsValid(activator) and activator:IsPlayer() and activator == self:GetOriginator() then
-        local prints = self.fingerprints or {}
-
-        -- picks up weapon, switches if possible and needed, returns weapon if successful
-        local wep = activator:SafePickupWeaponClass("weapon_ttt_radio", true)
-
-        if not IsValid(wep) then
-            return
-        end
-
-        self:Remove()
-
-        wep.fingerprints = wep.fingerprints or {}
-
-        table.Add(wep.fingerprints, prints)
-    else
-        LANG.Msg(activator, "entity_pickup_owner_only")
-    end
-end
-
 if SERVER then
     ---
     -- @realm server
@@ -95,6 +74,22 @@ if SERVER then
         end
 
         LANG.Msg(originator, "radio_broken", nil, MSG_MSTACK_WARN)
+    end
+
+    ---
+    -- @realm server
+    function ENT:PlayerCanPickupWeapon(activator)
+        return activator == self:GetOriginator()
+    end
+
+    ---
+    -- @realm server
+    function ENT:OnPickup(activator, wep)
+        local prints = self.fingerprints or {}
+
+        wep.fingerprints = wep.fingerprints or {}
+
+        table.Add(wep.fingerprints, prints)
     end
 end
 

--- a/gamemodes/terrortown/entities/entities/ttt_radio.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_radio.lua
@@ -77,12 +77,15 @@ if SERVER then
     end
 
     ---
+    -- @param Player activator
     -- @realm server
     function ENT:PlayerCanPickupWeapon(activator)
         return activator == self:GetOriginator()
     end
 
     ---
+    -- @param Player activator
+    -- @param Weapon wep
     -- @realm server
     function ENT:OnPickup(activator, wep)
         local prints = self.fingerprints or {}

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_beacon.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_beacon.lua
@@ -98,18 +98,6 @@ function SWEP:PlacedBeacon()
 end
 
 ---
--- @realm shared
-function SWEP:PickupBeacon()
-    if self:Clip1() >= self.Primary.ClipSize then
-        return false
-    else
-        self:SetClip1(self:Clip1() + 1)
-
-        return true
-    end
-end
-
----
 -- @param Player buyer
 -- @realm shared
 function SWEP:WasBought(buyer)

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_decoy.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_decoy.lua
@@ -121,7 +121,7 @@ if CLIENT then
     ---
     -- @ignore
     function SWEP:Initialize()
-        self:AddTTT2HUDHelp("decoy_help_pri")
+        self:AddTTT2HUDHelp("decoy_help_primary", "decoy_help_secondary")
 
         self.BaseClass.Initialize(self)
     end

--- a/lua/terrortown/lang/en.lua
+++ b/lua/terrortown/lang/en.lua
@@ -262,7 +262,6 @@ Analyzes a corpse to show how the victim was killed, but only if they died of gu
 
 -- Decoy
 L.decoy_name = "Decoy"
-L.decoy_no_room = "You cannot carry this decoy."
 L.decoy_broken = "Your Decoy has been destroyed!"
 
 L.decoy_short_desc = "This decoy shows a fake radar sign visible for other teams"


### PR DESCRIPTION
I added pickup handling to the recently added entity base.

To add this to an entity, the following two parameters have to be set:
```lua
ENT.CanUseKey = true -- to enable the ENT:UseOverwrite hook
ENT.pickupWeaponClass = "weapon_ttt_radio" -- to define which weapon should be added to the inventory
```

There are two hooks that are called during the pickup process:
```lua
---
-- Run if a valid player tries to pick up this entity to check if this pickup is accepted.
-- @param Player activator The player that used their use key
-- @return[default=true] boolean Return true to allow pickup
-- @hook
-- @realm server
function ENT:PlayerCanPickupWeapon(activator)
```

```lua
---
-- Called when this entity is picked up and about to be removed.
-- @param Player activator The player that used their use key
-- @param Weapon wep The weapon that is added to their inventory
-- @hook
-- @realm server
function ENT:OnPickup(activator, wep)
```

It can handle the following scenarios:
- weapons that are "stackable" like the beacon (it adds to the weapon's clip)
- weapons that are not stackable
- weapons that are not dropable and therefore might prevent the pickup of the placed entity

Also it adds sounds and notifications that improve the player feedback, while also making sure that all entities behave the same