### PR TITLE
Fix: Radar decoy fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed draw.Arc when `gmod_mcore_test` is set to 1 (by @WardenPotato)
 - Fixed weapon help box width for wide bindings with short descriptions (by @TimGoll)
 - Fixed `GM:TTTBodySearchPopulate` using the wrong data variable (by @TimGoll)
+- Fixed the decoy producing a wrong colored icon for other teams (by @NickCloudAT)
 
 ### Removed
 

--- a/lua/terrortown/entities/items/item_ttt_radar/init.lua
+++ b/lua/terrortown/entities/items/item_ttt_radar/init.lua
@@ -152,6 +152,7 @@ local function GetDataForRadar(ply, ent)
         -- Decoys appear as innocents for players from other teams
         if ent:GetNWString("decoy_owner_team", "none") ~= ply:GetTeam() then
             subrole = ROLE_INNOCENT
+            team = TEAM_INNOCENT
         end
     else
         ---


### PR DESCRIPTION
This fixes and issue with the radar showing a grey radar symbol instead of the green one for other teams.

I'm not sure, but was this just an oversight or am I just not seeing something else that may cause this issue?
Setting the team to TEAM_INNOCENT too fixes the issue.