### PR TITLE
Playersettings: Fixed unwanted shared rederence

### DIFF
--- a/gamemodes/terrortown/gamemode/client/cl_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_player_ext.lua
@@ -370,6 +370,8 @@ end
 -- @param any value The setting's value, it is parsed as a string before transmitting
 -- @realm client
 function plymeta:SetSettingOnServer(identifier, value)
+    self.playerSettings = self.playerSettings or {}
+
     if self.playerSettings[identifier] == value then
         return
     end

--- a/gamemodes/terrortown/gamemode/server/sv_player.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player.lua
@@ -1493,6 +1493,8 @@ net.Receive("ttt2_set_player_setting", function(_, ply)
         return
     end
 
+    ply.playerSettings = ply.playerSettings or {}
+
     local identifier = net.ReadString()
     local data = net.ReadString()
 

--- a/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
@@ -22,9 +22,6 @@ if not plymeta then
     return
 end
 
--- player meta table is hotreload safe, so we want to keep this table as well
-plymeta.playerSettings = plymeta.playerSettings or {}
-
 ---
 -- @internal
 -- @realm shared
@@ -1307,7 +1304,7 @@ end
 -- @return any The value of the setting, nil if not set
 -- @realm shared
 function plymeta:GetPlayerSetting(identifier)
-    return self.playerSettings[identifier]
+    return self.playerSettings and self.playerSettings[identifier]
 end
 
 ---


### PR DESCRIPTION
This PR fixes an issue with the synced player settings. Initializing the synced player settings as `plymeta.playerSettings = plymeta.playerSettings or {}` results in one table reference being created that is shared between all instances of the `Player` class. This pullrequest changes this so that each player has their own instance of said class.