### PR TITLE
Doors: Added rounding to door health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed weapon help box width for wide bindings with short descriptions (by @TimGoll)
 - Fixed `GM:TTTBodySearchPopulate` using the wrong data variable (by @TimGoll)
 - Fixed the decoy producing a wrong colored icon for other teams (by @NickCloudAT)
+- Fixed door health displaying as a humongous string of decimals
 
 ### Removed
 

--- a/lua/ttt2/libraries/targetid.lua
+++ b/lua/ttt2/libraries/targetid.lua
@@ -645,7 +645,7 @@ function targetid.HUDDrawTargetIDDoors(tData)
 
     if ent:DoorIsDestructible() then
         tData:AddDescriptionLine(
-            ParT("door_destructible", { health = ent:GetFastSyncedHealth() }),
+            ParT("door_destructible", { health = math.ceil(ent:GetFastSyncedHealth()) }),
             COLOR_LBROWN,
             { materialDestructible }
         )


### PR DESCRIPTION
Door health is a float internally, but it should not be displayed that way to the clients. `math.ceil` was chosen to prevent the door showing "0 HP" and still existing.