### PR TITLE
EntityBase: Changed Owner to Originator

### DIFF
--- a/gamemodes/terrortown/entities/entities/ttt_beacon.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_beacon.lua
@@ -121,7 +121,7 @@ if SERVER then
             if plysFound[ply] and not self.lastPlysFound[ply] then
                 -- newly added player in range
                 local mvObject = ply:AddMarkerVision("beacon_player")
-                mvObject:SetOwner(self:GetOwner())
+                mvObject:SetOwner(self:GetOriginator())
                 mvObject:SetVisibleFor(VISIBLE_FOR_ALL)
                 mvObject:SetColor(roles.DETECTIVE.color)
                 mvObject:SyncToClients()

--- a/gamemodes/terrortown/entities/entities/ttt_c4/cl_init.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_c4/cl_init.lua
@@ -433,7 +433,7 @@ function ShowC4Disarm(bomb)
     ddesc:SetWrap(true)
     if LocalPlayer():IsTraitor() then
         ddesc:SetText(T("c4_disarm_t"))
-    elseif LocalPlayer() == bomb:GetOwner() then
+    elseif LocalPlayer() == bomb:GetOriginator() then
         ddesc:SetText(T("c4_disarm_owned"))
     else
         ddesc:SetText(T("c4_disarm_other"))

--- a/gamemodes/terrortown/entities/entities/ttt_radio.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_radio.lua
@@ -41,7 +41,7 @@ function ENT:Initialize()
         self:SetUseType(SIMPLE_USE)
 
         local mvObject = self:AddMarkerVision("radio_owner")
-        mvObject:SetOwner(self:GetOwner())
+        mvObject:SetOwner(self:GetOriginator())
         mvObject:SetVisibleFor(VISIBLE_FOR_TEAM)
         mvObject:SyncToClients()
     end


### PR DESCRIPTION
Due to an auto merge issue, the originator got wrongly reset to the owner. This PR fixes this. This also fixes marker vision not working and the radio not making any sounds.