### PR TITLE
EquipmentMenu: Added check before function call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ### Fixed
 
-- Fixed database now properly saving boolean `false` values
+- Fixed database now properly saving boolean `false` values (by @ZenBre4ker)
 - Fixed cached weapons not being selected after giving them back to the owner (by @TimGoll)
 - The roundendscreen can now be closed with the correct Binding (by @ZenBre4ker)
 - Fixed last seen player being wrongly visible for every search instead of only public policing role search (by @TimGoll)
@@ -103,7 +103,8 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed font initialization to not trip engine font fallback behavior (by @EntranceJew)
 - Fixed the decoy producing a wrong colored icon for other teams (by @NickCloudAT)
 - Fixed the scoreboard being stuck open sometimes if the inflictor was no weapon (by @TimGoll)
-- Fixed door health displaying as a humongous string of decimals
+- Fixed door health displaying as a humongous string of decimals (by @EntranceJew)
+- Fixed weapons that use the wrong weapon base from throwing errors in the F1 menu (by @TimGoll)
 
 ### Removed
 

--- a/lua/terrortown/menus/gamemode/equipment/base_equipment.lua
+++ b/lua/terrortown/menus/gamemode/equipment/base_equipment.lua
@@ -186,7 +186,9 @@ function CLGAMEMODESUBMENU:Populate(parent)
     end
 
     -- now add custom equipment settings
-    equipment:AddToSettingsMenu(parent)
+    if isfunction(equipment.AddToSettingsMenu) then
+        equipment:AddToSettingsMenu(parent)
+    end
 
     -- stylua: ignore
     hook.Run("TTT2OnEquipmentAddToSettingsMenu", equipment, parent)

--- a/lua/terrortown/menus/gamemode/equipment/base_equipment.lua
+++ b/lua/terrortown/menus/gamemode/equipment/base_equipment.lua
@@ -193,7 +193,7 @@ function CLGAMEMODESUBMENU:Populate(parent)
             1,
             "Weapon '"
                 .. equipment:GetClass()
-                .. "' does't use the weapon_tttbase and can therefore not populate the settings panel."
+                .. "' doesn't use the weapon_tttbase and cannot be added to the settings panel."
         )
     end
 

--- a/lua/terrortown/menus/gamemode/equipment/base_equipment.lua
+++ b/lua/terrortown/menus/gamemode/equipment/base_equipment.lua
@@ -188,6 +188,13 @@ function CLGAMEMODESUBMENU:Populate(parent)
     -- now add custom equipment settings
     if isfunction(equipment.AddToSettingsMenu) then
         equipment:AddToSettingsMenu(parent)
+    else
+        Dev(
+            1,
+            "Weapon '"
+                .. equipment:GetClass()
+                .. "' does't use the weapon_tttbase and can therefore not populate the settings panel."
+        )
     end
 
     -- stylua: ignore


### PR DESCRIPTION
Last night I discussed some things with @mexikoedi. One thing we noticed that there are quite a few badly done weapons for TTT that forget to set the weapon base correctly. While this is bad practice and shouldn't be done, most of these weapons still work just fine. Adding this check here makes sure that this populate function is only called if it actually uses the correct base.