### PR TITLE
Entity Base: Added throw space check

### DIFF
--- a/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
@@ -306,12 +306,19 @@ if SERVER then
     -- @return boolean Returns true on success
     -- @realm server
     function ENT:ThrowEntity(ply, rotationalOffset)
+        local posThrow = ply:GetShootPos() - Vector(0, 0, 15)
+        local vecAim = ply:GetAimVector()
+
+        if not ply:HasDropSpace(nil, posThrow, vecAim) then
+            LANG.Msg(ply, "throw_no_room", nil, MSG_MSTACK_WARN)
+
+            return false
+        end
+
         ply:SetAnimation(PLAYER_ATTACK1)
 
         rotationalOffset = rotationalOffset or Angle(0, 0, 0)
 
-        local posThrow = ply:GetShootPos() - Vector(0, 0, 15)
-        local vecAim = ply:GetAimVector()
         local velocity = ply:GetVelocity()
         local velocityThrow = velocity + vecAim * 250
 

--- a/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
@@ -309,7 +309,7 @@ if SERVER then
         local posThrow = ply:GetShootPos() - Vector(0, 0, 15)
         local vecAim = ply:GetAimVector()
 
-        if not ply:HasDropSpace(nil, posThrow, vecAim) then
+        if not ply:HasDropSpace(posThrow, vecAim) then
             LANG.Msg(ply, "throw_no_room", nil, MSG_MSTACK_WARN)
 
             return false

--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -1318,13 +1318,13 @@ end
 
 ---
 -- Checks if the player has space in front of them to drop a weapon.
--- @param[opt] Weapon wep The weapon that should be dropped; add it as a parameter
--- to have it on the trace ignore list
 -- @param Vector pos The position from where the drop should start
 -- @param Vector aim The aim vector or the general drop vector
+-- @param[opt] Weapon wep The weapon that should be dropped; add it as a parameter
+-- to have it on the trace ignore list
 -- @return boolean Returns if there is space for a weapon to be dropped
 -- @realm server
-function plymeta:HasDropSpace(wep, pos, aim)
+function plymeta:HasDropSpace(pos, aim, wep)
     local tr = util.QuickTrace(pos, aim * 18, { self, wep })
 
     return not tr.Hit
@@ -1344,7 +1344,7 @@ function plymeta:CanSafeDropWeapon(wep)
         return false
     end
 
-    if not self:HasDropSpace(wep, self:GetShootPos(), self:GetAimVector()) then
+    if not self:HasDropSpace(self:GetShootPos(), self:GetAimVector(), wep) then
         LANG.Msg(self, "drop_no_room", nil, MSG_MSTACK_WARN)
 
         return false

--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -1317,6 +1317,20 @@ function plymeta:Give(weaponClassName, bNoAmmo)
 end
 
 ---
+-- Checks if the player has space in front of them to drop a weapon.
+-- @param[opt] Weapon wep The weapon that should be dropped; add it as a parameter
+-- to have it on the trace ignore list
+-- @param Vector pos The position from where the drop should start
+-- @param Vector aim The aim vector or the general drop vector
+-- @return boolean Returns if there is space for a weapon to be dropped
+-- @realm server
+function plymeta:HasDropSpace(wep, pos, aim)
+    local tr = util.QuickTrace(pos, aim * 18, { self, wep })
+
+    return not tr.Hit
+end
+
+---
 -- Checks if the weapon can be dropped in a safely manner.
 -- @param Weapon wep The weapon that should be dropped
 -- @return boolean Returns if this weapon can be dropped
@@ -1330,9 +1344,7 @@ function plymeta:CanSafeDropWeapon(wep)
         return false
     end
 
-    local tr = util.QuickTrace(self:GetShootPos(), self:GetAimVector() * 32, self)
-
-    if tr.Hit then
+    if not self:HasDropSpace(wep, self:GetShootPos(), self:GetAimVector()) then
         LANG.Msg(self, "drop_no_room", nil, MSG_MSTACK_WARN)
 
         return false

--- a/lua/terrortown/lang/en.lua
+++ b/lua/terrortown/lang/en.lua
@@ -2190,4 +2190,4 @@ L.magneto_stick_help_carry_prop_release = "Release prop"
 L.magneto_stick_help_carry_prop_drop = "Drop prop"
 
 -- 2024-02-14
-L.throw_no_room = "You have to place here to throw this device"
+L.throw_no_room = "You have no space here to throw this device"

--- a/lua/terrortown/lang/en.lua
+++ b/lua/terrortown/lang/en.lua
@@ -2188,3 +2188,6 @@ L.magneto_stick_help_carry_rag_pin = "Pin ragdoll"
 L.magneto_stick_help_carry_rag_drop = "Drop ragdoll"
 L.magneto_stick_help_carry_prop_release = "Release prop"
 L.magneto_stick_help_carry_prop_drop = "Drop prop"
+
+-- 2024-02-14
+L.throw_no_room = "You have to place here to throw this device"


### PR DESCRIPTION
Previously you were always able to throw devices (beacon, radio etc). This could cause issues when really close to a wall as they would glitch through it. I added the same check to it, that the weapon dropping also uses.

While working on that I decreased the min distance to a wall when dropping a weapon as I noticed that a smaller distance works as well and improves the weapon pickup in tight corners. My testing also showed no glitches with this change.

This should fix the issue @mexikoedi was having.