### PR TITLE
Weapon Base: Auto select last weapon on remove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - UI for grenade throw arcs from [colemclaren's TTT fork](https://github.com/colemclaren/ttt/blob/master/addons/moat_addons/lua/weapons/weapon_tttbasegrenade.lua#L293-L353) (integrated by @EntranceJew)
 - `gameEffects` library for global effects that are useful, such as starting fires (by @EntranceJew)
 - Added weapon pickup sounds when picking up weapons manually (by @TimGoll)
+- Added `SWEP.SelectLastWeaponOnRemove` to handle weapon selection on weapon removal; it is set to `true` by default (by @TimGoll)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,6 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - UI for grenade throw arcs from [colemclaren's TTT fork](https://github.com/colemclaren/ttt/blob/master/addons/moat_addons/lua/weapons/weapon_tttbasegrenade.lua#L293-L353) (integrated by @EntranceJew)
 - `gameEffects` library for global effects that are useful, such as starting fires (by @EntranceJew)
 - Added weapon pickup sounds when picking up weapons manually (by @TimGoll)
-- Added `SWEP.SelectLastWeaponOnRemove` to handle weapon selection on weapon removal; it is set to `true` by default (by @TimGoll)
 
 ### Changed
 
@@ -88,6 +87,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
   - Rendering order is based on distance, no more weird visual glitches
   - Hidden when observing a player in first person view
 - Your own spectator nametag will not display when looking directly up in post-round (by @EntranceJew)
+- Made sure the last weapon is selected by default if the current weapon is removed; overwrite `OnRemove` to prevent that (by @TimGoll)
 
 ### Fixed
 

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_beacon.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_beacon.lua
@@ -152,14 +152,4 @@ if CLIENT then
             bodygroup = {},
         })
     end
-
-    ---
-    -- @realm client
-    function SWEP:OnRemove()
-        local owner = self:GetOwner()
-
-        if IsValid(owner) and owner == LocalPlayer() and owner:IsTerror() then
-            RunConsoleCommand("lastinv")
-        end
-    end
 end

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_binoculars.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_binoculars.lua
@@ -268,16 +268,6 @@ if CLIENT then
     local cv_thickness
 
     ---
-    -- @realm client
-    function SWEP:OnRemove()
-        local owner = self:GetOwner()
-
-        if IsValid(owner) and owner == LocalPlayer() and owner:IsTerror() then
-            RunConsoleCommand("lastinv")
-        end
-    end
-
-    ---
     -- @ignore
     function SWEP:Initialize()
         self:AddTTT2HUDHelp("binoc_help_pri", "binoc_help_sec")

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_c4.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_c4.lua
@@ -98,14 +98,4 @@ if CLIENT then
 
         return BaseClass.Initialize(self)
     end
-
-    ---
-    -- @realm client
-    function SWEP:OnRemove()
-        local owner = self:GetOwner()
-
-        if IsValid(owner) and owner == LocalPlayer() and owner:IsTerror() then
-            RunConsoleCommand("lastinv")
-        end
-    end
 end

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_cse.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_cse.lua
@@ -149,14 +149,4 @@ if CLIENT then
             bodygroup = {},
         })
     end
-
-    ---
-    -- @realm client
-    function SWEP:OnRemove()
-        local owner = self:GetOwner()
-
-        if IsValid(owner) and owner == LocalPlayer() and owner:IsTerror() then
-            RunConsoleCommand("lastinv")
-        end
-    end
 end

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_decoy.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_decoy.lua
@@ -159,14 +159,4 @@ if CLIENT then
             bodygroup = {},
         })
     end
-
-    ---
-    -- @realm client
-    function SWEP:OnRemove()
-        local owner = self:GetOwner()
-
-        if IsValid(owner) and owner == LocalPlayer() and owner:IsTerror() then
-            RunConsoleCommand("lastinv")
-        end
-    end
 end

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_health_station.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_health_station.lua
@@ -100,15 +100,5 @@ if CLIENT then
 
     ---
     -- @realm client
-    function SWEP:OnRemove()
-        local owner = self:GetOwner()
-
-        if IsValid(owner) and owner == LocalPlayer() and owner:IsTerror() then
-            RunConsoleCommand("lastinv")
-        end
-    end
-
-    ---
-    -- @realm client
     function SWEP:DrawWorldModelTranslucent() end
 end

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_knife.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_knife.lua
@@ -336,16 +336,6 @@ if CLIENT then
         return BaseClass.Initialize(self)
     end
 
-    ---
-    -- @realm client
-    function SWEP:OnRemove()
-        local owner = self:GetOwner()
-
-        if IsValid(owner) and owner == LocalPlayer() and owner:IsTerror() then
-            RunConsoleCommand("lastinv")
-        end
-    end
-
     hook.Add("TTTRenderEntityInfo", "HUDDrawTargetIDKnife", function(tData)
         local client = LocalPlayer()
         local ent = tData:GetEntity()

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_phammer.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_phammer.lua
@@ -238,11 +238,7 @@ end
 ---
 -- @realm shared
 function SWEP:OnRemove()
-    local owner = self:GetOwner()
-
-    if CLIENT and IsValid(owner) and owner == LocalPlayer() and owner:IsTerror() then
-        RunConsoleCommand("lastinv")
-    end
+    BaseClass.OnRemove(self)
 
     if CLIENT and IsValid(self.Ghost) then
         self.Ghost:Remove()

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_push.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_push.lua
@@ -203,11 +203,7 @@ end
 ---
 -- @realm shared
 function SWEP:OnRemove()
-    local owner = self:GetOwner()
-
-    if CLIENT and IsValid(owner) and owner == LocalPlayer() and owner:IsTerror() then
-        RunConsoleCommand("lastinv")
-    end
+    BaseClass.OnRemove(self)
 
     self.IsCharging = false
     self:SetCharge(0)

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_radio.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_radio.lua
@@ -138,14 +138,4 @@ if CLIENT then
             bodygroup = {},
         })
     end
-
-    ---
-    -- @realm client
-    function SWEP:OnRemove()
-        local owner = self:GetOwner()
-
-        if IsValid(owner) and owner == LocalPlayer() and owner:IsTerror() then
-            RunConsoleCommand("lastinv")
-        end
-    end
 end

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_spawneditor.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_spawneditor.lua
@@ -353,16 +353,12 @@ if CLIENT then
     ---
     -- @realm client
     function SWEP:OnRemove()
+        BaseClass.OnRemove(self)
+
         hook.Remove("PostDrawTranslucentRenderables", "RenderWeaponSpawnEdit")
 
         -- clear the local cache to prevent flickering after reset
         entspawnscript.ClearLocalCache()
-
-        local owner = self:GetOwner()
-
-        if IsValid(owner) and owner == LocalPlayer() and owner:IsTerror() then
-            RunConsoleCommand("lastinv")
-        end
     end
 
     ---

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -128,10 +128,6 @@ SWEP.silentPickup = false
 -- Can be useful if you have multiple instances, that rely on global variables stored via weapons.GetStored()
 SWEP.HotReloadableKeys = {}
 
--- Auto select the last weapon, when this weapon is removed from the player's iventory
--- Only works if OnRemove in the base class is called
-SWEP.SelectLastWeaponOnRemove = true
-
 -- If this weapon should be given to players upon spawning, set a table of the
 -- roles this should happen for here
 --	SWEP.InLoadoutFor = {ROLE_TRAITOR, ROLE_DETECTIVE, ROLE_INNOCENT}
@@ -750,10 +746,6 @@ if CLIENT then
     ---
     -- @realm client
     function SWEP:OnRemove()
-        if not self.SelectLastWeaponOnRemove then
-            return
-        end
-
         local owner = self:GetOwner()
 
         if IsValid(owner) and owner == LocalPlayer() and owner:IsTerror() then

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -128,6 +128,10 @@ SWEP.silentPickup = false
 -- Can be useful if you have multiple instances, that rely on global variables stored via weapons.GetStored()
 SWEP.HotReloadableKeys = {}
 
+-- Auto select the last weapon, when this weapon is removed from the player's iventory
+-- Only works if OnRemove in the base class is called
+SWEP.SelectLastWeaponOnRemove = true
+
 -- If this weapon should be given to players upon spawning, set a table of the
 -- roles this should happen for here
 --	SWEP.InLoadoutFor = {ROLE_TRAITOR, ROLE_DETECTIVE, ROLE_INNOCENT}
@@ -742,6 +746,20 @@ if CLIENT then
     -- @see https://wiki.facepunch.com/gmod/WEAPON:DrawWeaponSelection
     -- @realm client
     function SWEP:DrawWeaponSelection() end
+
+    ---
+    -- @realm client
+    function SWEP:OnRemove()
+        if not self.SelectLastWeaponOnRemove then
+            return
+        end
+
+        local owner = self:GetOwner()
+
+        if IsValid(owner) and owner == LocalPlayer() and owner:IsTerror() then
+            RunConsoleCommand("lastinv")
+        end
+    end
 
     ---
     -- @realm client

--- a/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
@@ -737,12 +737,6 @@ end
 function SWEP:OnRemove()
     BaseClass.OnRemove(self)
 
-    local owner = self:GetOwner()
-
-    if CLIENT and IsValid(owner) and owner == LocalPlayer() and owner:IsTerror() then
-        RunConsoleCommand("lastinv")
-    end
-
     self:Reset()
 end
 


### PR DESCRIPTION
While fixing bugs in weapons I was pretty annoyed about two things:

- many weapons forget to call `lastinv` on remove, meaning that you don't have a weapon selected, not even unarmed (e.g. when placing a boom body the boom body placer weapon is removed)
- fixing this means copying the same code to each weapon

Therefore I added it to the weapon base with a SWEP flag to disable it if desired. But I don't see a reason why you wouldn't want it, my testing showed no problems.