### PR TITLE
Shop: Invert internal Team buy check

### DIFF
--- a/gamemodes/terrortown/gamemode/shared/sh_shop.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_shop.lua
@@ -123,8 +123,8 @@ end
 function shop.SetEquipmentTeamBought(ply, equipmentName)
     local team = ply:GetTeam()
 
-    if team and team ~= TEAM_NONE and not TEAMS[team].alone then
-        return false
+    if team and team == TEAM_NONE or TEAMS[team].alone then
+        return
     end
 
     shop.teamBuyTable[team] = shop.teamBuyTable[team] or {}
@@ -135,8 +135,6 @@ function shop.SetEquipmentTeamBought(ply, equipmentName)
         net.WriteString(equipmentName)
         net.Send(GetTeamFilter(team))
     end
-
-    return true
 end
 
 ---

--- a/gamemodes/terrortown/gamemode/shared/sh_shop.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_shop.lua
@@ -123,7 +123,7 @@ end
 function shop.SetEquipmentTeamBought(ply, equipmentName)
     local team = ply:GetTeam()
 
-    if team and team == TEAM_NONE or TEAMS[team].alone then
+    if not team or team == TEAM_NONE or TEAMS[team].alone then
         return
     end
 


### PR DESCRIPTION
Apparently this check moved out of the function everytime the team is not none and not alone, therefore nearly always.

Also fixing the return type, which is just void.
Does now only skip a table entry if there is no team, or team_none or alone.