### PR TITLE
remove(sh_sql): Remove adding columns to existing database table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,10 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed the scoreboard being stuck open sometimes if the inflictor was no weapon (by @TimGoll)
 - Fixed door health displaying as a humongous string of decimals
 
+### Deprecated
+
+- Deprecated `sql.CreateSqlTable`, use migrations to manage database schemas instead
+
 ### Removed
 
 - Removed some crosshair related convars and replaced them with other ones, see the crosshair settings menu for details
@@ -115,6 +119,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Removed the convar `ttt_damage_own_healthstation` as it was inconsistent and probably unused as well
 - Removed `ttt_fire_fallback`, there's no situation where the fire shouldn't draw anymore.
 - Removed `resource.AddFile` calls, server operators should use the workshop version or manually bundle loose files.
+- Removed ability to add columns on existing database table through `sql.CreateSqlTable`
 
 ### Breaking Changes
 


### PR DESCRIPTION
Before this change it was possible to add columns to an existing database table through the `sql.CreateSqlTable()` function.

This is a troublesome and undocumented(!) functionality which should not exist going further.
Troublesome as once a column is added there is no way back. This whole functionality also sways from the `CreateSqlTable` expectation as running a `CREATE TABLE` statement on an existing sqlite table fails normally. (In our case we used this function to ensure a table exists, hence we now return `true` if the table already exists)

`sql.CreateSqlTable` is now also "soft" deprecated through our code annoations and therefore in our api-docs.
Handling database table definitions should be done through migrations from now on.

"Hard" deprecation (`ErrorNoHalt` on function call) should follow once we have migrated our codebase to use migrations to prevent spamming of deprecation messages.

Additionally this partially fixes #1418 as one of the offending pragma statements is removed.

A few notes:
- i'm not super sure on the `Dev` messages, maybe those could be improved/changed
- i've gone with the "soft" deprecation route so this **could** be merged for v0.13.0, but it is definitely not required.