### PR TITLE
Equipment: Always remove weapon_ttt_unarmed

### DIFF
--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_unarmed.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_unarmed.lua
@@ -68,6 +68,18 @@ function SWEP:Holster()
     return true
 end
 
+---
+-- @ignore
+function SWEP:OnDrop()
+    self:Remove()
+end
+
+---
+-- @ignore
+function SWEP:ShouldDropOnDie()
+    return false
+end
+
 if CLIENT then
     ---
     -- @realm client
@@ -82,4 +94,14 @@ if CLIENT then
     ---
     -- @realm client
     function SWEP:DrawWorldModelTranslucent() end
+end
+
+if SERVER then
+    ---
+    -- Always return true to be removed instead of dropped
+    -- @return boolean
+    -- @realm client
+    function SWEP:ShouldRemove()
+        return true
+    end
 end

--- a/lua/terrortown/menus/gamemode/equipment/base_equipment.lua
+++ b/lua/terrortown/menus/gamemode/equipment/base_equipment.lua
@@ -66,7 +66,6 @@ function CLGAMEMODESUBMENU:Populate(parent)
             { title = TryT("slot_weapon_heavy"), value = WEAPON_HEAVY },
             { title = TryT("slot_weapon_nade"), value = WEAPON_NADE },
             { title = TryT("slot_weapon_carry"), value = WEAPON_CARRY },
-            { title = TryT("slot_weapon_unarmed"), value = WEAPON_UNARMED },
             { title = TryT("slot_weapon_special"), value = WEAPON_SPECIAL },
             { title = TryT("slot_weapon_extra"), value = WEAPON_EXTRA },
             { title = TryT("slot_weapon_class"), value = WEAPON_CLASS },


### PR DESCRIPTION
Currently it is possible for weapon_ttt_unarmed to be dropped, but as it is no real weapon it's not inside the shopeditor, therefore settings made to it via mysterious ways cant be reversed.

One example are the wrongly saved values to the database introduced in v0.11.7b with this PR #1041.
As only in v0.12.0b with PR #984 the way no default values are saved was introduced, servers before this PR now have partly unusable values saved for some weapons and changing their defaults now doesnt change that anymore.

So this partly reverts changes done in #1310  at least for unarmed.
To make sure this never has any consequences on other weapons we also block the ability to choose the unarmed slot.