### PR TITLE
Custom World Models: Fixed rendering for custom world models

### DIFF
--- a/lua/ttt2/libraries/weaponrenderer.lua
+++ b/lua/ttt2/libraries/weaponrenderer.lua
@@ -291,7 +291,7 @@ function weaponrenderer.Render(wep, elements, boneEntity)
     local renderOrder = BuildRenderOrder(elements)
 
     -- if a model has a hand bone, it is probably created as a weapon and should therefore
-    -- be handled that way. If a model is abused aas a weapon then it doesn't have a handbone
+    -- be handled that way. If a model is abused as a weapon then it doesn't have a handbone
     -- and should therefore not be rotated
     local boneId = boneEntity:LookupBone("ValveBiped.Bip01_R_Hand")
     local hasHandBone = boneId and boneId ~= "__INVALIDBONE__"

--- a/lua/ttt2/libraries/weaponrenderer.lua
+++ b/lua/ttt2/libraries/weaponrenderer.lua
@@ -42,10 +42,11 @@ local propertiesMaterial = { "nocull", "additive", "vertexalpha", "vertexcolor",
 -- @param table baseDataTable The base data table, most of the time the view elements
 -- @param table dataTable The data table, most of the time the model data
 -- @param Entity boneEntity The bone entity, can be the view model, the player or the weapon
+-- @param boolean isInWorld If the weapon is placed in the world, without a player holding it
 -- @return Vector pos The bone position
 -- @return Angle ang The bone angle
 -- @realm client
-local function GetBoneOrientation(wep, baseDataTable, dataTable, boneEntity)
+local function GetBoneOrientation(wep, baseDataTable, dataTable, boneEntity, isInWorld)
     local bone, pos, ang
 
     if dataTable.rel and dataTable.rel ~= "" then
@@ -57,7 +58,7 @@ local function GetBoneOrientation(wep, baseDataTable, dataTable, boneEntity)
 
         -- Technically, if there exists an element with the same name as a bone
         -- you can get in an infinite loop. Let's just hope nobody's that stupid.
-        pos, ang = GetBoneOrientation(wep, baseDataTable, tbl, boneEntity)
+        pos, ang = GetBoneOrientation(wep, baseDataTable, tbl, boneEntity, isInWorld)
 
         if not pos then
             return
@@ -75,7 +76,9 @@ local function GetBoneOrientation(wep, baseDataTable, dataTable, boneEntity)
         -- this is important when the model is thrown in the world and has to be
         -- rendered on its own; especially for models that chose random names for
         -- their main bone
-        bone = bone or boneEntity:LookupBone(boneEntity:GetBoneName(0))
+        if isInWorld then
+            bone = bone or boneEntity:LookupBone(boneEntity:GetBoneName(0))
+        end
 
         if not bone then
             return
@@ -304,7 +307,7 @@ function weaponrenderer.Render(wep, elements, boneEntity)
         local model = modelData.modelEnt
         local sprite = modelData.spriteMaterial
 
-        local pos, ang = GetBoneOrientation(wep, elements, modelData, boneEntity)
+        local pos, ang = GetBoneOrientation(wep, elements, modelData, boneEntity, not hasHandBone)
 
         if not pos then
             continue


### PR DESCRIPTION
Fixes #1415 

When weapons with a custom world model are dropped, the renderer tries to render them but fails because it was unable to find the relevant bone and therefore exits early. This is not a problem when the entity has an owner (mostly the player holding that weapon) because the player entity has the required bone if the weapon is set up properly.

This PR fixes this issue by introducing a fallback to render it in place when the weapon has no owner by using its own main bone (which can have any random bone name).

Additionally I noticed the hitboxes of the models were completely off after I fixed the rendering issue. This is because we apply render filters clientside to the model that only change its appearnce, not its actual entity. This is not an issue for custom world or view models, but it is an issue when it is dropped in the world. I fixed this by detecting if the weapon is in the hands of a player or not. If it isn't, no clientside modifications should be applied.

There is one part that has to be discussed though:
```lua
-- if a model has a hand bone, it is probably created as a weapon and should therefore
-- be handled that way. If a model is abused aas a weapon then it doesn't have a handbone
-- and should therefore not be rotated
local boneId = boneEntity:LookupBone("ValveBiped.Bip01_R_Hand")
local hasHandBone = boneId and boneId ~= "__INVALIDBONE__"
```

This part doesn't really make sense to me. In my opinion the correct check here would be to see if the weapon has a valid owner. If it has one, then the entity can be model (not the entity!) can be resized.
However this completely breaks the hitboxes of the melon mine. The melon mine is the only one of these that correctly defines a bone that could be used as an attachment point when used as a weapon. If I use that bone (`ValveBiped.Bip01_R_Hand`) then the hitboxes are no longer off, as I now also apply the clientside modifications to the model, that should only be applied when in hand.
I'm not sure if this is an issue with the melon model or if there is something else going on. I'd suggest keeping it the way I implemented and taking a look at it again in case it breaks something in the future. For now I tested with all models that I had at hand and it worked fine