### PR TITLE
Markervision: Generalize for all placeable entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ### Added
 
+- Added all entities inheriting from ttt_base_placeable to get markervision
 - Added migrations between TTT2-versions, some breaking changes could now be migrated instead
 - Added a new markerVision module that adds information to a specific point in space to replace the old C4 radar; it is currently used by these builtin weapons (by @TimGoll)
   - C4

--- a/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
@@ -408,6 +408,11 @@ if SERVER then
         return true
     end
 
+    ---
+    -- Gets the current markerOwner
+    -- @note Override if not the originator should own the marker
+    -- @return Player|Role The Player or role be marker owner
+    -- @realm server
     function ENT:GetMarkerOwner()
         return self:GetOriginator()
     end
@@ -417,27 +422,46 @@ if CLIENT then
     local TryT = LANG.TryTranslation
     local ParT = LANG.GetParamTranslation
 
-    function ENT:ShouldDrawMarkerVision()
+    ---
+    -- Override to handle activation of marker overlay
+    -- @param MARKER_VISION_DATA mvData The @{MARKER_VISION_DATA} data object
+    -- @realm client
+    function ENT:ShouldDrawMarkerVision(mvData)
         return true
     end
 
+    ---
+    -- Override to customize markervision on drawcalls
+    -- @param MARKER_VISION_DATA mvData The @{MARKER_VISION_DATA} data object
+    -- @realm client
     function ENT:CustomizeMarkerVision(mvData) end
 
+    ---
+    -- Override if not the markerIconMaterial should be used
+    -- @param MARKER_VISION_DATA mvData The @{MARKER_VISION_DATA} data object
+    -- @return table Containing the icon Materials to show
+    -- @realm client
     function ENT:GetMarkerVisionIcons(mvData)
         return { self.markerIconMaterial }
     end
 
+    ---
+    -- Override if not the default color for the icons should be used
+    -- @param MARKER_VISION_DATA mvData The @{MARKER_VISION_DATA} data object
+    -- @return table Containing the icon colors to show
+    -- @realm client
     function ENT:GetMarkerVisionIconColors(mvData)
         return { COLOR_WHITE }
     end
 
+    -- Handle markervision for ttt_base_placeables
     hook.Add("TTT2RenderMarkerVisionInfo", "HUDDrawMarkerVisionBasePlaceable", function(mvData)
         local ent = mvData:GetEntity()
         local mvObject = mvData:GetMarkerVisionObject()
 
         if
             not mvObject:IsObjectFor(ent, "ttt_base_placeable_owner")
-            or not ent:ShouldDrawMarkerVision()
+            or not ent:ShouldDrawMarkerVision(mvData)
         then
             return
         end

--- a/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
@@ -15,7 +15,7 @@ ENT.isDestructible = true
 ENT.pickupWeaponClass = nil
 
 -- MarkerVision related
-ENT.iconMaterial = Material("vgui/ttt/tid/tid_big_role_not_known")
+ENT.markerIconMaterial = Material("vgui/ttt/tid/tid_big_role_not_known")
 ENT.markerVisibility = VISIBLE_FOR_PLAYER
 
 ---
@@ -420,10 +420,10 @@ if CLIENT then
     function ENT:CustomizeMarkerVision(mvData) end
 
     function ENT:GetMarkerVisionIcons(mvData)
-        return { self.iconMaterial }
+        return { self.markerIconMaterial }
     end
 
-    function ENT:GetMarkerVisionColors(mvData)
+    function ENT:GetMarkerVisionIconColors(mvData)
         return { COLOR_WHITE }
     end
 
@@ -447,7 +447,7 @@ if CLIENT then
         mvData:SetTitle(TryT(ent.PrintName))
 
         local icons = ent:GetMarkerVisionIcons(mvData)
-        local colors = ent:GetMarkerVisionColors(mvData)
+        local colors = ent:GetMarkerVisionIconColors(mvData)
         local size = math.min(#icons, #colors)
 
         for i = 1, size do

--- a/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
@@ -30,7 +30,7 @@ function ENT:Initialize()
         self:PrecacheGibs()
 
         local mvObject = self:AddMarkerVision("ttt_base_placeable_owner")
-        mvObject:SetOwner(self:GetOriginator())
+        mvObject:SetOwner(self:GetMarkerOwner())
         mvObject:SetVisibleFor(self.markerVisibility)
         mvObject:SyncToClients()
     end
@@ -406,6 +406,10 @@ if SERVER then
         self:WeldToSurface(true)
 
         return true
+    end
+
+    function ENT:GetMarkerOwner()
+        return self:GetOriginator()
     end
 end -- SERVER
 

--- a/gamemodes/terrortown/entities/entities/ttt_beacon.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_beacon.lua
@@ -25,7 +25,7 @@ ENT.pickupWeaponClass = "weapon_ttt_beacon"
 ENT.timeLastBeep = CurTime()
 ENT.lastPlysFound = {}
 
-ENT.iconMaterial = Material("vgui/ttt/marker_vision/beacon")
+ENT.markerIconMaterial = Material("vgui/ttt/marker_vision/beacon")
 ENT.markerVisibility = VISIBLE_FOR_PLAYER
 
 local beaconDetectionRange = 135

--- a/gamemodes/terrortown/entities/entities/ttt_beacon.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_beacon.lua
@@ -25,6 +25,9 @@ ENT.pickupWeaponClass = "weapon_ttt_beacon"
 ENT.timeLastBeep = CurTime()
 ENT.lastPlysFound = {}
 
+ENT.iconMaterial = Material("vgui/ttt/marker_vision/beacon")
+ENT.markerVisibility = VISIBLE_FOR_PLAYER
+
 local beaconDetectionRange = 135
 
 ---
@@ -42,11 +45,6 @@ function ENT:Initialize()
     if SERVER then
         self:SetUseType(SIMPLE_USE)
         self:NextThink(CurTime() + 1)
-
-        local mvObject = self:AddMarkerVision("beacon_owner")
-        mvObject:SetOwner(ROLE_DETECTIVE)
-        mvObject:SetVisibleFor(VISIBLE_FOR_ROLE)
-        mvObject:SyncToClients()
     end
 end
 
@@ -124,7 +122,7 @@ if SERVER then
             ply:RemoveMarkerVision("beacon_player")
         end
 
-        self:RemoveMarkerVision("beacon_owner")
+        BaseClass.OnRemove(self)
     end
 
     ---
@@ -164,7 +162,7 @@ if SERVER then
             end
 
             ---
-            -- @realm server			
+            -- @realm server
             -- stylua: ignore
             if hook.Run("TTT2BeaconDeathNotify", victim, beacon) == false then continue end
 
@@ -203,7 +201,6 @@ if CLIENT then
     local baseOpacity = 35
     local factorRenderDistance = 3
 
-    local materialBeacon = Material("vgui/ttt/marker_vision/beacon")
     local materialPlayer = Material("vgui/ttt/tid/tid_big_role_not_known")
 
     -- handle looking at Beacon
@@ -238,30 +235,6 @@ if CLIENT then
         end
 
         tData:AddDescriptionLine(TryT("beacon_short_desc"))
-    end)
-
-    hook.Add("TTT2RenderMarkerVisionInfo", "HUDDrawMarkerVisionBeacon", function(mvData)
-        local ent = mvData:GetEntity()
-        local mvObject = mvData:GetMarkerVisionObject()
-
-        if not mvObject:IsObjectFor(ent, "beacon_owner") then
-            return
-        end
-
-        local owner = ent:GetOriginator()
-        local nick = IsValid(owner) and owner:Nick() or "---"
-
-        local distance = math.Round(util.HammerUnitsToMeters(mvData:GetEntityDistance()), 1)
-
-        mvData:EnableText()
-
-        mvData:AddIcon(materialBeacon)
-        mvData:SetTitle(TryT(ent.PrintName))
-
-        mvData:AddDescriptionLine(ParT("marker_vision_owner", { owner = nick }))
-        mvData:AddDescriptionLine(ParT("marker_vision_distance", { distance = distance }))
-
-        mvData:AddDescriptionLine(TryT(mvObject:GetVisibleForTranslationKey()), COLOR_SLATEGRAY)
     end)
 
     hook.Add("TTT2RenderMarkerVisionInfo", "HUDDrawMarkerVisionBeaconPlys", function(mvData)

--- a/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
@@ -871,6 +871,11 @@ else -- CLIENT
         tData:AddDescriptionLine(TryT("c4_short_desc"))
     end)
 
+    ---
+    -- Overriden to change colors with distance to armed c4
+    -- @param MARKER_VISION_DATA mvData The @{MARKER_VISION_DATA} data object
+    -- @return table Containing the icon colors to show
+    -- @realm client
     function ENT:GetMarkerVisionIconColors(mvData)
         local color = COLOR_WHITE
 
@@ -893,6 +898,10 @@ else -- CLIENT
         return { color }
     end
 
+    ---
+    -- Overriden to add time to marker
+    -- @param MARKER_VISION_DATA mvData The @{MARKER_VISION_DATA} data object
+    -- @realm client
     function ENT:CustomizeMarkerVision(mvData)
         if not self:GetArmed() then
             return

--- a/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_c4/shared.lua
@@ -37,7 +37,7 @@ ENT.Avoidable = true
 
 ENT.isDestructible = false
 
-ENT.iconMaterial = Material("vgui/ttt/marker_vision/c4")
+ENT.markerIconMaterial = Material("vgui/ttt/marker_vision/c4")
 ENT.markerVisibility = VISIBLE_FOR_TEAM
 
 ---
@@ -871,7 +871,7 @@ else -- CLIENT
         tData:AddDescriptionLine(TryT("c4_short_desc"))
     end)
 
-    function ENT:GetMarkerVisionColors(mvData)
+    function ENT:GetMarkerVisionIconColors(mvData)
         local color = COLOR_WHITE
 
         if mvData:GetEntityDistance() > self:GetRadius() then

--- a/gamemodes/terrortown/entities/entities/ttt_decoy.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_decoy.lua
@@ -19,6 +19,12 @@ ENT.CanHavePrints = false
 ENT.CanUseKey = true
 ENT.pickupWeaponClass = "weapon_ttt_decoy"
 
+if CLIENT then
+    ENT.Icon = "vgui/ttt/icon_decoy"
+    ENT.PrintName = "decoy_name"
+    ENT.iconMaterial = Material("vgui/ttt/icon_decoy")
+end
+
 ---
 -- @realm shared
 function ENT:Initialize()

--- a/gamemodes/terrortown/entities/entities/ttt_decoy.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_decoy.lua
@@ -22,7 +22,7 @@ ENT.pickupWeaponClass = "weapon_ttt_decoy"
 if CLIENT then
     ENT.Icon = "vgui/ttt/icon_decoy"
     ENT.PrintName = "decoy_name"
-    ENT.iconMaterial = Material("vgui/ttt/icon_decoy")
+    ENT.markerIconMaterial = Material("vgui/ttt/icon_decoy")
 end
 
 ---

--- a/gamemodes/terrortown/entities/entities/ttt_health_station.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_health_station.lua
@@ -12,7 +12,7 @@ DEFINE_BASECLASS("ttt_base_placeable")
 if CLIENT then
     ENT.Icon = "vgui/ttt/icon_health"
     ENT.PrintName = "hstation_name"
-    ENT.iconMaterial = Material("vgui/ttt/icon_health")
+    ENT.markerIconMaterial = Material("vgui/ttt/icon_health")
 end
 
 ENT.Base = "ttt_base_placeable"

--- a/gamemodes/terrortown/entities/entities/ttt_health_station.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_health_station.lua
@@ -12,6 +12,7 @@ DEFINE_BASECLASS("ttt_base_placeable")
 if CLIENT then
     ENT.Icon = "vgui/ttt/icon_health"
     ENT.PrintName = "hstation_name"
+    ENT.iconMaterial = Material("vgui/ttt/icon_health")
 end
 
 ENT.Base = "ttt_base_placeable"

--- a/gamemodes/terrortown/entities/entities/ttt_radio.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_radio.lua
@@ -27,6 +27,9 @@ ENT.pickupWeaponClass = "weapon_ttt_radio"
 ENT.SoundLimit = 5
 ENT.SoundDelay = 0.5
 
+ENT.iconMaterial = Material("vgui/ttt/marker_vision/radio")
+ENT.markerVisibility = VISIBLE_FOR_TEAM
+
 ---
 -- @realm shared
 function ENT:Initialize()
@@ -42,11 +45,6 @@ function ENT:Initialize()
 
     if SERVER then
         self:SetUseType(SIMPLE_USE)
-
-        local mvObject = self:AddMarkerVision("radio_owner")
-        mvObject:SetOwner(self:GetOriginator())
-        mvObject:SetVisibleFor(VISIBLE_FOR_TEAM)
-        mvObject:SyncToClients()
     end
 
     -- Register with owner
@@ -107,9 +105,9 @@ function ENT:OnRemove()
         end
 
         client.radio = nil
-    else
-        self:RemoveMarkerVision("radio_owner")
     end
+
+    BaseClass.OnRemove(self)
 end
 ---
 -- @param Sound snd
@@ -340,30 +338,6 @@ if CLIENT then
 
         tData:SetKeyBinding("+use")
         tData:AddDescriptionLine(TryT("radio_short_desc"))
-    end)
-
-    hook.Add("TTT2RenderMarkerVisionInfo", "HUDDrawMarkerVisionRadio", function(mvData)
-        local ent = mvData:GetEntity()
-        local mvObject = mvData:GetMarkerVisionObject()
-
-        if not mvObject:IsObjectFor(ent, "radio_owner") then
-            return
-        end
-
-        local originator = ent:GetOriginator()
-        local nick = IsValid(originator) and originator:Nick() or "---"
-
-        local distance = math.Round(util.HammerUnitsToMeters(mvData:GetEntityDistance()), 1)
-
-        mvData:EnableText()
-
-        mvData:SetTitle(TryT(ent.PrintName))
-        mvData:AddIcon(materialRadio)
-
-        mvData:AddDescriptionLine(ParT("marker_vision_owner", { owner = nick }))
-        mvData:AddDescriptionLine(ParT("marker_vision_distance", { distance = distance }))
-
-        mvData:AddDescriptionLine(TryT(mvObject:GetVisibleForTranslationKey()), COLOR_SLATEGRAY)
     end)
 end
 

--- a/gamemodes/terrortown/entities/entities/ttt_radio.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_radio.lua
@@ -27,7 +27,7 @@ ENT.pickupWeaponClass = "weapon_ttt_radio"
 ENT.SoundLimit = 5
 ENT.SoundDelay = 0.5
 
-ENT.iconMaterial = Material("vgui/ttt/marker_vision/radio")
+ENT.markerIconMaterial = Material("vgui/ttt/marker_vision/radio")
 ENT.markerVisibility = VISIBLE_FOR_TEAM
 
 ---
@@ -303,8 +303,6 @@ function ENT:Think()
 end
 
 if CLIENT then
-    local materialRadio = Material("vgui/ttt/marker_vision/radio")
-
     local TryT = LANG.TryTranslation
     local ParT = LANG.GetParamTranslation
 


### PR DESCRIPTION
This enables markervision for all placeable entities, by initializing and removing it in the baseclass.
To overwrite, change icons or add additional infos, you can use the ent specific functions.

This shall also be the start of remote triggerable entities, that make use of the markervision system, by enabling remote configuration when a markervision enabled entity is in line of sight.