### PR TITLE
Equipment Caching: Rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed the decoy producing a wrong colored icon for other teams (by @NickCloudAT)
 - Fixed the scoreboard being stuck open sometimes if the inflictor was no weapon (by @TimGoll)
 - Fixed door health displaying as a humongous string of decimals
+- Fixed the initial lag-spike when opening the shop for the first time on a map (by @TimGoll)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
   - Hidden when observing a player in first person view
 - Your own spectator nametag will not display when looking directly up in post-round (by @EntranceJew)
 - Made sure the last weapon is selected by default if the current weapon is removed; overwrite `OnRemove` to prevent that (by @TimGoll)
+- Changed the way weapon icon caching is working to make sure all weapons always have a cached icon material (by @TimGoll)
 
 ### Fixed
 

--- a/gamemodes/terrortown/gamemode/client/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_equip.lua
@@ -1195,40 +1195,6 @@ function GM:OnContextMenuOpen()
     end
 end
 
----
--- Caches the material or model
--- @param table item
--- @realm client
-function TTT2CacheEquipMaterials(item)
-    item.isValidEquipment = true
-
-    if item.material then
-        item.iconMaterial = Material(item.material)
-
-        if item.iconMaterial:IsError() then
-            -- setting fallback error material
-            item.iconMaterial = fallback_mat
-        end
-    elseif item.model then
-        -- do not use fallback mat and use model instead
-        item.itemModel = item.model
-    end
-
-    --if there is no sensible material and model, the item should probably not be editable in the equipment Editor
-    if item.material == "vgui/ttt/icon_id" and item.model == "models/weapons/w_bugbait.mdl" then
-        item.isValidEquipment = false
-    end
-end
-
--- Preload materials for the shop
-hook.Add("PostInitPostEntity", "TTT2CacheEquipMaterials", function()
-    local itms = ShopEditor.GetEquipmentForRoleAll()
-
-    for _, item in pairs(itms) do
-        TTT2CacheEquipMaterials(item)
-    end
-end)
-
 -- Closes menu when roles are selected
 hook.Add("TTTBeginRound", "TTTBEMCleanUp", function()
     if not IsValid(eqframe) then

--- a/gamemodes/terrortown/gamemode/client/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_equip.lua
@@ -150,8 +150,6 @@ local color_bad = Color(244, 67, 54, 255)
 --local color_good = Color(76, 175, 80, 255)
 local color_darkened = Color(255, 255, 255, 80)
 
-local fallback_mat = Material("vgui/ttt/missing_equip_icon")
-
 -- Buyable weapons are loaded automatically. Buyable items are defined in
 -- equip_items_shd.lua
 

--- a/gamemodes/terrortown/gamemode/client/cl_main.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_main.lua
@@ -208,6 +208,8 @@ function GM:Initialize()
 
     keyhelp.InitializeBasicKeys()
 
+    ShopEditor.BuildValidEquipmentCache()
+
     ---
     -- @realm shared
     -- stylua: ignore
@@ -389,6 +391,8 @@ function GM:OnReloaded()
     vskin.UpdatedVSkin(skinName, skinName)
 
     keyhelp.InitializeBasicKeys()
+
+    ShopEditor.BuildValidEquipmentCache()
 
     LocalPlayer():SetSettingOnServer(
         "enable_dynamic_fov",

--- a/gamemodes/terrortown/gamemode/client/cl_shopeditor.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_shopeditor.lua
@@ -13,6 +13,12 @@ ShopEditor = ShopEditor or {}
 ShopEditor.fallback = {}
 ShopEditor.customShopRefresh = false
 
+---
+-- Generates and returns a list of all equipment items and weapons on the server that can be loaded.
+-- This means that they have an ID and are not a base for other weapons. This list also contains
+-- disabled or ejected equipment.
+-- @return table The table with all equipment
+-- @realm client
 function ShopEditor.GetInstalledEquipment()
     local installedEquipment = {}
 
@@ -58,12 +64,11 @@ function ShopEditor.GetInstalledEquipment()
     return installedEquipment
 end
 
+---
+-- Builts the clientside equipment cache with the cached icons; only caches weapons that are
+-- deemed valid and not ejected.
+-- @realm client
 function ShopEditor.BuildValidEquipmentCache()
-    -- need to build equipment cache?
-    if equipmentCache ~= nil then
-        return equipmentCache
-    end
-
     equipmentCache = {}
 
     local eject = {
@@ -100,7 +105,8 @@ function ShopEditor.BuildValidEquipmentCache()
             continue
         end
 
-        --if there is no sensible material and model, the equipment should probably not be editable in the equipment Editor
+        --if there is no sensible material and model, the equipment should probably not be
+        -- editable in the equipment editor or being added to the shop
         if
             equipment.material == "vgui/ttt/icon_id"
             and equipment.model == "models/weapons/w_bugbait.mdl"
@@ -108,25 +114,17 @@ function ShopEditor.BuildValidEquipmentCache()
             continue
         end
 
-        -- this hook: hook.Run("TTT2RegisterWeaponID", eq)
-
         equipmentCache[#equipmentCache + 1] = equipment
     end
-
-    return equipmentCache
 end
 
 ---
--- Returns a list of every available equipment
--- @return table
+-- Returns the cached equipment list that is built on every (re-)load of the game.
+-- @return table The cached equipment table
 -- @realm client
 function ShopEditor.GetEquipmentForRoleAll()
-    return ShopEditor.BuildValidEquipmentCache()
+    return equipmentCache or {}
 end
-
-hook.Add("TTT2FinishedLoading", "TTT2BuildEquipCache", function()
-    ShopEditor.BuildValidEquipmentCache()
-end)
 
 local function shopFallbackAnsw(len)
     local subrole = net.ReadUInt(ROLE_BITS)

--- a/gamemodes/terrortown/gamemode/client/cl_shopeditor.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_shopeditor.lua
@@ -53,6 +53,8 @@ function ShopEditor.GetInstalledEquipment()
             and not string.match(name, "base")
             and not string.match(name, "event")
         then
+            -- @realm client
+            -- stylua: ignore
             if hook.Run("TTT2RegisterWeaponID", equipment) then
                 installedEquipment[#installedEquipment + 1] = equipment
             else

--- a/gamemodes/terrortown/gamemode/client/cl_shopeditor.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_shopeditor.lua
@@ -94,16 +94,16 @@ function ShopEditor.BuildValidEquipmentCache()
         -- maybe even eject weapons with the wrong base?
 
         -- equipment is valid, cache the material now
-        if item.material then
-            item.iconMaterial = Material(item.material)
+        if equipment.material then
+            equipment.iconMaterial = Material(equipment.material)
     
-            if item.iconMaterial:IsError() then
+            if equipment.iconMaterial:IsError() then
                 -- setting fallback error material
-                item.iconMaterial = materialFallback
+                equipment.iconMaterial = materialFallback
             end
-        elseif item.model then
+        elseif equipment.model then
             -- do not use fallback mat and use model instead
-            item.itemModel = item.model
+            equipment.itemModel = equipment.model
         end
 
         equipmentCache[#equipmentCache + 1] = equipment

--- a/gamemodes/terrortown/gamemode/shared/sh_main.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_main.lua
@@ -197,7 +197,7 @@ local function TTT2RegisterSWEP(equipment, name, initialize)
             util.PrecacheModel(equipment.ViewModel)
         end
     elseif CLIENT then
-        TTT2CacheEquipMaterials(equipment)
+        ShopEditor.BuildValidEquipmentCache()
         net.Start("TTT2SyncShopsWithServer")
         net.SendToServer()
     end

--- a/lua/terrortown/menus/gamemode/equipment.lua
+++ b/lua/terrortown/menus/gamemode/equipment.lua
@@ -30,10 +30,6 @@ function CLGAMEMODEMENU:InitializeVirtualMenus()
     for i = 1, #equipments do
         local equipment = equipments[i]
 
-        if not equipment.isValidEquipment then
-            continue
-        end
-
         counter = counter + 1
 
         virtualSubmenus[counter] = tableCopy(equipmentMenuBase)

--- a/lua/terrortown/menus/gamemode/shops/base_shops.lua
+++ b/lua/terrortown/menus/gamemode/shops/base_shops.lua
@@ -86,10 +86,6 @@ function CLGAMEMODESUBMENU:Populate(parent)
         for i = 1, #items do
             local item = items[i]
 
-            if not item.isValidEquipment then
-                continue
-            end
-
             counter = counter + 1
 
             sortedEquipmentList[counter] = item


### PR DESCRIPTION
Fixes #1403 
Partly fixes some of #1091 (it does not fix this issue, it fixes a part of this issue, but after hotreload weapons are still missing (items are there) and everything is not buyable)

It looks like lots of changes, but I only moved things around. It is mostly the old code with renamed variables split into three functions. Notable changes:

- caching is now independant of eject and other changes, meaning that also `weapon_ttt_unarmed` has a cached icon
- caching now happens on every load / reload of the game instead of the first call this improved the first opening time of the shop for me by a lot
- it fixes the issue that the cache is not rebuilt on hoteload until the shop is reopened, improving some things mentioned in in 1091