### PR TITLE
AddonChecker: added base checking

### DIFF
--- a/gamemodes/terrortown/gamemode/server/sv_addonchecker.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_addonchecker.lua
@@ -651,6 +651,7 @@ function addonChecker.Check()
     print("TTT2 ADDON CHECKER")
     print("=============================================================")
     print("")
+    print("Scanning for known incompatible addons:")
 
     for i = 1, #addonTable do
         local addon = addonTable[i]
@@ -693,6 +694,29 @@ function addonChecker.Check()
         print("")
     end
 
+    print("=============================================================")
+    print("")
+    print("Scanning for weapons with incorrect weapon base:")
+
+    local equipmentWeapons = weapons.GetList()
+
+    for i = 1, #equipmentWeapons do
+        local wep = equipmentWeapons[i]
+
+        if weapons.IsBasedOn(wep.ClassName, "weapon_tttbase") then
+            continue
+        end
+
+        print("Warning: " .. wep.ClassName .. " is not based on 'weapon_tttbase', this may lead to issues when playing the game\n")
+        print("Location: " .. wep.Folder .. "\n")
+
+        if wep.Author and wep.Author ~= "" then
+            print("Author: " .. wep.Author .. "\n")
+        end
+    end
+    
+    
+    print("")
     print("=============================================================")
     print("This is the end of the addon checker output.")
     print("")


### PR DESCRIPTION
This is still a draft as I have to test how useful this actually is. But this is what I envisioned: Print a warning in the addon checker if an addon uses the wrong base. Sadly I think there is no way to detect the addon where this file came from.