### PR TITLE
Radio: Create new UI for remote useable radio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ## Unreleased
 
 ### Added
-- Added ENT:RemoteUse to ttt_base_placeable entities to allow remote triggers clientside
 
 - Added hook ENTITY:ClientUse(), which is triggered clientside if an entity is used
   - Return true to prevent also using this on the server for clientside only usecases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,15 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
   - Return true to prevent also using this on the server for clientside only usecases
 - Added hook ENTITY:RemoteUse(ply), which is shared
   - Return true if only clientside should be used
+- Added remote use to radio, you can now directly access it via use button on marker focus
 
 ### Changed
 
 ### Fixed
+
+### Removed
+
+- Removed radio tab in shop UI
 
 ## [v0.13.1b](https://github.com/TTT-2/TTT2/tree/v0.13.1b) (2024-02-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
   - Return true to prevent also using this on the server for clientside only usecases
 - Added hook ENTITY:RemoteUse(ply), which is shared
   - Return true if only clientside should be used
-- Added remote use to radio, you can now directly access it via use button on marker focus
+- Added RemoteUse to radio, you can now directly access it via use button on marker focus
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ## Unreleased
 
 ### Added
+- Added ENT:RemoteUse to ttt_base_placeable entities to allow remote triggers clientside
 
 - Added hook ENTITY:ClientUse(), which is triggered clientside if an entity is used
   - Return true to prevent also using this on the server for clientside only usecases

--- a/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
@@ -392,43 +392,4 @@ if SERVER then
 
         return true
     end
-end -- SERVER
-
-if CLIENT then
-    ---
-    -- This is triggered, when you focus a marker of an entity and press 'Use'-Key
-    -- Override to handle remote use
-    -- @realm client
-    function ENT:RemoteUse() end
-
-    hook.Add("KeyRelease", "TTT2RemoteUsePlaceable", function(ply, key)
-        if
-            key ~= IN_USE
-            or not IsValid(ply)
-            or not ply:IsTerror()
-            or not IsFirstTimePredicted()
-        then
-            return
-        end
-
-        local focussedEnt = markerVision.GetFocussedEntity()
-        if not IsValid(focussedEnt) or not isfunction(focussedEnt.RemoteUse) then
-            return
-        end
-
-        -- see if we need to do some custom usekey overriding
-        local tr = util.TraceLine({
-            start = ply:GetShootPos(),
-            endpos = ply:GetShootPos() + ply:GetAimVector() * 110,
-            filter = ply,
-            mask = MASK_SHOT,
-        })
-
-        -- Check if we want to pickup a weapon or check a corpse
-        if tr.Hit and IsValid(tr.Entity) and (tr.Entity.CanUseKey or tr.Entity.player_ragdoll) then
-            return
-        end
-
-        focussedEnt:RemoteUse()
-    end)
-end -- CLIENT
+end

--- a/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
@@ -392,4 +392,43 @@ if SERVER then
 
         return true
     end
-end
+end -- SERVER
+
+if CLIENT then
+    ---
+    -- This is triggered, when you focus a marker of an entity and press 'Use'-Key
+    -- Override to handle remote use
+    -- @realm client
+    function ENT:RemoteUse() end
+
+    hook.Add("KeyRelease", "TTT2RemoteUsePlaceable", function(ply, key)
+        if
+            key ~= IN_USE
+            or not IsValid(ply)
+            or not ply:IsTerror()
+            or not IsFirstTimePredicted()
+        then
+            return
+        end
+
+        local focussedEnt = markerVision.GetFocussedEntity()
+        if not IsValid(focussedEnt) or not isfunction(focussedEnt.RemoteUse) then
+            return
+        end
+
+        -- see if we need to do some custom usekey overriding
+        local tr = util.TraceLine({
+            start = ply:GetShootPos(),
+            endpos = ply:GetShootPos() + ply:GetAimVector() * 110,
+            filter = ply,
+            mask = MASK_SHOT,
+        })
+
+        -- Check if we want to pickup a weapon or check a corpse
+        if tr.Hit and IsValid(tr.Entity) and (tr.Entity.CanUseKey or tr.Entity.player_ragdoll) then
+            return
+        end
+
+        focussedEnt:RemoteUse()
+    end)
+end -- CLIENT

--- a/gamemodes/terrortown/entities/entities/ttt_radio.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_radio.lua
@@ -368,10 +368,14 @@ if CLIENT then
 
     ---
     -- This is triggered, when you focus a marker of an entity and press 'Use'-Key
-    -- Overriden to open the radio menu
+    -- Opens the radio menu
+    -- @param Player ply The player that used this entity. Always LocalPlayer here.
+    -- @return bool True, if this shouldnt be used serverside
     -- @realm client
-    function ENT:RemoteUse()
+    function ENT:RemoteUse(ply)
         TRADIO:Toggle(self)
+
+        return true
     end
 end
 

--- a/gamemodes/terrortown/entities/entities/ttt_radio.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_radio.lua
@@ -362,6 +362,7 @@ if CLIENT then
 
         mvData:AddDescriptionLine(ParT("marker_vision_owner", { owner = nick }))
         mvData:AddDescriptionLine(ParT("marker_vision_distance", { distance = distance }))
+        mvData:AddDescriptionLine(ParT("use_entity", { usekey = Key("+use", "USE") }))
 
         mvData:AddDescriptionLine(TryT(mvObject:GetVisibleForTranslationKey()), COLOR_SLATEGRAY)
     end)

--- a/gamemodes/terrortown/entities/entities/ttt_radio.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_radio.lua
@@ -371,7 +371,7 @@ if CLIENT then
     -- This is triggered, when you focus a marker of an entity and press 'Use'-Key
     -- Opens the radio menu
     -- @param Player ply The player that used this entity. Always LocalPlayer here.
-    -- @return bool True, if this shouldnt be used serverside
+    -- @return bool True, because this shouldn't be used serverside
     -- @realm client
     function ENT:RemoteUse(ply)
         TRADIO:Toggle(self)

--- a/gamemodes/terrortown/entities/entities/ttt_radio.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_radio.lua
@@ -365,6 +365,14 @@ if CLIENT then
 
         mvData:AddDescriptionLine(TryT(mvObject:GetVisibleForTranslationKey()), COLOR_SLATEGRAY)
     end)
+
+    ---
+    -- This is triggered, when you focus a marker of an entity and press 'Use'-Key
+    -- Overriden to open the radio menu
+    -- @realm client
+    function ENT:RemoteUse()
+        TRADIO:Toggle(self)
+    end
 end
 
 if SERVER then

--- a/gamemodes/terrortown/gamemode/client/cl_equip.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_equip.lua
@@ -938,20 +938,6 @@ function TraitorMenuPopup()
         )
     end
 
-    -- Weapon/item control
-    if IsValid(client.radio) or client:HasWeapon("weapon_ttt_radio") then
-        local dradio = TRADIO.CreateMenu(dsheet)
-
-        dsheet:AddSheet(
-            GetTranslation("radio_name"),
-            dradio,
-            "icon16/transmit.png",
-            false,
-            false,
-            GetTranslation("equip_tooltip_radio")
-        )
-    end
-
     -- Credit transferring
     if credits > 0 then
         local dtransfer = CreateTransferMenu(dsheet)

--- a/gamemodes/terrortown/gamemode/client/cl_tradio.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_tradio.lua
@@ -77,14 +77,10 @@ function TRADIO:Toggle(radioEnt)
     contentBox:SetSize(self.sizes.widthMainArea, self.sizes.heightMainArea)
     contentBox:Dock(TOP)
 
-    local contentAreaScroll = vgui.Create("DScrollPanelTTT2", contentBox)
-    contentAreaScroll:SetVerticalScrollbarEnabled(true)
-    contentAreaScroll:SetSize(self.sizes.widthContentArea, self.sizes.heightMainArea)
-    contentAreaScroll:Dock(FILL)
-
-    local buttonField = vgui.Create("DIconLayout", contentAreaScroll)
+    local buttonField = vgui.Create("DIconLayout", contentBox)
     buttonField:SetSpaceY(self.sizes.padding)
     buttonField:SetSpaceX(self.sizes.padding)
+    buttonField:SetSize(self.sizes.widthContentArea, self.sizes.heightMainArea)
     buttonField:Dock(TOP)
 
     for sound, translationName in pairs(sounds) do

--- a/gamemodes/terrortown/gamemode/client/cl_tradio.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_tradio.lua
@@ -88,7 +88,9 @@ function TRADIO:Toggle(radioEnt)
         buttonReport:SetText(LANG.GetTranslation(translationName))
         buttonReport:SetSize(self.sizes.widthButton, self.sizes.heightButton)
         buttonReport.DoClick = function(btn)
-            if not IsValid(self.radio) then return end
+            if not IsValid(self.radio) then
+                return
+            end
 
             RunConsoleCommand("ttt_radio_play", self.entIndex, sound)
         end

--- a/gamemodes/terrortown/gamemode/client/cl_tradio.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_tradio.lua
@@ -88,9 +88,9 @@ function TRADIO:Toggle(radioEnt)
         buttonReport:SetText(LANG.GetTranslation(translationName))
         buttonReport:SetSize(self.sizes.widthButton, self.sizes.heightButton)
         buttonReport.DoClick = function(btn)
-            if IsValid(self.radio) then
-                RunConsoleCommand("ttt_radio_play", self.entIndex, sound)
-            end
+            if not IsValid(self.radio) then return end
+
+            RunConsoleCommand("ttt_radio_play", self.entIndex, sound)
         end
     end
 end

--- a/gamemodes/terrortown/gamemode/client/cl_tradio.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_tradio.lua
@@ -46,6 +46,7 @@ end
 
 ---
 -- Show the radio UI with all sound buttons. Generates the whole UI.
+-- @param Entity radioEnt The radio Entity to toggle UI for
 -- @realm client
 function TRADIO:Toggle(radioEnt)
     self.radio = radioEnt

--- a/lua/terrortown/lang/en.lua
+++ b/lua/terrortown/lang/en.lua
@@ -2188,3 +2188,6 @@ L.magneto_stick_help_carry_prop_drop = "Drop prop"
 
 -- 2024-02-14
 L.throw_no_room = "You have no space here to throw this device"
+
+-- 2024-03-04
+L.use_entity = "Press [{usekey}] to use"

--- a/lua/terrortown/lang/en.lua
+++ b/lua/terrortown/lang/en.lua
@@ -130,8 +130,6 @@ L.xfer_received = "{player} has given you {num} credit."
 
 -- Radio tab in equipment menu
 L.radio_name = "Radio"
-L.radio_help = "Click a button to make your Radio play that sound."
-L.radio_notplaced = "You must place the Radio to play sound on it."
 
 -- Radio soundboard buttons
 L.radio_button_scream = "Scream"


### PR DESCRIPTION
Before this you had to navigate to the shop tabs to use it, which is really unintuitive and currently blocks our idea to do a new shop.
![grafik](https://github.com/TTT-2/TTT2/assets/72046466/cf56c6e4-3d36-4e77-9ea8-94eceba39173)

Now you can use the 'Use'-Key from any distance on the focussed radio marker
![grafik](https://github.com/TTT-2/TTT2/assets/72046466/7c4d6c30-d48b-40c1-b799-934fd09d7aad)
and get the following new UI, which triggers the sounds in the same way as before
![grafik](https://github.com/TTT-2/TTT2/assets/72046466/a9fa7cd5-e929-4878-9e54-3f63aba65737)

This will be waiting for the approval of the remote trigger feature in #1436 
