### PR TITLE
Fix for an error in a debug message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ### Fixed
 
+- Fixed an error in an error message (by @mexikoedi)
+
 ## [v0.13.0b](https://github.com/TTT-2/TTT2/tree/v0.13.0b) (2024-02-21)
 
 ### Added

--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -236,7 +236,7 @@ plymeta.RemoveEquipmentWeapon = plymeta.StripWeapon
 -- @realm server
 function plymeta:SendEquipment(mode, itemName)
     if not mode then
-        ErrorNoHaltWithStackWithStack(
+        ErrorNoHaltWithStack(
             "[TTT2] Define an EQUIPITEMS_mode for plymeta:SendEquipment(mode, itemName) to work.\n"
         )
 


### PR DESCRIPTION
There was a typo in a debug message which caused the following error.
```
[TTT2 (Base) - v0.13.0b] gamemodes/terrortown/gamemode/server/sv_player_ext.lua:239: attempt to call global 'ErrorNoHaltWithStackWithStack' (a nil value)
  1. SendEquipment - gamemodes/terrortown/gamemode/server/sv_player_ext.lua:239
   2. ForceAddEquipmentItem - lua/autorun/sh_lastmanstanding_init.lua:240
    3. OnLastManStanding - lua/autorun/sh_lastmanstanding_init.lua:189
     4. unknown - lua/autorun/sh_lastmanstanding_init.lua:47
      5. unknown - lua/includes/modules/concommand.lua:54
```

This is now fixed.