### PR TITLE
Bodysearch: Added safeguard to support undefined title or text

### DIFF
--- a/gamemodes/terrortown/gamemode/client/cl_vskin/default_skin.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/default_skin.lua
@@ -1996,10 +1996,12 @@ function SKIN:PaintInfoItemTTT2(panel, w, h)
     local title = panel:GetTitle()
     local text_title = ""
 
-    if title.params then
-        text_title = ParT(title.body, title.params)
-    else
-        text_title = TryT(title.body)
+    if title then
+        if title.params then
+            text_title = ParT(title.body, title.params)
+        else
+            text_title = TryT(title.body)
+        end
     end
 
     drawSimpleText(
@@ -2014,15 +2016,18 @@ function SKIN:PaintInfoItemTTT2(panel, w, h)
 
     local text = panel:GetText()
     local text_translated = ""
-    for i = 1, #text do
-        local params = text[i].params
-        local body = text[i].body
 
-        if not body then
-            continue
+    if text then
+        for i = 1, #text do
+            local params = text[i].params
+            local body = text[i].body
+
+            if not body then
+                continue
+            end
+
+            text_translated = text_translated .. DynT(body, params, true) .. ""
         end
-
-        text_translated = text_translated .. DynT(body, params, true) .. ""
     end
 
     local text_wrapped = drawGetWrappedText(text_translated, w - posText - padding, "DermaDefault")


### PR DESCRIPTION
![image](https://github.com/TTT-2/TTT2/assets/13639408/19997fc6-b623-4cf5-bec0-26edd98d4272)

There was this bugreport. I wasn't able to track down the root of this problem, but I'm pretty sure addons try to add things without a title via the hook (which is fine) breaking the rendering code. So I made sure that not providing a title won't break the rendering.