### PR TITLE
AFK timer / incomplete player join bookkeeping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,13 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 - Added hook ENTITY:ClientUse(), which is triggered clientside if an entity is used
   - Return true to prevent also using this on the server for clientside only usecases
+- Added `plymeta:IsFullySignedOn()` to allow excluding players that have not gotten control yet (by @EntranceJew)
 
 ### Changed
 
 ### Fixed
+
+- Fixed the AFK timer accumulating while player not fully joined (by @EntranceJew)
 
 ## [v0.13.1b](https://github.com/TTT-2/TTT2/tree/v0.13.1b) (2024-02-27)
 

--- a/gamemodes/terrortown/gamemode/client/cl_main.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_main.lua
@@ -1000,6 +1000,7 @@ local idle = {
     mx = 0,
     my = 0,
     t = 0,
+    last_check = 0,
 }
 
 ---
@@ -1023,16 +1024,16 @@ end)
 -- @realm client
 -- @internal
 function CheckIdle()
-    if not GetGlobalBool("ttt_idle", false) then
-        return
-    end
-
     local client = LocalPlayer()
-    if not IsValid(client) then
-        return
-    end
 
-    if GetRoundState() == ROUND_ACTIVE and client:IsTerror() and client:Alive() then
+    if
+        GetGlobalBool("ttt_idle", false)
+        and IsValid(client)
+        and GetRoundState() == ROUND_ACTIVE
+        and client:IsTerror()
+        and client:Alive()
+        and client:IsFullySignedOn()
+    then
         local idle_limit = GetGlobalInt("ttt_idle_limit", 300) or 300
 
         if idle_limit <= 0 then -- networking sucks sometimes
@@ -1056,10 +1057,12 @@ function CheckIdle()
 
                 RunConsoleCommand("ttt_cl_idlepopup")
             end)
-        elseif CurTime() > idle.t + idle_limit * 0.5 then
+        elseif CurTime() > idle.t + (idle_limit * 0.5) then
             -- will repeat
             LANG.Msg("idle_warning")
         end
+    else
+        idle.t = CurTime()
     end
 end
 

--- a/gamemodes/terrortown/gamemode/shared/sh_main.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_main.lua
@@ -308,6 +308,20 @@ function GM:FinishMove(ply, moveData)
     SPRINT:HandleStaminaCalculation(ply)
 end
 
+---
+-- This hook is called every time a connecting client advances progress to signing on.
+-- @param number userID The userID of the player whose sign on state has changed.
+-- @param number oldState The previous sign on state. See @{SIGNONSTATE} enums.
+-- @param number newState The new/current sign on state. See @{SIGNONSTATE} enums.
+-- @hook
+-- @realm client
+-- @ref https://wiki.facepunch.com/gmod/GM:ClientSignOnStateChanged
+-- @local
+function GM:ClientSignOnStateChanged(userID, oldState, newState)
+    GAMEMODE.PlayerSignOnStates = GAMEMODE.PlayerSignOnStates or {}
+    GAMEMODE.PlayerSignOnStates[userID] = newState
+end
+
 local ttt_playercolors = {
     all = {
         COLOR_WHITE,

--- a/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
@@ -561,6 +561,15 @@ function plymeta:IsActive()
 end
 
 ---
+-- Checks whether a @{Player} is fully connected to the server
+-- @return boolean
+-- @realm shared
+function plymeta:IsFullySignedOn()
+    return (GAMEMODE.PlayerSignOnStates and GAMEMODE.PlayerSignOnStates[self:UserID()])
+        == SIGNONSTATE_FULL
+end
+
+---
 -- Convenience functions for common patterns
 -- will match if player has specific subrole or a general baserole if requested.
 -- To check whether a player have a specific baserole not a subrole, use <code>@{plymeta:GetSubRole} == baserole</code>


### PR DESCRIPTION
 - add plymeta:IsFullySignedOn
 - overzealous AFK reigned in

now the player will not get booted the very moment they receive a role while joining or between rounds, as long as the idle_limit is greater than 5, the hardcoded check interval