### PR TITLE
MarkerVision: Added subtitle option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,11 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Added hook ENTITY:RemoteUse(ply), which is shared
   - Return true if only clientside should be used
 - Added RemoteUse to radio, you can now directly access it via use button on marker focus
+- Added the option to add a subtitle to a marker vision element
 
 ### Changed
+
+- TargetID is now hidden when a marker vision element is focused
 
 ### Fixed
 

--- a/gamemodes/terrortown/entities/entities/ttt_radio.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_radio.lua
@@ -360,9 +360,10 @@ if CLIENT then
         mvData:SetTitle(TryT(ent.PrintName))
         mvData:AddIcon(materialRadio)
 
+        mvData:SetSubtitle(ParT("use_entity", { usekey = Key("+use", "USE") }))
+
         mvData:AddDescriptionLine(ParT("marker_vision_owner", { owner = nick }))
         mvData:AddDescriptionLine(ParT("marker_vision_distance", { distance = distance }))
-        mvData:AddDescriptionLine(ParT("use_entity", { usekey = Key("+use", "USE") }))
 
         mvData:AddDescriptionLine(TryT(mvObject:GetVisibleForTranslationKey()), COLOR_SLATEGRAY)
     end)

--- a/gamemodes/terrortown/gamemode/client/cl_keys.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_keys.lua
@@ -79,7 +79,7 @@ function GM:PlayerBindPress(ply, bindName, pressed)
 
         -- Find out if a marker is focussed otherwise check normal use
         local isClientOnly = false
-        local useEnt = markerVision.GetFocussedEntity()
+        local useEnt = markerVision.GetFocusedEntity()
         local isRemote = IsValid(useEnt)
         if not isRemote then
             local tr = util.TraceLine({

--- a/gamemodes/terrortown/gamemode/client/cl_marker_vision_data.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_marker_vision_data.lua
@@ -134,6 +134,20 @@ function MARKER_VISION_DATA:SetTitle(text, color, inline_icons)
 end
 
 ---
+-- Sets the subtitle of the specific targetID element
+-- @param[default=""] string text The text that should be displayed
+-- @param[default=Color(210, 210, 210, 255)] Color color The color of the line
+-- @param[opt] table inline_icons A table of materials that should be rendered in front of the text
+-- @realm client
+function MARKER_VISION_DATA:SetSubtitle(text, color, inline_icons)
+    self.params.displayInfo.subtitle = {
+        text = text or "",
+        color = IsColor(color) and color or COLOR_LLGRAY,
+        icons = inline_icons or {},
+    }
+end
+
+---
 -- Adds a line of text to the description area of the radar vision element
 -- @param[default=""] string text The text that should be displayed
 -- @param[default=Color(255, 255, 255, 255)] Color color The color of the line
@@ -170,6 +184,14 @@ end
 -- @realm client
 function MARKER_VISION_DATA:HasTitle()
     return self.params.displayInfo.title and self.params.displayInfo.title.text ~= ""
+end
+
+---
+-- Returns whether or not a subtitle has been set
+-- @return boolean True if a subtitle is set
+-- @realm client
+function MARKER_VISION_DATA:HasSubtitle()
+    return self.params.displayInfo.subtitle and self.params.displayInfo.subtitle ~= ""
 end
 
 ---

--- a/gamemodes/terrortown/gamemode/client/cl_marker_vision_data.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_marker_vision_data.lua
@@ -134,7 +134,7 @@ function MARKER_VISION_DATA:SetTitle(text, color, inline_icons)
 end
 
 ---
--- Sets the subtitle of the specific targetID element
+-- Sets the subtitle of the specific radar vision element
 -- @param[default=""] string text The text that should be displayed
 -- @param[default=Color(210, 210, 210, 255)] Color color The color of the line
 -- @param[opt] table inline_icons A table of materials that should be rendered in front of the text

--- a/gamemodes/terrortown/gamemode/client/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_targetid.lua
@@ -309,7 +309,7 @@ function GM:HUDDrawTargetID()
     end
 
     -- if the entity also is a focused marker vision element, then targetID should be hidden
-    if ent == markerVision.GetFocussedEntity() then
+    if ent == markerVision.GetFocusedEntity() then
         return
     end
 

--- a/gamemodes/terrortown/gamemode/client/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_targetid.lua
@@ -308,6 +308,11 @@ function GM:HUDDrawTargetID()
         return
     end
 
+    -- if the entity also is a focused marker vision element, then targetID should be hidden
+    if ent == markerVision.GetFocussedEntity() then
+        return
+    end
+
     -- call internal targetID functions first so the data can be modified by addons
     local tData = TARGET_DATA:Initialize(ent, unchangedEnt, distance)
 

--- a/lua/ttt2/libraries/marker_vision.lua
+++ b/lua/ttt2/libraries/marker_vision.lua
@@ -224,6 +224,10 @@ if CLIENT then
         { font = "Tahoma", size = 20, weight = 600, extended = true }
     )
     surface.CreateAdvancedFont(
+        "RadarVision_Subtitle",
+        { font = "Tahoma", size = 17, weight = 300, extended = true }
+    )
+    surface.CreateAdvancedFont(
         "RadarVision_Text",
         { font = "Tahoma", size = 14, weight = 300, extended = true }
     )
@@ -253,7 +257,7 @@ if CLIENT then
     function markerVision.Draw()
         local scale = appearance.GetGlobalScale()
 
-        local padding = 3 * scale
+        local padding = 4 * scale
         local paddingScreen = 10 * scale
 
         local sizeIcon = 28 * scale
@@ -264,6 +268,11 @@ if CLIENT then
 
         local sizeTitleIcon = 14 * scale
         local offsetTitleIcon = 0.5 * sizeTitleIcon
+
+        local sizeSubtitleIcon = 12 * scale
+        local offsetSubtitleIcon = 0.5 * sizeSubtitleIcon
+
+        local offsetSubtitle = 8 * scale
 
         local heightLineDescription = 14 * scale
 
@@ -378,15 +387,19 @@ if CLIENT then
                 continue
             end
 
-            screenPos.x = math.Clamp(
-                screenPos.x,
-                offsetIcon + paddingScreen,
-                widthScreen - offsetIcon - paddingScreen
+            screenPos.x = math.Round(
+                math.Clamp(
+                    screenPos.x,
+                    offsetIcon + paddingScreen,
+                    widthScreen - offsetIcon - paddingScreen
+                )
             )
-            screenPos.y = math.Clamp(
-                screenPos.y,
-                offsetIcon + paddingScreen,
-                heightScreen - offsetIcon - paddingScreen
+            screenPos.y = math.Round(
+                math.Clamp(
+                    screenPos.y,
+                    offsetIcon + paddingScreen,
+                    heightScreen - offsetIcon - paddingScreen
+                )
             )
 
             -- draw Icons
@@ -414,11 +427,14 @@ if CLIENT then
                 end
             end
 
+            -- check if a subtitle is set because that shifts multiple things around
+            local hasSubtitle = mvData:HasSubtitle()
+
             -- draw title
             local stringTitle = params.displayInfo.title.text
 
             local xStringTitle = screenPos.x + offsetIcon + padding
-            local yStringTitle = screenPos.y
+            local yStringTitle = hasSubtitle and (screenPos.y - offsetSubtitle) or screenPos.y
 
             for j = 1, #params.displayInfo.title.icons do
                 drawsc.FilteredShadowedTexture(
@@ -431,7 +447,7 @@ if CLIENT then
                     params.displayInfo.title.color
                 )
 
-                xStringTitle = xStringTitle + 18 * scale
+                xStringTitle = xStringTitle + sizeTitleIcon + 4 * scale
             end
 
             draw.AdvancedText(
@@ -446,6 +462,38 @@ if CLIENT then
                 scale
             )
 
+            -- draw subtitle
+            if hasSubtitle then
+                local stringSubtitle = params.displayInfo.subtitle.text
+
+                local xStringSubtitle = xStringTitle
+                local yStringSubtitle = screenPos.y + offsetSubtitle
+
+                for j = 1, #params.displayInfo.subtitle.icons do
+                    drawsc.FilteredShadowedTexture(
+                        xStringSubtitle,
+                        yStringSubtitle - offsetSubtitleIcon,
+                        sizeSubtitleIcon,
+                        sizeSubtitleIcon,
+                        params.displayInfo.subtitle.icons[j],
+                        params.displayInfo.subtitle.color.a,
+                        params.displayInfo.subtitle.color
+                    )
+
+                    xStringSubtitle = xStringSubtitle + sizeSubtitleIcon + 4 * scale
+                end
+
+                drawsc.AdvancedShadowedText(
+                    stringSubtitle,
+                    "RadarVision_Subtitle",
+                    xStringSubtitle,
+                    yStringSubtitle,
+                    params.displayInfo.subtitle.color,
+                    TEXT_ALIGN_LEFT,
+                    TEXT_ALIGN_CENTER
+                )
+            end
+
             -- draw description
             local linesDescription = params.displayInfo.desc
             local amountLinesDescription = #linesDescription
@@ -458,7 +506,9 @@ if CLIENT then
                 local color = linesDescription[j].color
 
                 local xStringDescriptionShifted = xStringDescription
-                local yStringDescription = yStringTitle + j * heightLineDescription
+                local yStringDescription = yStringTitle
+                    + j * heightLineDescription
+                    + (hasSubtitle and 3 * offsetSubtitle or 0)
 
                 for k = 1, #icons do
                     draw.FilteredShadowedTexture(

--- a/lua/ttt2/libraries/marker_vision.lua
+++ b/lua/ttt2/libraries/marker_vision.lua
@@ -235,7 +235,7 @@ if CLIENT then
     ---
     -- This gets the currently focussed closest entity.
     -- @realm client
-    function markerVision.GetFocussedEntity()
+    function markerVision.GetFocusedEntity()
         local closestEntTbl = markerVision.focussedMarkers[1] or {}
 
         for i = 2, #markerVision.focussedMarkers do


### PR DESCRIPTION
Added the possibility to add a subtitle to marker vision
![image](https://github.com/TTT-2/TTT2/assets/13639408/5a01f127-c485-4de0-8ec8-15b12acfbcb6)

Also targetID is now hidden, when a marker vision element is focused as it is quite confusing to see two mutually exclusive use interactions on screen at the same time.