### PR TITLE
Bugfix: Fixed issue with +use for traitors

### DIFF
--- a/gamemodes/terrortown/gamemode/client/cl_keys.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_keys.lua
@@ -65,7 +65,7 @@ function GM:PlayerBindPress(ply, bindName, pressed)
 
             return true
         end
-    elseif bindName == "+use" then
+    elseif bindName == "+use" and pressed then
         -- Do old traitor button check
         if TBHUD:PlayerIsFocused() then
             if ply:KeyDown(IN_WALK) then

--- a/gamemodes/terrortown/gamemode/client/cl_keys.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_keys.lua
@@ -65,7 +65,7 @@ function GM:PlayerBindPress(ply, bindName, pressed)
 
             return true
         end
-    elseif bindName == "+use" and pressed then
+    elseif bindName == "+use" then
         -- Do old traitor button check
         if TBHUD:PlayerIsFocused() then
             if ply:KeyDown(IN_WALK) then

--- a/gamemodes/terrortown/gamemode/client/cl_tbuttons.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_tbuttons.lua
@@ -77,7 +77,6 @@ function TBHUD:PlayerIsFocused()
         and ply:IsActive()
         and self.focus_but
         and (self.focus_but.access or self.focus_but.admin)
-        and self.focus_stick
         and self.focus_stick >= CurTime()
         and IsValid(self.focus_but.ent)
 end

--- a/gamemodes/terrortown/gamemode/client/cl_tbuttons.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_tbuttons.lua
@@ -77,6 +77,8 @@ function TBHUD:PlayerIsFocused()
         and ply:IsActive()
         and self.focus_but
         and (self.focus_but.access or self.focus_but.admin)
+        and self.focus_stick
+        and self.focus_stick >= CurTime()
         and IsValid(self.focus_but.ent)
 end
 


### PR DESCRIPTION
This PR fixes traitors sometimes not being able to use entities (doors, weapons, etc), and spectators not being able to use entities at all.

**Detail:**
Traitors were denied pressing Use on all entities except traitor buttons if they ever hovered their crosshair over a traitor button, as TBHUD:PlayerIsFocused would report they were always focused on one for the rest of the round.
_This has been fixed by adding a TBHUD.focus_stick check to TBHUD:PlayerIsFocused._

Spectators were permanently denied pressing Use. This was because the "pressed" parameter in GM:PlayerBindPress always returned false for spectators while the +use check inside it wanted "pressed" to be true in order to pass.
_This has been fixed by removing the "pressed" check for +use in GM:PlayerBindPress. The "pressed" parameter seems to always return true only for non-spectators anyway, but if there's an issue let me know._