### PR TITLE
Crosshair: Show for nades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ### Changed
 
 - TargetID is now hidden when a marker vision element is focused
+- A crosshair is now also drawn when holding a nade, making it less confusing when looking at entities
 
 ### Fixed
 

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbasegrenade.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbasegrenade.lua
@@ -486,16 +486,6 @@ if CLIENT then
     local hudTextColor = Color(255, 255, 255, 180)
 
     ---
-    -- @realm client
-    function SWEP:OnRemove()
-        local owner = self:GetOwner()
-
-        if IsValid(owner) and owner == LocalPlayer() and owner:IsTerror() then
-            RunConsoleCommand("use", "weapon_ttt_unarmed")
-        end
-    end
-
-    ---
     -- @ignore
     function SWEP:DrawHUD()
         if self.HUDHelp then
@@ -534,6 +524,8 @@ if CLIENT then
             draw.Box(x - w / 2 + scale, y - h + scale, w * pct, h, COLOR_BLACK)
             draw.OutlinedShadowedBox(x - w / 2, y - h, w, h, scale, drawColor)
             draw.Box(x - w / 2, y - h, w * pct, h, drawColor)
+        else
+            BaseClass.DrawHUD(self)
         end
     end
 end


### PR DESCRIPTION
A crosshair is now also shown when holding a nade (not when the pin is pulled). This is done so you still know where to point when trying to interact with an entity.

I also removed the "select on remove" part, as this is in our weapon base since the last update.