### PR TITLE
EquipmentMenu: Fix GetClass error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ### Fixed
 
 - Fixed the AFK timer accumulating while player not fully joined (by @EntranceJew)
-- 
+- Fixed the equipment menu throwing errors when clicking on some items
+
 ### Removed
 
 - Removed radio tab in shop UI

--- a/lua/terrortown/entities/items/item_base/shared.lua
+++ b/lua/terrortown/entities/items/item_base/shared.lua
@@ -100,9 +100,32 @@ function ITEM:Bought(ply) end
 function ITEM:Initialize() end
 
 ---
--- useable, but do not modify this!
--- @return boolean whether this @{ITEM} is an equipment
+-- Checks whether this items is a valid equipment item.
+-- @note Useable, but do not modify or overwrite this!
+-- @return boolean Return whether this @{ITEM} is an equipment
 -- @realm shared
 function ITEM:IsEquipment()
     return WEPS.IsEquipment(self)
+end
+
+---
+-- Returns the classname of an item. This is often the name of the Lua file or folder containing the files for the item.
+-- @return string The item's class name
+-- @realm shared
+function ITEM:GetClass()
+    return self.ClassName
+end
+
+---
+-- Checks if the item is valid. Returns true if valid.
+-- @return boolean Returns true if item is valid
+-- @realm shared
+function ITEM:IsValid()
+    -- this is probably always valid if there is no custom weird stuff done
+    -- to the item's class
+    if self:GetClass() and self:GetClass() ~= "" then
+        return true
+    end
+
+    return false
 end

--- a/lua/terrortown/menus/gamemode/equipment/base_equipment.lua
+++ b/lua/terrortown/menus/gamemode/equipment/base_equipment.lua
@@ -194,7 +194,7 @@ function CLGAMEMODESUBMENU:Populate(parent)
             1,
             "Weapon / item '"
                 .. equipmentClass
-                .. "' doesn't use the weapon_tttbase / item_base and cannot be added to the settings panel."
+                .. "' doesn't use the weapon_tttbase / item_base and can therefore add no custom settings to the settings panel."
         )
     end
 

--- a/lua/terrortown/menus/gamemode/equipment/base_equipment.lua
+++ b/lua/terrortown/menus/gamemode/equipment/base_equipment.lua
@@ -179,9 +179,11 @@ function CLGAMEMODESUBMENU:Populate(parent)
         database = DatabaseElement(accessName, itemName, "damageScaling"),
     })
 
+    local equipmentClass = WEPS.GetClass(equipment)
+
     -- Get inheritable version for weapons to access inherited functions
     if not self.isItem then
-        equipment = weapons.Get(WEPS.GetClass(equipment))
+        equipment = weapons.Get(equipmentClass)
     end
 
     -- now add custom equipment settings
@@ -190,9 +192,9 @@ function CLGAMEMODESUBMENU:Populate(parent)
     else
         Dev(
             1,
-            "Weapon '"
-                .. equipment:GetClass()
-                .. "' doesn't use the weapon_tttbase and cannot be added to the settings panel."
+            "Weapon / item '"
+                .. equipmentClass
+                .. "' doesn't use the weapon_tttbase / item_base and cannot be added to the settings panel."
         )
     end
 


### PR DESCRIPTION
This error was reported by @mexikoedi on Discord:

![image](https://github.com/TTT-2/TTT2/assets/13639408/8b6398bd-e2a2-427f-a6fc-2727b76dbabf)

I fixed this by correctly using `WEPS.GetClass` here instead of `equipment:GetClass`. While doing this I noticed that items have no equivalent of `GetClass` and `IsValid` so I added that to the base class. These changes are not strictly needed for this fix, but imho they are useful for consistency.