### PR TITLE
Equipment Settings: Item hide irrelevant settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ### Fixed
 
 - Fixed the AFK timer accumulating while player not fully joined (by @EntranceJew)
-- Fixed view models of some weapons having an error texture
-
+- 
 ### Removed
 
 - Removed radio tab in shop UI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ### Fixed
 
 - Fixed the AFK timer accumulating while player not fully joined (by @EntranceJew)
-- 
+- Fixed view models of some weapons having an error texture
+
 ### Removed
 
 - Removed radio tab in shop UI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - TargetID is now hidden when a marker vision element is focused
 - Crosshair rendering now is a bit more flexible and customizable
 - A crosshair is now also drawn when holding a nade, making it less confusing when looking at entities
+- Hides item settings in the equipment editor that are only relevant for weapons
 
 ### Fixed
 

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -854,10 +854,9 @@ if CLIENT then
         weaponrenderer.RenderWorldModel(self, self, self.customWorldModelElements, self:GetOwner())
     end
 
-    local weaponIsHidden = false
-
     ---
-    -- Allows you to modify viewmodel of the weapon in use before it is drawn.
+    -- Allows you to modify viewmodel while the weapon in use before it is drawn.
+    -- @warning This hook only works if you haven't overridden @{GM:PreDrawViewModel}.
     -- @param Entity viewModel This is the view model entity before it is drawn
     -- @param Player ply The the owner of the view model
     -- @param Weapon wep This is the weapon that is from the view model
@@ -877,38 +876,17 @@ if CLIENT then
         if wep.UseHands and wep.ShowDefaultViewModel == false then
             viewModel:SetMaterial("vgui/hsv")
 
-            -- trigger a texture reset after the view model is drawn
-            weaponIsHidden = true
-
             return
         end
+
+        -- default case: Normal view model texture is used and view model draw is defined
+        -- with the SWEP.ShowDefaultViewModel variable
+        viewModel:SetMaterial("")
 
         -- only return something if we actually want to hide it because otherwise the SWEP
         -- hook is never called even if the view model is rendered
         if wep.ShowDefaultViewModel == false then
             return true
-        end
-    end)
-
-    ---
-    -- Allows you to modify viewmodel of the weapon in use after it is drawn.
-    -- @param Entity viewModel This is the view model entity before it is drawn
-    -- @param Player ply The the owner of the view model
-    -- @param Weapon wep This is the weapon that is from the view model
-    -- @realm client
-    hook.Add("PostDrawViewModel", "TTT2ViewModelHiderReset", function(viewModel, ply, wep)
-        -- default case: Normal view model texture is used and view model draw is defined
-        -- with the SWEP.ShowDefaultViewModel variable
-
-        -- note: we only reset the material to the default material if it was previously set to
-        -- the invisible debug material. That way it is only applied to view models that are
-        -- intended to be invisible where it doesn't matter if it messes up their materials.
-        -- This is done because some weapons set custom materials to the view model (e.g. the
-        -- zombie perk bottles) and always resetting it makes the texture the error texture.
-        if weaponIsHidden then
-            viewModel:SetMaterial("")
-
-            weaponIsHidden = false
         end
     end)
 

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -854,9 +854,10 @@ if CLIENT then
         weaponrenderer.RenderWorldModel(self, self, self.customWorldModelElements, self:GetOwner())
     end
 
+    local weaponIsHidden = false
+
     ---
-    -- Allows you to modify viewmodel while the weapon in use before it is drawn.
-    -- @warning This hook only works if you haven't overridden @{GM:PreDrawViewModel}.
+    -- Allows you to modify viewmodel of the weapon in use before it is drawn.
     -- @param Entity viewModel This is the view model entity before it is drawn
     -- @param Player ply The the owner of the view model
     -- @param Weapon wep This is the weapon that is from the view model
@@ -876,17 +877,38 @@ if CLIENT then
         if wep.UseHands and wep.ShowDefaultViewModel == false then
             viewModel:SetMaterial("vgui/hsv")
 
+            -- trigger a texture reset after the view model is drawn
+            weaponIsHidden = true
+
             return
         end
-
-        -- default case: Normal view model texture is used and view model draw is defined
-        -- with the SWEP.ShowDefaultViewModel variable
-        viewModel:SetMaterial("")
 
         -- only return something if we actually want to hide it because otherwise the SWEP
         -- hook is never called even if the view model is rendered
         if wep.ShowDefaultViewModel == false then
             return true
+        end
+    end)
+
+    ---
+    -- Allows you to modify viewmodel of the weapon in use after it is drawn.
+    -- @param Entity viewModel This is the view model entity before it is drawn
+    -- @param Player ply The the owner of the view model
+    -- @param Weapon wep This is the weapon that is from the view model
+    -- @realm client
+    hook.Add("PostDrawViewModel", "TTT2ViewModelHiderReset", function(viewModel, ply, wep)
+        -- default case: Normal view model texture is used and view model draw is defined
+        -- with the SWEP.ShowDefaultViewModel variable
+
+        -- note: we only reset the material to the default material if it was previously set to
+        -- the invisible debug material. That way it is only applied to view models that are
+        -- intended to be invisible where it doesn't matter if it messes up their materials.
+        -- This is done because some weapons set custom materials to the view model (e.g. the
+        -- zombie perk bottles) and always resetting it makes the texture the error texture.
+        if weaponIsHidden then
+            viewModel:SetMaterial("")
+
+            weaponIsHidden = false
         end
     end)
 

--- a/lua/terrortown/menus/gamemode/equipment/base_equipment.lua
+++ b/lua/terrortown/menus/gamemode/equipment/base_equipment.lua
@@ -53,24 +53,26 @@ function CLGAMEMODESUBMENU:Populate(parent)
 
     local form = vgui.CreateTTT2Form(parent, "header_equipment_setup")
 
-    form:MakeHelp({
-        label = "equipmenteditor_desc_kind",
-    })
+    if not self.isItem then
+        form:MakeHelp({
+            label = "equipmenteditor_desc_kind",
+        })
 
-    form:MakeComboBox({
-        label = "equipmenteditor_name_kind",
-        database = DatabaseElement(accessName, itemName, "Kind"),
-        choices = {
-            { title = TryT("slot_weapon_melee"), value = WEAPON_MELEE },
-            { title = TryT("slot_weapon_pistol"), value = WEAPON_PISTOL },
-            { title = TryT("slot_weapon_heavy"), value = WEAPON_HEAVY },
-            { title = TryT("slot_weapon_nade"), value = WEAPON_NADE },
-            { title = TryT("slot_weapon_carry"), value = WEAPON_CARRY },
-            { title = TryT("slot_weapon_special"), value = WEAPON_SPECIAL },
-            { title = TryT("slot_weapon_extra"), value = WEAPON_EXTRA },
-            { title = TryT("slot_weapon_class"), value = WEAPON_CLASS },
-        },
-    })
+        form:MakeComboBox({
+            label = "equipmenteditor_name_kind",
+            database = DatabaseElement(accessName, itemName, "Kind"),
+            choices = {
+                { title = TryT("slot_weapon_melee"), value = WEAPON_MELEE },
+                { title = TryT("slot_weapon_pistol"), value = WEAPON_PISTOL },
+                { title = TryT("slot_weapon_heavy"), value = WEAPON_HEAVY },
+                { title = TryT("slot_weapon_nade"), value = WEAPON_NADE },
+                { title = TryT("slot_weapon_carry"), value = WEAPON_CARRY },
+                { title = TryT("slot_weapon_special"), value = WEAPON_SPECIAL },
+                { title = TryT("slot_weapon_extra"), value = WEAPON_EXTRA },
+                { title = TryT("slot_weapon_class"), value = WEAPON_CLASS },
+            },
+        })
+    end
 
     form:MakeHelp({
         label = "equipmenteditor_desc_not_buyable",
@@ -126,28 +128,30 @@ function CLGAMEMODESUBMENU:Populate(parent)
         master = master,
     })
 
-    form:MakeHelp({
-        label = "equipmenteditor_desc_allow_drop",
-    })
+    if not self.isItem then
+        form:MakeHelp({
+            label = "equipmenteditor_desc_allow_drop",
+        })
 
-    form:MakeCheckBox({
-        label = "equipmenteditor_name_allow_drop",
-        database = DatabaseElement(accessName, itemName, "AllowDrop"),
-    })
+        form:MakeCheckBox({
+            label = "equipmenteditor_name_allow_drop",
+            database = DatabaseElement(accessName, itemName, "AllowDrop"),
+        })
 
-    form:MakeHelp({
-        label = "equipmenteditor_desc_drop_on_death_type",
-    })
+        form:MakeHelp({
+            label = "equipmenteditor_desc_drop_on_death_type",
+        })
 
-    form:MakeComboBox({
-        label = "equipmenteditor_name_drop_on_death_type",
-        database = DatabaseElement(accessName, itemName, "overrideDropOnDeath"),
-        choices = {
-            { title = TryT("drop_on_death_type_default"), value = DROP_ON_DEATH_TYPE_DEFAULT },
-            { title = TryT("drop_on_death_type_force"), value = DROP_ON_DEATH_TYPE_FORCE },
-            { title = TryT("drop_on_death_type_deny"), value = DROP_ON_DEATH_TYPE_DENY },
-        },
-    })
+        form:MakeComboBox({
+            label = "equipmenteditor_name_drop_on_death_type",
+            database = DatabaseElement(accessName, itemName, "overrideDropOnDeath"),
+            choices = {
+                { title = TryT("drop_on_death_type_default"), value = DROP_ON_DEATH_TYPE_DEFAULT },
+                { title = TryT("drop_on_death_type_force"), value = DROP_ON_DEATH_TYPE_FORCE },
+                { title = TryT("drop_on_death_type_deny"), value = DROP_ON_DEATH_TYPE_DENY },
+            },
+        })
+    end
 
     form = vgui.CreateTTT2Form(parent, "header_equipment_value_setup")
 
@@ -167,17 +171,19 @@ function CLGAMEMODESUBMENU:Populate(parent)
         database = DatabaseElement(accessName, itemName, "credits"),
     })
 
-    form:MakeHelp({
-        label = "equipmenteditor_desc_damage_scaling",
-    })
+    if not self.isItem then
+        form:MakeHelp({
+            label = "equipmenteditor_desc_damage_scaling",
+        })
 
-    form:MakeSlider({
-        label = "equipmenteditor_name_damage_scaling",
-        min = 0,
-        max = 8,
-        decimal = 2,
-        database = DatabaseElement(accessName, itemName, "damageScaling"),
-    })
+        form:MakeSlider({
+            label = "equipmenteditor_name_damage_scaling",
+            min = 0,
+            max = 8,
+            decimal = 2,
+            database = DatabaseElement(accessName, itemName, "damageScaling"),
+        })
+    end
 
     -- Get inheritable version for weapons to access inherited functions
     if not self.isItem then


### PR DESCRIPTION
Fixes #1307 

Weapon settings:
![image](https://github.com/TTT-2/TTT2/assets/13639408/cbea348f-bbb0-48c2-ba15-329f614ddb17)

Item settings:
![image](https://github.com/TTT-2/TTT2/assets/13639408/4d93ffed-1b86-49d5-a2e3-cc9b0fe0e55e)

Over time additions to the equipment menu did not take into account that these settings are mostly only relevant to weapons. So I added a check that hides settings that have no effect on items.