### PR TITLE
ViewModels: Fix error texture bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ### Fixed
 
 - Fixed the AFK timer accumulating while player not fully joined (by @EntranceJew)
-- Fixed view models of some weapons having an error texture
+- Fixed weapons which set a custom view model texture having an error texture
 - Fixed the equipment menu throwing errors when clicking on some items
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ### Fixed
 
 - Fixed the AFK timer accumulating while player not fully joined (by @EntranceJew)
-- 
+- Fixed view models of some weapons having an error texture
+
 ### Removed
 
 - Removed radio tab in shop UI

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -854,9 +854,10 @@ if CLIENT then
         weaponrenderer.RenderWorldModel(self, self, self.customWorldModelElements, self:GetOwner())
     end
 
+    local weaponIsHidden = false
+
     ---
-    -- Allows you to modify viewmodel while the weapon in use before it is drawn.
-    -- @warning This hook only works if you haven't overridden @{GM:PreDrawViewModel}.
+    -- Allows you to modify viewmodel of the weapon in use before it is drawn.
     -- @param Entity viewModel This is the view model entity before it is drawn
     -- @param Player ply The the owner of the view model
     -- @param Weapon wep This is the weapon that is from the view model
@@ -876,17 +877,38 @@ if CLIENT then
         if wep.UseHands and wep.ShowDefaultViewModel == false then
             viewModel:SetMaterial("vgui/hsv")
 
+            -- trigger a texture reset after the view model is drawn
+            weaponIsHidden = true
+
             return
         end
-
-        -- default case: Normal view model texture is used and view model draw is defined
-        -- with the SWEP.ShowDefaultViewModel variable
-        viewModel:SetMaterial("")
 
         -- only return something if we actually want to hide it because otherwise the SWEP
         -- hook is never called even if the view model is rendered
         if wep.ShowDefaultViewModel == false then
             return true
+        end
+    end)
+
+    ---
+    -- Allows you to modify viewmodel of the weapon in use after it is drawn.
+    -- @param Entity viewModel This is the view model entity before it is drawn
+    -- @param Player ply The the owner of the view model
+    -- @param Weapon wep This is the weapon that is from the view model
+    -- @realm client
+    hook.Add("PostDrawViewModel", "TTT2ViewModelHiderReset", function(viewModel, ply, wep)
+        -- default case: Normal view model texture is used and view model draw is defined
+        -- with the SWEP.ShowDefaultViewModel variable
+
+        -- note: we only reset the material to the default material if it was previously set to
+        -- the invisible debug material. That way it is only applied to view models that are
+        -- intended to be invisible where it doesn't matter if it messes up their materials.
+        -- This is done because some weapons set custom materials to the view model (e.g. the
+        -- zombie perk bottles) and always resetting it makes the texture the error texture.
+        if weaponIsHidden then
+            viewModel:SetMaterial("")
+
+            weaponIsHidden = false
         end
     end)
 

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -857,7 +857,7 @@ if CLIENT then
     local weaponIsHidden = false
 
     ---
-    -- Allows you to modify viewmodel of the weapon in use before it is drawn.
+    -- Allows you to modify the viewmodel of the weapon in use before it is drawn.
     -- @param Entity viewModel This is the view model entity before it is drawn
     -- @param Player ply The the owner of the view model
     -- @param Weapon wep This is the weapon that is from the view model
@@ -891,7 +891,7 @@ if CLIENT then
     end)
 
     ---
-    -- Allows you to modify viewmodel of the weapon in use after it is drawn.
+    -- Allows you to modify the viewmodel of the weapon in use after it is drawn.
     -- @param Entity viewModel This is the view model entity before it is drawn
     -- @param Player ply The the owner of the view model
     -- @param Weapon wep This is the weapon that is from the view model


### PR DESCRIPTION
Fixes this issue reported by @EntranceJew and @mexikoedi:
![image](https://github.com/TTT-2/TTT2/assets/13639408/25bd7d61-fca3-4f9a-b396-e0918053a147)
![image](https://github.com/TTT-2/TTT2/assets/13639408/6336a791-6ffb-46bb-89ed-67e0baf80855)

The bug seen in the image happens because some weapons set a custom view model texture. Our view model hider resets this custom texture by calling `viewModel:SetMaterial("")`. I did not anticipate that weapons might set custom view models, so I wasn't aware that this is an issue.
![image](https://github.com/TTT-2/TTT2/assets/13639408/30296816-9bb0-402e-b4b1-ba7b8904c970)
![image](https://github.com/TTT-2/TTT2/assets/13639408/0fdad9d7-f3b7-4dfd-9439-3f23d6d9e3a5)

We *have to* reset the view model texture because the view model does not change on weapon change. So if weapon A has a hidden view model and we apply the debug texture, the same debug texture is applied to weapon B making it invisible as well. The first solution of applying the texture reset if it should not be hidden caused the bug mentioned above.

The solution therefore is to set a trigger, if the debug texture is set before the view model is rendered and reset the material after the view model is rendered. If a player then switches to weapon B, the view model works as expected without a continuous material reset.