### PR TITLE
Crosshair: Use default crosshair renderer for binoculars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Crosshair rendering now is a bit more flexible and customizable
 - A crosshair is now also drawn when holding a nade, making it less confusing when looking at entities
 - Hides item settings in the equipment editor that are only relevant for weapons
+- The binoculars now use the default crosshair as well
 
 ### Fixed
 

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_binoculars.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_binoculars.lua
@@ -35,6 +35,7 @@ SWEP.Primary.DefaultClip = -1
 SWEP.Primary.Automatic = false
 SWEP.Primary.Ammo = "none"
 SWEP.Primary.Delay = 1.0
+SWEP.Primary.Cone = 0.075
 
 SWEP.Secondary.ClipSize = -1
 SWEP.Secondary.DefaultClip = -1
@@ -262,10 +263,7 @@ if CLIENT then
     local GetPT = LANG.GetParamTranslation
     local mathRound = math.Round
     local mathClamp = math.Clamp
-
-    local hud_color = Color(60, 220, 20, 255)
-
-    local cv_thickness
+    local mathCeil = math.ceil
 
     ---
     -- @ignore
@@ -273,9 +271,7 @@ if CLIENT then
         self:AddTTT2HUDHelp("binoc_help_pri", "binoc_help_sec")
         self:AddHUDHelpLine("binoc_help_reload", Key("+reload", "R"))
 
-        cv_thickness = GetConVar("ttt_crosshair_thickness")
-
-        self.BaseClass.Initialize(self)
+        BaseClass.Initialize(self)
     end
 
     ---
@@ -330,40 +326,29 @@ if CLIENT then
         local progress =
             mathRound(mathClamp((c_wep:GetProgress() / c_wep.ProcessingDelay) * 100, 0, 100))
 
-        tData:AddDescriptionLine(GetPT("binoc_progress", { progress = progress }), hud_color)
+        tData:AddDescriptionLine(
+            GetPT("binoc_progress", { progress = progress }),
+            client.GetRoleColor and client:GetRoleColor() or roles.INNOCENT.color
+        )
     end)
 
     ---
     -- @ignore
     function SWEP:DrawHUD()
-        self:DrawHelp()
+        BaseClass.DrawHUD(self)
 
-        local length = 35
-        local gap = 15
-        local thickness = math.floor(cv_thickness and cv_thickness:GetFloat() or 1)
-        local offset = thickness * 0.5
-
-        surface.SetDrawColor(clr(hud_color))
-
-        -- change scope when looking at corpse
-        if self:IsTargetingCorpse() then
-            gap = thickness * 2
-        end
-
-        local x = ScrW() * 0.5
-        local y = ScrH() * 0.5
-
-        surface.DrawRect(x - length, y - offset, length - gap, thickness)
-        surface.DrawRect(x + gap, y - offset, length - gap, thickness)
-        surface.DrawRect(x - offset, y - length, thickness, length - gap)
-        surface.DrawRect(x - offset, y + gap, thickness, length - gap)
+        local client = LocalPlayer()
+        local scale = appearance.GetGlobalScale()
+        local color = appearance.SelectFocusColor(
+            client.GetRoleColor and client:GetRoleColor() or roles.INNOCENT.color
+        )
 
         draw.ShadowedText(
             TryT("binoc_zoom_level") .. ": " .. self:GetZoomAmount(),
             "TargetID_Description",
-            x + length + 10,
-            y - length,
-            hud_color,
+            mathCeil(ScrW() * 0.5) + 45 * scale,
+            mathCeil(ScrH() * 0.5) - 35 * scale,
+            color,
             TEXT_ALIGN_LEFT,
             TEXT_ALIGN_CENTER
         )


### PR DESCRIPTION
The binoculars previously had custom crosshair rendering code. It now uses the same rendering code from the base that all weapons use.

old:
![image_2024-03-08_12-11-08](https://github.com/TTT-2/TTT2/assets/13639408/9dfc2c88-2eb5-4b3a-b8af-5356ce83155c)

new (with custom color set in the settings):
![image](https://github.com/TTT-2/TTT2/assets/13639408/33eae0f5-9139-4913-b41b-480e6029b7f1)
