### PR TITLE
Crosshair: Prevent rendering GMod crosshair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 - Fixed the AFK timer accumulating while player not fully joined (by @EntranceJew)
 - Fixed the equipment menu throwing errors when clicking on some items
+- TTT2 now ignores Gmods SWEP.DrawCrosshair and always draws just its own crosshair to prevent two crosshairs at once
 
 ### Removed
 

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -363,15 +363,30 @@ if CLIENT then
             self:DrawHelp()
         end
 
-        if not cvEnableCrosshair:GetBool() then
-            return
+        self:DoDrawCrosshair(mathCeil(ScrW() * 0.5), mathCeil(ScrH() * 0.5), true)
+    end
+
+    ---
+    -- Called when the crosshair is about to get drawn, and allows you to override it.
+    -- @note This is a hook that is used to draw the crosshair. We use the function to prevent
+    -- the crosshair from being drawn and then use the same hook to draw our own custom
+    -- crosshair. The third parameter has therefore be set to true if the crosshair should
+    -- actually be drawn, otherwise the function only returns true to prevent the default one.
+    -- @param number xCenter The x center position of the crosshair
+    -- @param number yCenter The y center position of the crosshair
+    -- @param boolean shouldDraw Should the crosshair be drawn
+    -- @return boolean Return true to prevent the default crosshair from being drawn
+    -- @ref https://wiki.facepunch.com/gmod/WEAPON:DoDrawCrosshair
+    -- @hook
+    -- @realm client
+    function SWEP:DoDrawCrosshair(xCenter, yCenter, shouldDraw)
+        if not shouldDraw or not cvEnableCrosshair:GetBool() then
+            return true
         end
 
         local client = LocalPlayer()
         local sights = not self.NoSights and self:GetIronsights()
 
-        local xCenter = mathCeil(ScrW() * 0.5)
-        local yCenter = mathCeil(ScrH() * 0.5)
         local scale = appearance.GetGlobalScale()
         local baseConeWeapon = mathMax(0.2, 10 * self:GetPrimaryConeBase())
         local scaleWeapon = cvCrosshairUseWeaponscale:GetBool()
@@ -506,6 +521,8 @@ if CLIENT then
             )
             surface.DrawRect(xCenter - offsetLine, yCenter + gap, thicknessLine, lengthLine - gap)
         end
+
+        return true
     end
 
     local colorBox = Color(0, 0, 0, 100)

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbasegrenade.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbasegrenade.lua
@@ -492,11 +492,12 @@ if CLIENT then
             self:DrawHelp()
         end
 
+        local x = ScrW() * 0.5
+        local y = ScrH() * 0.5
+
         if self:GetPin() and self:GetPullTime() > 0 then
             local client = LocalPlayer()
 
-            local x = ScrW() * 0.5
-            local y = ScrH() * 0.5
             y = y + (y / 3)
 
             local pct = 1
@@ -513,7 +514,7 @@ if CLIENT then
             draw.AdvancedText(
                 TryT("grenade_fuse"),
                 "PureSkinBar",
-                x - w / 2,
+                x - 0.5 * w,
                 y - h,
                 hudTextColor,
                 TEXT_ALIGN_LEFT,
@@ -525,7 +526,7 @@ if CLIENT then
             draw.OutlinedShadowedBox(x - w / 2, y - h, w, h, scale, drawColor)
             draw.Box(x - w / 2, y - h, w * pct, h, drawColor)
         else
-            BaseClass.DrawHUD(self)
+            self:DoDrawCrosshair(x, y, true)
         end
     end
 end


### PR DESCRIPTION
This started as a fix for a bug introduced in #1464 because HUD Help was now drawn twice for grenades with HUD help. So I decided to make the crosshairq function callable, so it can be called seperately in the grenade base.

While doing so I noticed [`SWEP:DoDrawCrosshair`](https://wiki.facepunch.com/gmod/WEAPON:DoDrawCrosshair). This function is called when `SWEP.DrawCrosshair` is set to true. We have set that to false in our base, because we do not want the GMod crosshair do be visible at all. However, some weapons set this to true, probably because the SWEP author thinks setting this to false disables the TTT2 crosshair. This results in two crosshairs being drawn at once:
![image](https://github.com/TTT-2/TTT2/assets/13639408/ac2fe7b6-0a39-499f-a415-0b9263386efe)

In a perfect world we would use `SWEP:DoDrawCrosshair` to draw our own crosshair and then return `true` at the end. That way the GMod crosshair is never drawn and SWEP authors can use `SWEP.DrawCrosshair` to disable the crosshair for their weapon. However I know for a fact that there are a few weapons that explicitly set this variable to `false` which would result in no crosshair being drawn at all, even though this is not the intention.

My solution here was to use this hook to draw the crosshair and pass another variable to it. If it is called by us, the crosshair should be drawn. If it is called by the engine, the hook should just return true. This way all weapons always have a crosshair and only the TTT2 crosshair.

We could also opt to use `SWEP:DoDrawCrosshair` in its intended way hoping that those authors fix their weapons, but I think that this would cause people complaining about TTT2.