### PR TITLE
Weapons: Show trace for every bullet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - A crosshair is now also drawn when holding a nade, making it less confusing when looking at entities
 - Hides item settings in the equipment editor that are only relevant for weapons
 - The binoculars now use the default crosshair as well
-- Tracers for weapons are no longer RNG 25% chance
+- Tracers are now drawn for every shot/pellet instead of only 25% of shots/pellets
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - A crosshair is now also drawn when holding a nade, making it less confusing when looking at entities
 - Hides item settings in the equipment editor that are only relevant for weapons
 - The binoculars now use the default crosshair as well
+- Tracers for weapons are no longer RNG 25% chance
 
 ### Fixed
 

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -1045,7 +1045,7 @@ function SWEP:ShootBullet(dmg, recoil, numbul, cone)
     bullet.Src = self:GetOwner():GetShootPos()
     bullet.Dir = self:GetOwner():GetAimVector()
     bullet.Spread = Vector(cone, cone, 0)
-    bullet.Tracer = 4
+    bullet.Tracer = 1
     bullet.TracerName = self.Tracer or "Tracer"
     bullet.Force = 10
     bullet.Damage = dmg * (self.damageScaling or 1)


### PR DESCRIPTION
doesn't make sense to do a dice roll for tracers in a deduction game, why let RNG play that part?