### PR TITLE
bodysearch: TTT2GiveFoundCredits bugfix & new TTT2CanTakeCredits hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Added sounds to multiple UI interactions (can be disabled in settings: Gameplay > Client-Sounds)
 - Added a globally audible sound when searching a body
 - Added the option to add a subtitle to a marker vision element
+- Added `TTT2CanTakeCredits` hook for overriding whether a player is allowed to take credits from a given corpse. (by @Spanospy)
 
 ### Changed
 
@@ -25,6 +26,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Hides item settings in the equipment editor that are only relevant for weapons
 - The binoculars now use the default crosshair as well
 - The ConVar "ttt_debug_preventwin" will now also prevent the time limit from ending the round (by @NickCloudAT)
+- `TTT2GiveFoundCredits` hook is no longer called when checking whether a player is allowed to take credits from a given corpse. (by @Spanospy)
 
 ### Fixed
 

--- a/gamemodes/terrortown/gamemode/server/sv_player.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player.lua
@@ -1626,10 +1626,20 @@ end
 function GM:TTT2CheckCreditAward(victim, attacker) end
 
 ---
--- Use this hook to prevent the transfer of credits from a body to a player.
+-- Use this hook to override whether a given player is allowed to take credits from a given corpse.
+-- @param Player ply The player that tries to take credits
+-- @param Entity rag The ragdoll where the credits should be taken from
+-- @param[default=false] isLongRange Whether the search is a long range search
+-- @return nil|boolean Return true/false to override if the player is able to take credits
+-- @hook
+-- @realm server
+function GM:TTT2CanTakeCredits(ply, rag, isLongRange) end
+
+---
+-- Use this hook to prevent or override the transfer of credits from a corpse to a player.
 -- @param Entity rag The ragdoll that is inspected
 -- @param Player ply The @{Player} attempting to find credits from ragdoll
--- @return nil|boolean Return false to prevent transfer
+-- @return nil|boolean Return false to prevent normal transfer
 -- @hook
 -- @realm server
 function GM:TTT2GiveFoundCredits(ply, rag) end

--- a/lua/ttt2/libraries/bodysearch.lua
+++ b/lua/ttt2/libraries/bodysearch.lua
@@ -83,7 +83,6 @@ function bodysearch.CanTakeCredits(ply, rag, isLongRange)
     ---
     -- @realm shared
     -- stylua: ignore
-
     local hookOverride = hook.Run("TTT2CanTakeCredits", ply, rag, isLongRange)
     if hookOverride ~= nil then
         return hookOverride
@@ -202,6 +201,9 @@ if SERVER then
             return
         end
 
+        ---
+        -- @realm shared
+        -- stylua: ignore
         if hook.Run("TTT2GiveFoundCredits", ply, rag) == false then
             return false
         end

--- a/lua/ttt2/libraries/bodysearch.lua
+++ b/lua/ttt2/libraries/bodysearch.lua
@@ -84,8 +84,8 @@ function bodysearch.CanTakeCredits(ply, rag, isLongRange)
     -- @realm shared
     -- stylua: ignore
 
-	local hookOverride = hook.Run("TTT2CanTakeCredits", ply, rag, isLongRange)
-    if hookOverride != nil then
+    local hookOverride = hook.Run("TTT2CanTakeCredits", ply, rag, isLongRange)
+    if hookOverride ~= nil then
         return hookOverride
     end
 
@@ -202,9 +202,9 @@ if SERVER then
             return
         end
 
-		if hook.Run("TTT2GiveFoundCredits", ply, rag) == false then
-			return false
-		end
+        if hook.Run("TTT2GiveFoundCredits", ply, rag) == false then
+            return false
+        end
 
         local corpseNick = CORPSE.GetPlayerNick(rag)
         local credits = CORPSE.GetCredits(rag, 0)

--- a/lua/ttt2/libraries/bodysearch.lua
+++ b/lua/ttt2/libraries/bodysearch.lua
@@ -83,7 +83,7 @@ function bodysearch.CanTakeCredits(ply, rag, isLongRange)
     ---
     -- @realm shared
     -- stylua: ignore
-    if hook.Run("TTT2CheckFindCredits", ply, rag) == false then
+    if hook.Run("TTT2GiveFoundCredits", ply, rag) == false then
         return false
     end
 

--- a/lua/ttt2/libraries/bodysearch.lua
+++ b/lua/ttt2/libraries/bodysearch.lua
@@ -74,7 +74,7 @@ end
 
 ---
 -- Checks if a given player is allowed to take credits from a given corpse-
--- @param Payer ply The player that tries to take credits
+-- @param Player ply The player that tries to take credits
 -- @param Entity rag The ragdoll where the credits should be taken from
 -- @param[default=false] isLongRange Whether the search is a long range search
 -- @return boolean Returns if the player is able to take credits
@@ -83,8 +83,10 @@ function bodysearch.CanTakeCredits(ply, rag, isLongRange)
     ---
     -- @realm shared
     -- stylua: ignore
-    if hook.Run("TTT2GiveFoundCredits", ply, rag) == false then
-        return false
+
+	local hookOverride = hook.Run("TTT2CanTakeCredits", ply, rag, isLongRange)
+    if hookOverride != nil then
+        return hookOverride
     end
 
     local credits = CORPSE.GetCredits(rag, 0)
@@ -199,6 +201,10 @@ if SERVER then
         if bodysearch.CanTakeCredits(ply, rag, isLongRange) == false then
             return
         end
+
+		if hook.Run("TTT2GiveFoundCredits", ply, rag) == false then
+			return false
+		end
 
         local corpseNick = CORPSE.GetPlayerNick(rag)
         local credits = CORPSE.GetCredits(rag, 0)


### PR DESCRIPTION
Noticed in 9cff5af that the hook run got re-added with the old name!

Used this opportunity to re-evaluate the hook, too. Decided to split it so that the original intention of the hook is intact whilst enabling the ability to handle the side effects of the hook.