### PR TITLE
Fixed DynamicCamera breaking if a weapon's CalcView doesn't return complete values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - TTT2 now ignores Gmods SWEP.DrawCrosshair and always draws just its own crosshair to prevent two crosshairs at once
 - Fixed hud help text not being shown for some old weapons
 - Fixed detective search being overwritten by player search results
+- Fixed `DynamicCamera` error when a weapon's `CalcView` doesn't return complete values (by @TW1STaL1CKY)
 
 ### Removed
 

--- a/gamemodes/terrortown/gamemode/client/cl_main.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_main.lua
@@ -797,7 +797,11 @@ function GM:CalcView(ply, origin, angles, fov, znear, zfar)
     if IsValid(wep) then
         local func = wep.CalcView
         if func then
-            view.origin, view.angles, view.fov = func(wep, ply, origin * 1, angles * 1, fov)
+            local wepOrigin, wepAngles, wepFov = func(wep, ply, origin * 1, angles * 1, fov)
+
+            view.origin = wepOrigin or view.origin
+            view.angles = wepAngles or view.angles
+            view.fov = wepFov or view.fov
         end
     end
 


### PR DESCRIPTION
If a SWEP's CalcView function doesn't return the three expected values, DynamicCamera would spam errors and not function anymore.
This has been fixed by ensuring the active SWEP's CalcView returns valid values before giving them to DynamicCamera.