### PR TITLE
Text: Added text and nickname limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Added `TTT2CanTakeCredits` hook for overriding whether a player is allowed to take credits from a given corpse. (by @Spanospy)
 - Disabled locational voice during the preparing phase by default
   - Added a ConVar `ttt_locational_voice_prep` to reenable it
+- Added Text / Nickname length limiting and caching (by @TimGoll)
 
 ### Changed
 

--- a/gamemodes/terrortown/gamemode/client/cl_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_player_ext.lua
@@ -115,6 +115,25 @@ function plymeta:AnimUpdateGesture()
 end
 
 ---
+-- Creates and caches a elliptic nick for a given length.
+-- @param number width The maximum width that should be used to limit the nick
+-- @param[default="DefaultBold"] string font The font ID
+-- @param[default="..."] string limitChar The limiting character(s) that might be appended to the end
+-- @param[default=1.0] number scale The UI scale factor
+-- @return string The length limited nick
+-- @realm client
+function plymeta:NickElliptic(width, font, limitChar, scale)
+    limitChar = limitChar or "..."
+
+    self.cachedEllipticNicks = self.cachedEllipticNicks or {}
+
+    self.cachedEllipticNicks[width] = self.cachedEllipticNicks[width]
+        or draw.GetLimitedLengthText(self:Nick(), width, font, limitChar, scale)
+
+    return self.cachedEllipticNicks[width]
+end
+
+---
 -- @hook
 -- @param Player ply The player to update the animation info for.
 -- @param Vector vel The player's velocity.

--- a/lua/ttt2/extensions/draw.lua
+++ b/lua/ttt2/extensions/draw.lua
@@ -678,6 +678,35 @@ function draw.GetTextSize(text, font, scale)
     return w * scale, h * scale
 end
 
+---
+-- Creates a text that is limited to the provided length. Adds a limiting chat (e.g. '...') after the
+-- text if so desired.
+-- @param string text The text that may be limited in length
+-- @param number width The maximum width that should be used to limit the text
+-- @param[default="DefaultBold"] string font The font ID
+-- @param[opt] string limitChar The limiting character(s) that might be appended to the end
+-- @param[default=1.0] number scale The UI scale factor
+-- @return string The length limited text
+-- @realm client
+function draw.GetLimitedLengthText(text, width, font, limitChar, scale)
+    scale = scale or 1.0
+
+    local widthText = draw.GetTextSize(text, font, scale)
+
+    if widthText <= width then
+        return text
+    end
+
+    if limitChar and limitChar ~= "" then
+        width = width - draw.GetTextSize(limitChar, font, scale)
+    end
+
+    -- we use this function here that splits the text in multiple lines
+    local lines = InternalSplitLongWord(text, width, widthText)
+
+    return lines[1] .. (limitChar or "")
+end
+
 local cachedArcs = {}
 
 -- Generates an arc out of triangles that is cached in a table to reduce rendering time


### PR DESCRIPTION
Adds the following two functions to the game:

```lua
---
-- Creates a text that is limited to the provided length. Adds a limiting chat (e.g. '...') after the
-- text if so desired.
-- @param string text The text that may be limited in length
-- @param number width The maximum width that should be used to limit the text
-- @param[default="DefaultBold"] string font The font ID
-- @param[opt] string limitChar The limiting character(s) that might be appended to the end
-- @param[default=1.0] number scale The UI scale factor
-- @return string The length limited text
-- @realm client
function draw.GetLimitedLengthText(text, width, font, limitChar, scale)
```

```lua
---
-- Creates and caches a elliptic nick for a given length.
-- @param number width The maximum width that should be used to limit the nick
-- @param[default="DefaultBold"] string font The font ID
-- @param[default="..."] string limitChar The limiting character(s) that might be appended to the end
-- @param[default=1.0] number scale The UI scale factor
-- @return string The length limited nick
-- @realm client
function plymeta:NickElliptic(width, font, limitChar, scale)
```

These can be used to limit text / nickname to a given maximum length, while also adding a limiting character.

**Example:**

```lua
print(LocalPlayer():NickElliptic(50, "DefaultBold", "", 1.0))

>>> "Tim | Mi"
```