### PR TITLE
Corpse: Corpse velocity can now be properly overridden using TTT2ModifyRagdollVelocity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Tracers are now drawn for every shot/pellet instead of only 25% of shots/pellets
 - The ConVar "ttt_debug_preventwin" will now also prevent the time limit from ending the round (by @NickCloudAT)
 - `TTT2GiveFoundCredits` hook is no longer called when checking whether a player is allowed to take credits from a given corpse. (by @Spanospy)
+- `TTT2ModifyRagdollVelocity` hook now supports returning a vector to properly override a created corpse's velocity (by @TW1STaL1CKY)
 - Micro optimizations
   - switched from `player.GetAll()` to `select(2, player.Iterator())`
   - use `net.ReadPlayer` / `net.WritePlayer` if applicable instead of `net.Read|WriteEntity`

--- a/gamemodes/terrortown/gamemode/server/sv_corpse.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_corpse.lua
@@ -556,7 +556,7 @@ function CORPSE.Create(ply, attacker, dmginfo)
     ---
     -- @realm server
     -- stylua: ignore
-    hook.Run("TTT2ModifyRagdollVelocity", ply, rag, v)
+    v = hook.Run("TTT2ModifyRagdollVelocity", ply, rag, v) or v
 
     for i = 0, num do
         local bone = rag:GetPhysicsObjectNum(i)


### PR DESCRIPTION
With this fun little change, a corpse's initial velocity can be properly overridden by returning a vector in a TTT2ModifyRagdollVelocity hook.