### PR TITLE
Add convar to prevent players without credits from being able to see credits on a body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Added `TTT2CanTakeCredits` hook for overriding whether a player is allowed to take credits from a given corpse. (by @Spanospy)
 - Disabled locational voice during the preparing phase by default
   - Added a ConVar `ttt_locational_voice_prep` to reenable it
+- Added a convar `ttt2_inspect_credits_always_visible` to control whether credits are visible to players that do not have a shop
 
 ### Changed
 

--- a/lua/terrortown/lang/en.lua
+++ b/lua/terrortown/lang/en.lua
@@ -1523,6 +1523,7 @@ L.label_roles_max_roles_pct = "Upper role limit by percentage"
 L.label_roles_max_baseroles = "Upper base role limit"
 L.label_roles_max_baseroles_pct = "Upper base role limit by percentage"
 L.label_detective_hats = "Enable hats for policing roles like the Detective (if player model allows to have them)"
+L.label_inspect_credits_always = "Allow all players to see credits on dead bodies"
 
 L.ttt2_desc_innocent = "An Innocent has no special abilities. They have to find the evil ones among the terrorists and kill them. But they have to be careful not to kill their teammates."
 L.ttt2_desc_traitor = "The Traitor is the enemy of the Innocent. They have an equipment menu with which they are being able to buy special equipment. They have to kill everyone but their teammates."
@@ -1545,6 +1546,10 @@ L.help_detective_hats = [[
 Policing roles such as the Detective may wear hats to show their authority. They lose them on death or if damaged at the head.
 
 Some player models do not support hats by default. This can be changed in 'Administration' -> 'Player Models']]
+L.help_inspect_credits_always = [[
+When players with credits (detectives, traitors, survivalist, etc.) die, their credits can be picked up by other players that can use credits. 
+
+When this option is disabled, only players that can pick up credits can see them on the body.]]
 
 L.label_roles_credits_award_kill = "Credit reward amount for the kill"
 L.label_roles_credits_dead_award = "Enable credits award for certain percentage of dead enemies"

--- a/lua/terrortown/lang/en.lua
+++ b/lua/terrortown/lang/en.lua
@@ -1523,7 +1523,6 @@ L.label_roles_max_roles_pct = "Upper role limit by percentage"
 L.label_roles_max_baseroles = "Upper base role limit"
 L.label_roles_max_baseroles_pct = "Upper base role limit by percentage"
 L.label_detective_hats = "Enable hats for policing roles like the Detective (if player model allows to have them)"
-L.label_inspect_credits_always = "Allow all players to see credits on dead bodies"
 
 L.ttt2_desc_innocent = "An Innocent has no special abilities. They have to find the evil ones among the terrorists and kill them. But they have to be careful not to kill their teammates."
 L.ttt2_desc_traitor = "The Traitor is the enemy of the Innocent. They have an equipment menu with which they are being able to buy special equipment. They have to kill everyone but their teammates."
@@ -1546,10 +1545,6 @@ L.help_detective_hats = [[
 Policing roles such as the Detective may wear hats to show their authority. They lose them on death or if damaged at the head.
 
 Some player models do not support hats by default. This can be changed in 'Administration' -> 'Player Models']]
-L.help_inspect_credits_always = [[
-When players with credits (detectives, traitors, survivalist, etc.) die, their credits can be picked up by other players that can use credits. 
-
-When this option is disabled, only players that can pick up credits can see them on the body.]]
 
 L.label_roles_credits_award_kill = "Credit reward amount for the kill"
 L.label_roles_credits_dead_award = "Enable credits award for certain percentage of dead enemies"
@@ -2231,3 +2226,11 @@ L.help_voice_duck_spectator = "Ducking spectators makes other spectators quieter
 L.help_locational_voice_range = [[This convar constrains the maximum range at which players can hear each other. It does not change how the volume decreases with distance but rather sets a hard cut-off point.
 
 Set to 0 to disable this cut-off.]]
+
+-- 2024-04-08
+L.label_inspect_credits_always = "Allow all players to see credits on dead bodies"
+L.help_inspect_credits_always = [[
+When shopping roles die, their credits can be picked up by other players with shopping roles.
+
+When this option is disabled, only players that can pick up credits can see them on a body.
+When enabled, all players can see credits on a body.]]

--- a/lua/terrortown/menus/gamemode/administration/roles.lua
+++ b/lua/terrortown/menus/gamemode/administration/roles.lua
@@ -123,11 +123,11 @@ function CLGAMEMODESUBMENU:Populate(parent)
     })
 
     form3:MakeHelp({
-        label = "help_inspect_credits_always"
+        label = "help_inspect_credits_always",
     })
 
     form3:MakeCheckBox({
         serverConvar = "ttt2_inspect_credits_always_visible",
-        label = "label_inspect_credits_always"
+        label = "label_inspect_credits_always",
     })
 end

--- a/lua/terrortown/menus/gamemode/administration/roles.lua
+++ b/lua/terrortown/menus/gamemode/administration/roles.lua
@@ -121,4 +121,13 @@ function CLGAMEMODESUBMENU:Populate(parent)
         serverConvar = "ttt_detective_hats",
         label = "label_detective_hats",
     })
+
+    form3:MakeHelp({
+        label = "help_inspect_credits_always"
+    })
+
+    form3:MakeCheckBox({
+        serverConvar = "ttt2_inspect_credits_always_visible",
+        label = "label_inspect_credits_always"
+    })
 end

--- a/lua/ttt2/libraries/bodysearch.lua
+++ b/lua/ttt2/libraries/bodysearch.lua
@@ -747,7 +747,7 @@ if CLIENT then
             -- special case: mode 2, only shopping roles can see credits
             local client = LocalPlayer()
             if
-                (cvInspectConfirmMode:GetInt() == 2 or cvCreditsVisibleToAll:GetInt() == 0)
+                (cvInspectConfirmMode:GetInt() == 2 or not cvCreditsVisibleToAll:GetBool())
                 and not bodysearch.CanTakeCredits(client, data.rag)
             then
                 return

--- a/lua/ttt2/libraries/bodysearch.lua
+++ b/lua/ttt2/libraries/bodysearch.lua
@@ -65,6 +65,7 @@ local cvInspectConfirmMode = CreateConVar("ttt2_inspect_confirm_mode", "0", {FCV
 -- on (1), default: all roles can see credits on a body
 -- NOTE: On is default only for compatability. Many players seem to expect it to not be the case by default,
 --       so perhaps it'd be a good idea to default to off.
+-- stylua: ignore
 local cvCreditsVisibleToAll = CreateConVar("ttt2_inspect_credits_always_visible", "1", {FCVAR_NOTIFY, FCVAR_ARCHIVE, FCVAR_REPLICATED})
 
 local materialWeaponFallback = Material("vgui/ttt/missing_equip_icon")

--- a/lua/ttt2/libraries/bodysearch.lua
+++ b/lua/ttt2/libraries/bodysearch.lua
@@ -59,6 +59,14 @@ CORPSE_KILL_DIRECTION_SIDE = 3
 -- stylua: ignore
 local cvInspectConfirmMode = CreateConVar("ttt2_inspect_confirm_mode", "0", {FCVAR_NOTIFY, FCVAR_ARCHIVE, FCVAR_REPLICATED})
 
+---
+-- @realm shared
+-- off (0): only roles which have a shop can see credits on a body
+-- on (1), default: all roles can see credits on a body
+-- NOTE: On is default only for compatability. Many players seem to expect it to not be the case by default,
+--       so perhaps it'd be a good idea to default to off.
+local cvCreditsVisibleToAll = CreateConVar("ttt2_inspect_credits_always_visible", "1", {FCVAR_NOTIFY, FCVAR_ARCHIVE, FCVAR_REPLICATED})
+
 local materialWeaponFallback = Material("vgui/ttt/missing_equip_icon")
 
 bodysearch = {}
@@ -738,7 +746,7 @@ if CLIENT then
             -- special case: mode 2, only shopping roles can see credits
             local client = LocalPlayer()
             if
-                cvInspectConfirmMode:GetInt() == 2
+                (cvInspectConfirmMode:GetInt() == 2 or cvCreditsVisibleToAll:GetInt() == 0)
                 and not bodysearch.CanTakeCredits(client, data.rag)
             then
                 return


### PR DESCRIPTION
The one question left for this is whether to change the default. Currently, this PR defaults to the previous behavior (all players can see credits, except in mode 2), but it seems to me like player expectations would favor not seeing credits by default.