### PR TITLE
Add multiple voice chat activation modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
   - Added a ConVar `ttt_locational_voice_prep` to reenable it
 - Added Text / Nickname length limiting (by @TimGoll)
 - Added `ttt_locational_voice_range` to set a cut-off radius for the locational voice chat range 
+- Added multiple voice chat activation modes for clients to choose from (Gameplay > Voice & Volume):
+  - Push-to-Talk (default)
+  - Push-to-Mute
+  - Toggle
+  - Toggle (Activate on Join)
 
 ### Changed
 

--- a/gamemodes/terrortown/gamemode/client/cl_voice.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_voice.lua
@@ -44,7 +44,7 @@ local scaling_mode = CreateConVar("ttt2_voice_scaling", "linear", {FCVAR_ARCHIVE
 ---
 -- @realm client
 -- stylua: ignore
-local cvVoiceActivationMode = CreateConVar("ttt2_voice_activation", "0", {FCVAR_ARCHIVE})
+local cvVoiceActivationMode = CreateConVar("ttt2_voice_activation", "ptt", {FCVAR_ARCHIVE})
 
 local function CreateVoiceTable()
     if not sql.TableExists("ttt2_voice") then
@@ -55,6 +55,18 @@ local function CreateVoiceTable()
 end
 
 CreateVoiceTable()
+
+local function ComboBoxChoicesFromKeys(tbl, labelPrefix, default)
+    local choices = {}
+    for key in pairs(tbl) do
+        choices[#choices + 1] = {
+            title = LANG.TryTranslation(labelPrefix .. key),
+            value = key,
+            select = key == default,
+        }
+    end
+    return choices
+end
 
 local function VoiceTryEnable()
     if not VOICE.IsSpeaking() and VOICE.CanSpeak() and VOICE.CanEnable() then
@@ -77,25 +89,6 @@ local function VoiceTryDisable()
     return false
 end
 
--- TODO This does not belong here
----
--- @param table tbl A table with all available choices as string keys
--- @param string labelPrefix The prefix for all label translations
--- @param string default The default value
--- @return table A choices table for MakeComboBox
--- @realm client
-function VOICE.ComboBoxChoicesFromKeys(tbl, labelPrefix, default)
-    local choices = {}
-    for key in pairs(tbl) do
-        choices[#choices + 1] = {
-            title = LANG.TryTranslation(labelPrefix .. key),
-            value = key,
-            select = key == default,
-        }
-    end
-    return choices
-end
-
 local function VoiceToggle()
     if VOICE.IsSpeaking() then
         return VoiceTryDisable()
@@ -111,7 +104,7 @@ VOICE.ActivationModes = {
     toggle_enabled = { OnPressed = VoiceToggle, OnJoin = VoiceTryEnable },
 }
 
-VOICE.ActivationModeChoices = VOICE.ComboBoxChoicesFromKeys(
+VOICE.ActivationModeChoices = ComboBoxChoicesFromKeys(
     VOICE.ActivationModes,
     "label_voice_activation_mode_",
     cvVoiceActivationMode:GetString()
@@ -559,7 +552,7 @@ VOICE.ScalingFunctions = {
     linear = VOICE.LinearToLinear,
 }
 
-VOICE.ScalingFunctionChoices = VOICE.ComboBoxChoicesFromKeys(
+VOICE.ScalingFunctionChoices = ComboBoxChoicesFromKeys(
     VOICE.ScalingFunctions,
     "label_voice_scaling_mode_",
     scaling_mode:GetString()

--- a/gamemodes/terrortown/gamemode/client/cl_voice.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_voice.lua
@@ -26,25 +26,27 @@ local MutedState
 
 g_VoicePanelList = nil
 
----
--- @realm client
--- stylua: ignore
-local cvDuckSpectator = CreateConVar("ttt2_voice_duck_spectator", "0", {FCVAR_ARCHIVE})
+VOICE.cv = {
+    ---
+    -- @realm client
+    -- stylua: ignore
+    duck_spectator = CreateConVar("ttt2_voice_duck_spectator", "0", {FCVAR_ARCHIVE}),
 
----
--- @realm client
--- stylua: ignore
-local cvDuckSpectatorAmount = CreateConVar("ttt2_voice_cvDuckSpectator_amount", "0", {FCVAR_ARCHIVE})
+    ---
+    -- @realm client
+    -- stylua: ignore
+    duck_spectator_amount = CreateConVar("ttt2_voice_cvDuckSpectator_amount", "0", {FCVAR_ARCHIVE}),
 
----
--- @realm client
--- stylua: ignore
-local scaling_mode = CreateConVar("ttt2_voice_scaling", "linear", {FCVAR_ARCHIVE})
+    ---
+    -- @realm client
+    -- stylua: ignore
+    scaling_mode = CreateConVar("ttt2_voice_scaling", "linear", {FCVAR_ARCHIVE}),
 
----
--- @realm client
--- stylua: ignore
-local cvVoiceActivationMode = CreateConVar("ttt2_voice_activation", "ptt", {FCVAR_ARCHIVE})
+    ---
+    -- @realm client
+    -- stylua: ignore
+    activation_mode = CreateConVar("ttt2_voice_activation", "ptt", {FCVAR_ARCHIVE}),
+}
 
 local function CreateVoiceTable()
     if not sql.TableExists("ttt2_voice") then
@@ -92,12 +94,6 @@ VOICE.ActivationModes = {
     toggle_enabled = { OnPressed = VoiceToggle, OnJoin = VoiceTryEnable },
 }
 
-VOICE.ActivationModeChoices = util.ComboBoxChoicesFromKeys(
-    VOICE.ActivationModes,
-    "label_voice_activation_mode_",
-    cvVoiceActivationMode:GetString()
-)
-
 ---
 -- Creates a closure that dynamically calls a function from VOICE.ActivationModes depending on the current mode.
 -- @param string func The name of the function to call on the current voice activation mode
@@ -105,7 +101,7 @@ VOICE.ActivationModeChoices = util.ComboBoxChoicesFromKeys(
 -- @realm client
 function VOICE.ActivationModeFunc(functionName)
     return function()
-        local mode = VOICE.ActivationModes[cvVoiceActivationMode:GetString()]
+        local mode = VOICE.ActivationModes[VOICE.cv.activation_mode:GetString()]
         if istable(mode) and isfunction(mode[functionName]) then
             return mode[functionName]()
         end
@@ -541,12 +537,6 @@ VOICE.ScalingFunctions = {
     linear = VOICE.LinearToLinear,
 }
 
-VOICE.ScalingFunctionChoices = util.ComboBoxChoicesFromKeys(
-    VOICE.ScalingFunctions,
-    "label_voice_scaling_mode_",
-    scaling_mode:GetString()
-)
-
 ---
 -- Gets the stored volume for the player's voice.
 -- @param Player ply
@@ -616,12 +606,12 @@ function VOICE.UpdatePlayerVoiceVolume(ply)
     end
 
     local vol = VOICE.GetPreferredPlayerVoiceVolume(ply)
-    if cvDuckSpectator:GetBool() and ply:IsSpec() then
-        vol = vol * (1 - cvDuckSpectatorAmount:GetFloat())
+    if VOICE.cv.duck_spectator:GetBool() and ply:IsSpec() then
+        vol = vol * (1 - VOICE.cv.duck_spectator_amount:GetFloat())
     end
     local out_vol = vol
 
-    local func = VOICE.ScalingFunctions[scaling_mode:GetString()]
+    local func = VOICE.ScalingFunctions[VOICE.cv.scaling_mode:GetString()]
     if isfunction(func) then
         out_vol = func(vol)
     end

--- a/gamemodes/terrortown/gamemode/client/cl_voice.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_voice.lua
@@ -56,18 +56,6 @@ end
 
 CreateVoiceTable()
 
-local function ComboBoxChoicesFromKeys(tbl, labelPrefix, default)
-    local choices = {}
-    for key in pairs(tbl) do
-        choices[#choices + 1] = {
-            title = LANG.TryTranslation(labelPrefix .. key),
-            value = key,
-            select = key == default,
-        }
-    end
-    return choices
-end
-
 local function VoiceTryEnable()
     if not VOICE.IsSpeaking() and VOICE.CanSpeak() and VOICE.CanEnable() then
         VOICE.isTeam = false
@@ -104,7 +92,7 @@ VOICE.ActivationModes = {
     toggle_enabled = { OnPressed = VoiceToggle, OnJoin = VoiceTryEnable },
 }
 
-VOICE.ActivationModeChoices = ComboBoxChoicesFromKeys(
+VOICE.ActivationModeChoices = util.ComboBoxChoicesFromKeys(
     VOICE.ActivationModes,
     "label_voice_activation_mode_",
     cvVoiceActivationMode:GetString()
@@ -552,7 +540,7 @@ VOICE.ScalingFunctions = {
     linear = VOICE.LinearToLinear,
 }
 
-VOICE.ScalingFunctionChoices = ComboBoxChoicesFromKeys(
+VOICE.ScalingFunctionChoices = util.ComboBoxChoicesFromKeys(
     VOICE.ScalingFunctions,
     "label_voice_scaling_mode_",
     scaling_mode:GetString()

--- a/gamemodes/terrortown/gamemode/client/cl_voice.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_voice.lua
@@ -99,19 +99,20 @@ VOICE.ActivationModeChoices = util.ComboBoxChoicesFromKeys(
 )
 
 ---
+-- Creates a closure that dynamically calls a function from VOICE.ActivationModes depending on the current mode.
 -- @param string func The name of the function to call on the current voice activation mode
--- @return function A closure that calls the function on the current voice activation mode if it exists
+-- @return function A closure that calls the function on the current voice activation mode, if it exists
 -- @realm client
-function VOICE.ActivationModeFunc(func)
+function VOICE.ActivationModeFunc(functionName)
     return function()
         local mode = VOICE.ActivationModes[cvVoiceActivationMode:GetString()]
-        if istable(mode) and isfunction(mode[func]) then
-            return mode[func]()
+        if istable(mode) and isfunction(mode[functionName]) then
+            return mode[functionName]()
         end
     end
 end
 
-hook.Add("InitPostEntity", "TTT2ActivateVoiceChat", VOICE.ActivationModeFunc("OnJoin"))
+hook.Add("TTT2FinishedLoading", "TTT2ActivateVoiceChat", VOICE.ActivationModeFunc("OnJoin"))
 
 local function VoiceTeamTryEnable()
     if not VOICE.IsSpeaking() and VOICE.CanSpeak() and VOICE.CanTeamEnable() then

--- a/gamemodes/terrortown/gamemode/client/cl_voice.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_voice.lua
@@ -78,9 +78,15 @@ local function VoiceTryDisable()
 end
 
 -- TODO This does not belong here
-function VOICE.ComboBoxChoicesFromKeys(choiceMap, labelPrefix, default)
+---
+-- @param table tbl A table with all available choices as string keys
+-- @param string labelPrefix The prefix for all label translations
+-- @param string default The default value
+-- @return table A choices table for MakeComboBox
+-- @realm client
+function VOICE.ComboBoxChoicesFromKeys(tbl, labelPrefix, default)
     local choices = {}
-    for key in pairs(choiceMap) do
+    for key in pairs(tbl) do
         choices[#choices + 1] = {
             title = LANG.TryTranslation(labelPrefix .. key),
             value = key,
@@ -111,6 +117,10 @@ VOICE.ActivationModeChoices = VOICE.ComboBoxChoicesFromKeys(
     cvVoiceActivationMode:GetString()
 )
 
+---
+-- @param string func The name of the function to call on the current voice activation mode
+-- @return function A closure that calls the function on the current voice activation mode if it exists
+-- @realm client
 function VOICE.ActivationModeFunc(func)
     return function()
         local mode = VOICE.ActivationModes[cvVoiceActivationMode:GetString()]

--- a/lua/terrortown/lang/de.lua
+++ b/lua/terrortown/lang/de.lua
@@ -2227,10 +2227,10 @@ L.help_voice_activation = [[Stellt ein, wie dein Mikro für den globalen Sprachc
 
 Push-to-Talk: Halte die Taste gedrückt, um zu sprechen.
 Push-to-Mute: Dein Mikro ist immer an, halte die Taste gedrückt um dich stumm zu stellen.
-Toggle: Drücke einmal die Taste, um dein Mikro an-/auszuschalten.
-Toggle (Aktiviere bei Beitritt): Wie 'Toggle', zusätzlich wird dein Mikro beim Server-Beitritt angeschaltet.]]
-L.label_voice_activation = "Voice Chat Activation Mode"
+Umschalten: Drücke einmal die Taste, um dein Mikro an-/auszuschalten.
+Umschalten (Aktiviert zum Start): Wie 'Umschalten', zusätzlich wird dein Mikro beim Server-Beitritt angeschaltet.]]
+L.label_voice_activation = "Sprachchat Aktivierungsmodus"
 L.label_voice_activation_mode_ptt = "Push-to-Talk"
 L.label_voice_activation_mode_ptm = "Push-to-Mute"
-L.label_voice_activation_mode_toggle_disabled = "Toggle"
-L.label_voice_activation_mode_toggle_enabled = "Toggle (Activate on Join)"
+L.label_voice_activation_mode_toggle_disabled = "Umschalten"
+L.label_voice_activation_mode_toggle_enabled = "Umschalten (Aktiviert zum Start)"

--- a/lua/terrortown/lang/de.lua
+++ b/lua/terrortown/lang/de.lua
@@ -2221,3 +2221,16 @@ L.throw_no_room = "Hier ist kein Platz, um dieses Gerät zu werfen."
 --
 --Note: Proximity chat is always disabled during the post round phase.]]
 --L.help_voice_duck_spectator = "Ducking spectators makes other spectators quieter in comparison to living players. This can be useful if one wants to listen closely to the discussions of the living players."
+
+-- 2024-04-07
+L.help_voice_activation = [[Stellt ein, wie dein Mikro für den globalen Sprachchat aktiviert wird. Alle Optionen nutzen deine "Globaler Sprachchat"-Taste. Der Team Sprachchat nutzt immer always Push-to-Talk.
+
+Push-to-Talk: Halte die Taste gedrückt, um zu sprechen.
+Push-to-Mute: Dein Mikro ist immer an, halte die Taste gedrückt um dich stumm zu stellen.
+Toggle: Drücke einmal die Taste, um dein Mikro an-/auszuschalten.
+Toggle (Aktiviere bei Beitritt): Wie "Toggle", zusätzlich wird dein Mikro beim Server-Beitritt angeschaltet.]]
+L.label_voice_activation = "Voice Chat Activation Mode"
+L.label_voice_activation_mode_ptt = "Push-to-Talk"
+L.label_voice_activation_mode_ptm = "Push-to-Mute"
+L.label_voice_activation_mode_toggle_disabled = "Toggle"
+L.label_voice_activation_mode_toggle_enabled = "Toggle (Activate on Join)"

--- a/lua/terrortown/lang/de.lua
+++ b/lua/terrortown/lang/de.lua
@@ -2223,12 +2223,12 @@ L.throw_no_room = "Hier ist kein Platz, um dieses Gerät zu werfen."
 --L.help_voice_duck_spectator = "Ducking spectators makes other spectators quieter in comparison to living players. This can be useful if one wants to listen closely to the discussions of the living players."
 
 -- 2024-04-07
-L.help_voice_activation = [[Stellt ein, wie dein Mikro für den globalen Sprachchat aktiviert wird. Alle Optionen nutzen deine "Globaler Sprachchat"-Taste. Der Team Sprachchat nutzt immer always Push-to-Talk.
+L.help_voice_activation = [[Stellt ein, wie dein Mikro für den globalen Sprachchat aktiviert wird. Alle Optionen nutzen deine 'Globaler Sprachchat'-Taste. Der Team Sprachchat nutzt immer always Push-to-Talk.
 
 Push-to-Talk: Halte die Taste gedrückt, um zu sprechen.
 Push-to-Mute: Dein Mikro ist immer an, halte die Taste gedrückt um dich stumm zu stellen.
 Toggle: Drücke einmal die Taste, um dein Mikro an-/auszuschalten.
-Toggle (Aktiviere bei Beitritt): Wie "Toggle", zusätzlich wird dein Mikro beim Server-Beitritt angeschaltet.]]
+Toggle (Aktiviere bei Beitritt): Wie 'Toggle', zusätzlich wird dein Mikro beim Server-Beitritt angeschaltet.]]
 L.label_voice_activation = "Voice Chat Activation Mode"
 L.label_voice_activation_mode_ptt = "Push-to-Talk"
 L.label_voice_activation_mode_ptm = "Push-to-Mute"

--- a/lua/terrortown/lang/en.lua
+++ b/lua/terrortown/lang/en.lua
@@ -2226,3 +2226,16 @@ L.help_voice_duck_spectator = "Ducking spectators makes other spectators quieter
 L.help_locational_voice_range = [[This convar constrains the maximum range at which players can hear each other. It does not change how the volume decreases with distance but rather sets a hard cut-off point.
 
 Set to 0 to disable this cut-off.]]
+
+-- 2024-04-07
+L.help_voice_activation = [[Changes the way your microphone is activated for global voice chat. These all use your "Global Voice Chat" keybinding. Team voice chat is always push-to-talk.
+
+Push-to-Talk: Hold down the key to talk.
+Push-to-Mute: Your mic is always on, hold down the key to mute yourself.
+Toggle: Press the key to toggle your mic on/off.
+Toggle (Activate on Join): Like "Toggle" but your mic gets activated when joining the server.]]
+L.label_voice_activation = "Voice Chat Activation Mode"
+L.label_voice_activation_mode_ptt = "Push to Talk"
+L.label_voice_activation_mode_ptm = "Push to Mute"
+L.label_voice_activation_mode_toggle_disabled = "Toggle"
+L.label_voice_activation_mode_toggle_enabled = "Toggle (Activate on Join)"

--- a/lua/terrortown/lang/en.lua
+++ b/lua/terrortown/lang/en.lua
@@ -2228,12 +2228,12 @@ L.help_locational_voice_range = [[This convar constrains the maximum range at wh
 Set to 0 to disable this cut-off.]]
 
 -- 2024-04-07
-L.help_voice_activation = [[Changes the way your microphone is activated for global voice chat. These all use your "Global Voice Chat" keybinding. Team voice chat is always push-to-talk.
+L.help_voice_activation = [[Changes the way your microphone is activated for global voice chat. These all use your 'Global Voice Chat' keybinding. Team voice chat is always push-to-talk.
 
 Push-to-Talk: Hold down the key to talk.
 Push-to-Mute: Your mic is always on, hold down the key to mute yourself.
 Toggle: Press the key to toggle your mic on/off.
-Toggle (Activate on Join): Like "Toggle" but your mic gets activated when joining the server.]]
+Toggle (Activate on Join): Like 'Toggle' but your mic gets activated when joining the server.]]
 L.label_voice_activation = "Voice Chat Activation Mode"
 L.label_voice_activation_mode_ptt = "Push to Talk"
 L.label_voice_activation_mode_ptm = "Push to Mute"

--- a/lua/terrortown/menus/gamemode/gameplay/voiceandvolume.lua
+++ b/lua/terrortown/menus/gamemode/gameplay/voiceandvolume.lua
@@ -9,6 +9,17 @@ CLGAMEMODESUBMENU.icon = Material("vgui/ttt/vskin/helpscreen/voiceandvolume")
 function CLGAMEMODESUBMENU:Populate(parent)
     local form = vgui.CreateTTT2Form(parent, "header_voiceandvolume_settings")
 
+    form:MakeHelp({
+        label = "help_voice_activation"
+    })
+
+    form:MakeComboBox({
+        label = "label_voice_activation",
+        convar = "ttt2_voice_activation",
+        choices = VOICE.ActivationModeChoices,
+        OnChange = VOICE.ActivationModeFunc("OnJoin")
+    })
+
     form:MakeCheckBox({
         label = "label_gameplay_mute",
         convar = "ttt_mute_team_check",
@@ -17,7 +28,7 @@ function CLGAMEMODESUBMENU:Populate(parent)
     form:MakeComboBox({
         label = "label_voice_scaling",
         convar = "ttt2_voice_scaling",
-        choices = VOICE.GetScalingFunctions(),
+        choices = VOICE.ScalingFunctionChoices,
         OnChange = function()
             for _, ply in ipairs(select(2, player.Iterator())) do
                 VOICE.UpdatePlayerVoiceVolume(ply)

--- a/lua/terrortown/menus/gamemode/gameplay/voiceandvolume.lua
+++ b/lua/terrortown/menus/gamemode/gameplay/voiceandvolume.lua
@@ -10,14 +10,14 @@ function CLGAMEMODESUBMENU:Populate(parent)
     local form = vgui.CreateTTT2Form(parent, "header_voiceandvolume_settings")
 
     form:MakeHelp({
-        label = "help_voice_activation"
+        label = "help_voice_activation",
     })
 
     form:MakeComboBox({
         label = "label_voice_activation",
         convar = "ttt2_voice_activation",
         choices = VOICE.ActivationModeChoices,
-        OnChange = VOICE.ActivationModeFunc("OnJoin")
+        OnChange = VOICE.ActivationModeFunc("OnJoin"),
     })
 
     form:MakeCheckBox({

--- a/lua/terrortown/menus/gamemode/gameplay/voiceandvolume.lua
+++ b/lua/terrortown/menus/gamemode/gameplay/voiceandvolume.lua
@@ -16,7 +16,11 @@ function CLGAMEMODESUBMENU:Populate(parent)
     form:MakeComboBox({
         label = "label_voice_activation",
         convar = "ttt2_voice_activation",
-        choices = VOICE.ActivationModeChoices,
+        choices = util.ComboBoxChoicesFromKeys(
+            VOICE.ActivationModes,
+            "label_voice_activation_mode_",
+            VOICE.cv.activation_mode:GetString()
+        ),
         OnChange = VOICE.ActivationModeFunc("OnJoin"),
     })
 
@@ -28,7 +32,11 @@ function CLGAMEMODESUBMENU:Populate(parent)
     form:MakeComboBox({
         label = "label_voice_scaling",
         convar = "ttt2_voice_scaling",
-        choices = VOICE.ScalingFunctionChoices,
+        choices = util.ComboBoxChoicesFromKeys(
+            VOICE.ScalingFunctions,
+            "label_voice_scaling_mode_",
+            VOICE.cv.scaling_mode:GetString()
+        ),
         OnChange = function()
             for _, ply in ipairs(select(2, player.Iterator())) do
                 VOICE.UpdatePlayerVoiceVolume(ply)

--- a/lua/ttt2/extensions/util.lua
+++ b/lua/ttt2/extensions/util.lua
@@ -673,4 +673,23 @@ if CLIENT then
 
         return parent
     end
+
+    ---
+    -- Generates a table of choices for PANEL:MakeComboBox from the string keys of a table
+    -- @param table tbl A table where the keys are strings of all available choices
+    -- @param string labelPrefix The prefix for all label translations, keys will be appended to this
+    -- @param string default The default key value that should be selected
+    -- @return table A choices table to be consumed by PANEL:MakeComboBox
+    -- @realm client
+    function util.ComboBoxChoicesFromKeys(tbl, labelPrefix, default)
+        local choices = {}
+        for key in pairs(tbl) do
+            choices[#choices + 1] = {
+                title = LANG.TryTranslation(labelPrefix .. key),
+                value = key,
+                select = key == default,
+            }
+        end
+        return choices
+    end
 end

--- a/lua/ttt2/extensions/util.lua
+++ b/lua/ttt2/extensions/util.lua
@@ -675,7 +675,7 @@ if CLIENT then
     end
 
     ---
-    -- Generates a table of choices for PANEL:MakeComboBox from the string keys of a table
+    -- Generates a table of choices for PANEL:MakeComboBox from the string keys of a table.
     -- @param table tbl A table where the keys are strings of all available choices
     -- @param string labelPrefix The prefix for all label translations, keys will be appended to this
     -- @param string default The default key value that should be selected


### PR DESCRIPTION
- Push-to-Talk (default)
- Push-to-Mute
- Toggle
- Toggle (Activate on Join)

### Things left to do that should probably be new PRs:
- Investigate how keeping voice chat activated interacts with rounds starting/ending
  - The voice chat color should update accordingly. HUD-related changes should probably wait for #1473 though
  - I think voice chat might currently get disabled once on round start (but your voice panel keeps being shown)
- Improve how team voice chat interacts with modes other than push-to-talk
  - I didn't touch the TeamVoice functions which means that currently team voice can only be activated while global voice is off which is obviously silly for PTM/Toggle
- (Maybe have separate sections (forms) for input and output settings in the Voice & Volume menu)
- (Move ComboBoxChoicesFromKeys somewhere else since it's just a form creation utility function)