### PR TITLE
Bugfix: Fixed weapon FOV issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed detective search being overwritten by player search results
 - Fixed `DynamicCamera` error when a weapon's `CalcView` doesn't return complete values (by @TW1STaL1CKY)
 - Fixed Roundendscreen showing karma changes even if karma is disabled
+- Fixed the player's FOV staying zoomed in if their weapon is removed while scoped in (by @TW1STaL1CKY)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed `DynamicCamera` error when a weapon's `CalcView` doesn't return complete values (by @TW1STaL1CKY)
 - Fixed Roundendscreen showing karma changes even if karma is disabled
 - Fixed the player's FOV staying zoomed in if their weapon is removed while scoped in (by @TW1STaL1CKY)
+- Fixed weapon unscoping (or generally any time FOV is set back to default) being delayed due to the player's lag (by @TW1STaL1CKY)
 
 ### Removed
 

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -771,16 +771,6 @@ if CLIENT then
 
     ---
     -- @realm client
-    function SWEP:OnRemove()
-        local owner = self:GetOwner()
-
-        if IsValid(owner) and owner == LocalPlayer() and owner:IsTerror() then
-            RunConsoleCommand("lastinv")
-        end
-    end
-
-    ---
-    -- @realm client
     function SWEP:CalcViewModel()
         if not IsFirstTimePredicted() then
             return
@@ -1220,6 +1210,22 @@ function SWEP:Reload()
     self:DefaultReload(self.ReloadAnim)
 
     self:SetIronsights(false)
+    self:SetZoom(false)
+end
+
+---
+-- Called when the weapon entity is about to be removed
+-- @see https://wiki.facepunch.com/gmod/WEAPON:OnRemove
+-- @realm shared
+function SWEP:OnRemove()
+    if CLIENT then
+        local owner = self:GetOwner()
+
+        if IsValid(owner) and owner == LocalPlayer() and owner:IsTerror() then
+            RunConsoleCommand("lastinv")
+        end
+    end
+
     self:SetZoom(false)
 end
 

--- a/gamemodes/terrortown/gamemode/client/cl_main.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_main.lua
@@ -876,7 +876,7 @@ function GM:DynamicCamera(viewTable, ply)
             curTimeShift = 0
         end
 
-        local curTime, fovTranDur = CurTime() + curTimeShift, ply:GetFOVTransitionTime()
+        local curTime = CurTime() + curTimeShift
 
         -- GetFOVTime ends up in the future with lag, causing a delay in the transition (the bigger your lag, the longer the delay)
         -- shift curTime by the difference to correct it
@@ -885,9 +885,10 @@ function GM:DynamicCamera(viewTable, ply)
             curTime = curTime + curTimeShift
         end
 
-        local time = math.max(0, (curTime - fovTime) * game.GetTimeScale() * cvHostTimescale:GetFloat())
+        local time =
+            math.max(0, (curTime - fovTime) * game.GetTimeScale() * cvHostTimescale:GetFloat())
 
-        local progressTransition = math.min(1.0, time / fovTranDur)
+        local progressTransition = math.min(1.0, time / ply:GetFOVTransitionTime())
 
         -- if the transition progress has reached 100%, we should enable the sprint
         -- FOV smoothing algorithm; the value 40 was determined by trying different values

--- a/gamemodes/terrortown/gamemode/client/cl_main.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_main.lua
@@ -885,10 +885,7 @@ function GM:DynamicCamera(viewTable, ply)
             curTime = curTime + curTimeShift
         end
 
-        local time = math.max(
-            0,
-            (curTime - fovTime) * game.GetTimeScale() * cvHostTimescale:GetFloat()
-        )
+        local time = math.max(0, (curTime - fovTime) * game.GetTimeScale() * cvHostTimescale:GetFloat())
 
         local progressTransition = math.min(1.0, time / fovTranDur)
 


### PR DESCRIPTION
1. Fixed player's FOV being stuck zoomed in if their weapon is removed while they're scoped in
2. Fixed FOV transitions being delayed in DynamicCamera when the player has lag, eg. when unscoping with a rifle