### PR TITLE
HUD: Fixed OHI Desync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed Roundendscreen showing karma changes even if karma is disabled
 - Fixed the player's FOV staying zoomed in if their weapon is removed while scoped in (by @TW1STaL1CKY)
 - Fixed weapon unscoping (or generally any time FOV is set back to default) being delayed due to the player's lag (by @TW1STaL1CKY)
+- Fixed overhead icons sometimes being stuck at random places (by @TimGoll)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 - Removed radio tab in shop UI
 
+### Breaking Changes
+
+- Renamed `ply:GetHeightVector()` to `ply:GetHeadPosition()`
+
 ## [v0.13.1b](https://github.com/TTT-2/TTT2/tree/v0.13.1b) (2024-02-27)
 
 ### Fixed

--- a/gamemodes/terrortown/gamemode/client/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_targetid.lua
@@ -87,7 +87,7 @@ local sizeIconOverHeadIcon = 0.7 * sizeOverHeadIcon
 -- @realm client
 function DrawOverheadRoleIcon(client, ply, iconRole, colorRole)
     local ang = client:EyeAngles()
-    local pos = ply:GetPos() + ply:GetHeightVector()
+    local pos = ply:GetPos() + ply:GetHeadPosition()
     pos.z = pos.z + offsetOverHeadIcon
 
     local shift = Vector(0, shiftOverHeadIcon, 0)

--- a/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
@@ -1235,7 +1235,7 @@ end
 -- @return vector The player height
 -- @realm shared
 function plymeta:GetHeightVector()
-    local matrix, pos
+    local matrix, posHeadBone
     local bone = self:LookupBone("ValveBiped.Bip01_Head1")
 
     local posPlayer = self:GetPos()
@@ -1248,18 +1248,19 @@ function plymeta:GetHeightVector()
     end
 
     if matrix then
-        pos = matrix:GetTranslation()
+        posHeadBone = matrix:GetTranslation()
     end
 
     -- if a player is too far away, their location is only updated sporadically
     -- if the distance between these two positions is too large, the fallback position
     -- should be used
-    if (pos - posPlayer):Length() < 90 then
+    if posHeadBone and (posHeadBone - posPlayer):Length() < 90 then
         -- note: the 8 is the assumed height of the head after the head bone
         -- this might not work for every model
-        pos.z = pos.z + 8 * self:GetModelScale() * self:GetManipulateBoneScale(bone).z
+        posHeadBone.z = posHeadBone.z
+            + 8 * self:GetModelScale() * self:GetManipulateBoneScale(bone).z
 
-        return pos - posPlayer
+        return posHeadBone - posPlayer
     end
 
     -- if the model has no head bone for some reason, use the player

--- a/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
@@ -1235,8 +1235,10 @@ end
 -- @return vector The player height
 -- @realm shared
 function plymeta:GetHeightVector()
-    local matrix
+    local matrix, pos
     local bone = self:LookupBone("ValveBiped.Bip01_Head1")
+
+    local posPlayer = self:GetPos()
 
     -- if the bone is defined, the bone matrix is defined as well;
     -- however on hot reloads this can momentarily break before it
@@ -1246,23 +1248,27 @@ function plymeta:GetHeightVector()
     end
 
     if matrix then
-        local pos = matrix:GetTranslation()
+        pos = matrix:GetTranslation()
+    end
 
+    -- if a player is too far away, their location is only updated sporadically
+    -- if the distance between these two positions is too large, the fallback position
+    -- should be used
+    if (pos - posPlayer):Length() < 90 then
         -- note: the 8 is the assumed height of the head after the head bone
         -- this might not work for every model
         pos.z = pos.z + 8 * self:GetModelScale() * self:GetManipulateBoneScale(bone).z
 
-        return pos - self:GetPos()
+        return pos - posPlayer
+    end
 
     -- if the model has no head bone for some reason, use the player
     -- position as a fallback
-    else
-        local obbmMaxs = self:OBBMaxs()
-        obbmMaxs.x = 0
-        obbmMaxs.y = 0
+    local obbmMaxs = self:OBBMaxs()
+    obbmMaxs.x = 0
+    obbmMaxs.y = 0
 
-        return obbmMaxs * self:GetModelScale()
-    end
+    return obbmMaxs * self:GetModelScale()
 end
 
 -- to make it hotreload safe, we have to make sure it is not

--- a/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
@@ -1251,9 +1251,12 @@ function plymeta:GetHeightVector()
         posHeadBone = matrix:GetTranslation()
     end
 
-    -- if a player is too far away, their location is only updated sporadically
-    -- if the distance between these two positions is too large, the fallback position
-    -- should be used
+    -- if a player is too far away, their head-bone position is only updated
+    -- sporadically.
+    -- if the head-bone position and the player position are not too far apart
+    -- we assume the head-bone position is accurate and use it.
+    -- otherwise we fall back to the highest corner of the players bounding
+    -- box position.
     if posHeadBone and (posHeadBone - posPlayer):Length() < 90 then
         -- note: the 8 is the assumed height of the head after the head bone
         -- this might not work for every model

--- a/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
@@ -1234,7 +1234,7 @@ end
 -- @note Respects the model scale for the height calculation
 -- @return vector The player height
 -- @realm shared
-function plymeta:GetHeightVector()
+function plymeta:GetHeadPosition()
     local matrix, posHeadBone
     local bone = self:LookupBone("ValveBiped.Bip01_Head1")
 

--- a/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
@@ -1253,11 +1253,7 @@ function plymeta:GetHeadPosition()
 
     -- If a player is too far away, their head-bone position is only updated
     -- sporadically.
-    -- If the head-bone position and the player position are not too far apart
-    -- we assume the head-bone position is accurate and use it. When this is the
-    -- case it is because the entity is dormant and its position is no longer
-    -- updated.
-    -- Otherwise we fall back to the highest corner of the players bounding
+    -- In that case we want to fall back to the highest corner of the players bounding
     -- box position.
     if posHeadBone and not self:IsDormant() then
         -- note: the 8 is the assumed height of the head after the head bone

--- a/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
@@ -1251,13 +1251,15 @@ function plymeta:GetHeightVector()
         posHeadBone = matrix:GetTranslation()
     end
 
-    -- if a player is too far away, their head-bone position is only updated
+    -- If a player is too far away, their head-bone position is only updated
     -- sporadically.
-    -- if the head-bone position and the player position are not too far apart
-    -- we assume the head-bone position is accurate and use it.
-    -- otherwise we fall back to the highest corner of the players bounding
+    -- If the head-bone position and the player position are not too far apart
+    -- we assume the head-bone position is accurate and use it. When this is the
+    -- case it is because the entity is dormant and its position is no longer
+    -- updated.
+    -- Otherwise we fall back to the highest corner of the players bounding
     -- box position.
-    if posHeadBone and (posHeadBone - posPlayer):Length() < 90 then
+    if posHeadBone and not self:IsDorman() then
         -- note: the 8 is the assumed height of the head after the head bone
         -- this might not work for every model
         posHeadBone.z = posHeadBone.z

--- a/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
@@ -1259,7 +1259,7 @@ function plymeta:GetHeadPosition()
     -- updated.
     -- Otherwise we fall back to the highest corner of the players bounding
     -- box position.
-    if posHeadBone and not self:IsDorman() then
+    if posHeadBone and not self:IsDormant() then
         -- note: the 8 is the assumed height of the head after the head bone
         -- this might not work for every model
         posHeadBone.z = posHeadBone.z


### PR DESCRIPTION
Sometimes overhead icons stayed stuck in the world. This is due to the way GMod/source handles player positions. If a player is far enough away, their position is no longer updated (as can be seen with wallhacks for example).

While `:GetPos()` still returns a position that at least represents a rough estimate of their position, the bone position stays at the last updated place. This means that the overhead icon stays floating in random places.

This pullrequest fixes this by introducing a check that uses the fallback position if the player position and the bone position diverge too much.

While I tested this, it would probably be good if @mexikoedi could confirm this as well.