### PR TITLE
fixed nil compare error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed Roundendscreen showing karma changes even if karma is disabled
 - Fixed the player's FOV staying zoomed in if their weapon is removed while scoped in (by @TW1STaL1CKY)
 - Fixed weapon unscoping (or generally any time FOV is set back to default) being delayed due to the player's lag (by @TW1STaL1CKY)
+- Fixed a nil compare error in the DrawHUD function in weapon_tttbasegrenade (by @mexikoedi)
 
 ### Removed
 

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbasegrenade.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbasegrenade.lua
@@ -503,11 +503,7 @@ if CLIENT then
             y = y + (y / 3)
 
             local pct = 1
-                - math.Clamp(
-                    (CurTime() - pulltime) / (self:GetDetTime() - pulltime),
-                    0,
-                    1
-                )
+                - math.Clamp((CurTime() - pulltime) / (self:GetDetTime() - pulltime), 0, 1)
 
             local scale = appearance.GetGlobalScale()
             local w, h = 100 * scale, 20 * scale

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbasegrenade.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbasegrenade.lua
@@ -495,14 +495,16 @@ if CLIENT then
         local x = ScrW() * 0.5
         local y = ScrH() * 0.5
 
-        if self:GetPin() and self:GetPullTime() > 0 then
+        local pulltime = self:GetPullTime()
+
+        if self:GetPin() and pulltime and pulltime > 0 then
             local client = LocalPlayer()
 
             y = y + (y / 3)
 
             local pct = 1
                 - math.Clamp(
-                    (CurTime() - self:GetPullTime()) / (self:GetDetTime() - self:GetPullTime()),
+                    (CurTime() - pulltime) / (self:GetDetTime() - pulltime),
                     0,
                     1
                 )


### PR DESCRIPTION
This fixes the following issue:
```
[TTT2 (Base) - v0.13.2b] gamemodes/terrortown/entities/weapons/weapon_tttbasegrenade.lua:498: attempt to compare number with nil 
1. unknown - gamemodes/terrortown/entities/weapons/weapon_tttbasegrenade.lua:498
```
It should work and also makes the code more robust without creating new issues.
Reduces redundancy as well.