### PR TITLE
fixed null entity error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed Roundendscreen showing karma changes even if karma is disabled
 - Fixed the player's FOV staying zoomed in if their weapon is removed while scoped in (by @TW1STaL1CKY)
 - Fixed weapon unscoping (or generally any time FOV is set back to default) being delayed due to the player's lag (by @TW1STaL1CKY)
+- Fixed a null entity error in the ShootBullet function in weapon_tttbase (by @mexikoedi)
 
 ### Removed
 

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -1045,18 +1045,24 @@ end
 -- @see https://wiki.facepunch.com/gmod/WEAPON:ShootBullet
 -- @realm shared
 function SWEP:ShootBullet(dmg, recoil, numbul, cone)
+    local owner = self:GetOwner()
+
+    if not IsValid(owner) then
+        return
+    end
+
     self:SendWeaponAnim(self.PrimaryAnim)
 
-    self:GetOwner():MuzzleFlash()
-    self:GetOwner():SetAnimation(PLAYER_ATTACK1)
+    owner:MuzzleFlash()
+    owner:SetAnimation(PLAYER_ATTACK1)
 
     numbul = numbul or 1
     cone = cone or 0.02
 
     local bullet = {}
     bullet.Num = numbul
-    bullet.Src = self:GetOwner():GetShootPos()
-    bullet.Dir = self:GetOwner():GetAimVector()
+    bullet.Src = owner:GetShootPos()
+    bullet.Dir = owner:GetAimVector()
     bullet.Spread = Vector(cone, cone, 0)
     bullet.Tracer = 1
     bullet.TracerName = self.Tracer or "Tracer"
@@ -1067,10 +1073,10 @@ function SWEP:ShootBullet(dmg, recoil, numbul, cone)
         bullet.Callback = Sparklies
     end
 
-    self:GetOwner():FireBullets(bullet)
+    owner:FireBullets(bullet)
 
     -- Owner can die after firebullets
-    if not IsValid(self:GetOwner()) or self:GetOwner():IsNPC() or not self:GetOwner():Alive() then
+    if not IsValid(owner) or owner:IsNPC() or not owner:Alive() then
         return
     end
 
@@ -1078,10 +1084,10 @@ function SWEP:ShootBullet(dmg, recoil, numbul, cone)
         SERVER and game.SinglePlayer()
         or CLIENT and not game.SinglePlayer() and IsFirstTimePredicted()
     then
-        local eyeang = self:GetOwner():EyeAngles()
+        local eyeang = owner:EyeAngles()
         eyeang.pitch = eyeang.pitch - recoil
 
-        self:GetOwner():SetEyeAngles(eyeang)
+        owner:SetEyeAngles(eyeang)
     end
 end
 


### PR DESCRIPTION
This fixes the following issue:
```
[TTT2 (Base) - v0.13.2b] gamemodes/terrortown/entities/weapons/weapon_tttbase.lua:1054: Tried to use a NULL entity! 
1. MuzzleFlash - [C]:-1 
2. ShootBullet - gamemodes/terrortown/entities/weapons/weapon_tttbase.lua:1054 
3. PrimaryAttack - gamemodes/terrortown/entities/weapons/weapon_tttbase.lua:957 
4. unknown - lua/weapons/m9k_dbarrel/shared.lua:76
```
It should work and also makes the code more robust without creating new issues.
Reduces redundancy as well.