### PR TITLE
Fix: Combobox Validity Check

### DIFF
--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcombobox_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcombobox_ttt2.lua
@@ -44,7 +44,7 @@ function PANEL:Init()
 
     local value, _ = self:GetSelected()
 
-    self:UpdateSlaves(IsValid(value))
+    self:UpdateSlaves(value ~= nil)
 end
 
 ---
@@ -59,7 +59,7 @@ function PANEL:AddSlave(slave)
 
     local value, _ = self:GetSelected()
 
-    slave:SetEnabled(IsValid(value))
+    slave:SetEnabled(value ~= nil)
 end
 
 ---
@@ -249,7 +249,7 @@ function PANEL:ChooseOptionID(index, ignoreCallbackEnabledVars)
     self:SetText(choice.title)
     self:OnSelect(index, value, choice.data)
 
-    self:UpdateSlaves(IsValid(value))
+    self:UpdateSlaves(value ~= nil)
 
     self:CloseMenu()
 


### PR DESCRIPTION
Fixed an issue introduced by #1521

This happens because combo boxes can have values where the validity check fails (like strings).