### PR TITLE
shifted prep time after cleanup

### DIFF
--- a/lua/ttt2/libraries/admin.lua
+++ b/lua/ttt2/libraries/admin.lua
@@ -31,8 +31,10 @@ function admin.RoundRestart()
     end
 
     if SERVER then
+        LANG.Msg("round_restart")
+
         StopRoundTimers()
-        PrepareRound()
+        PostRoundCleanupAndPrepStart()
     end
 end
 
@@ -192,4 +194,27 @@ if SERVER then
             admin.PlayerSetArmor(net.ReadPlayer(), net.ReadUInt(16))
         end
     end)
+
+    ---
+    -- Version announce also used in Initialize
+    -- @param Player ply
+    -- @realm server
+    function admin.ShowVersion(ply)
+        local text = Format(
+            "This is [TTT2] Trouble in Terrorist Town 2 (Advanced Update) - by the TTT2 Dev Team (v%s)\n",
+            GAMEMODE.Version
+        )
+
+        if IsValid(ply) then
+            LANG.Msg(ply, text, nil, MSG_MSTACK_WARN)
+        else
+            Msg(text)
+        end
+    end
+
+    -- CLASSIC TTT COMMANDS
+
+    concommand.Add("ttt_roundrestart", admin.RoundRestart)
+
+    concommand.Add("ttt_version", admin.ShowVersion)
 end

--- a/lua/ttt2/libraries/admin.lua
+++ b/lua/ttt2/libraries/admin.lua
@@ -31,8 +31,6 @@ function admin.RoundRestart()
     end
 
     if SERVER then
-        LANG.Msg("round_restart")
-
         StopRoundTimers()
         PostRoundCleanupAndPrepStart()
     end


### PR DESCRIPTION
Merge after #1524 

Prep time now starts AFTER the map cleanup is done, improving the situation where 4+ seconds of prep are already gone once you are spawned. This still doesn't fix it completely, as the networking still eats up one second or so, but it is way more predictable now, especially when the server is slow.

I also cleaned up the commands a bit to remove code duplication.

TODO: Clean up code once the other PR is merged