### PR TITLE
Weaponbase: Fixed weapon dryfire sound interrupting gunshot sounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed overhead icons sometimes being stuck at random places (by @TimGoll)
 - Fixed a null entity error in the ShootBullet function in weapon_tttbase (by @mexikoedi)
 - Fixed a nil compare error in the DrawHUD function in weapon_tttbasegrenade (by @mexikoedi)
+- Fixed weapon dryfire sound interrupting the weapon's gunshot sound (by @TW1STaL1CKY)
 
 ### Removed
 

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -978,7 +978,7 @@ end
 -- @realm shared
 function SWEP:DryFire(setnext)
     if CLIENT and LocalPlayer() == self:GetOwner() then
-        self:EmitSound("Weapon_Pistol.Empty")
+        self:EmitSound(")weapons/pistol/pistol_empty.wav", 75, 100, 0.7, CHAN_VOICE)
     end
 
     setnext(self, CurTime() + 0.2)

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -978,7 +978,7 @@ end
 -- @realm shared
 function SWEP:DryFire(setnext)
     if CLIENT and LocalPlayer() == self:GetOwner() then
-        self:EmitSound(")weapons/pistol/pistol_empty.wav", 75, 100, 0.7, CHAN_VOICE)
+        self:EmitSound(")weapons/pistol/pistol_empty.wav", 75, 100, 0.7, CHAN_ITEM)
     end
 
     setnext(self, CurTime() + 0.2)


### PR DESCRIPTION
Gunshot sounds would get interrupted by the dryfire sound, sounding quite jank.

This has been fixed by making the dryfire sound use a different channel. Now the last shot in the magazine won't be silenced if you keep holding the trigger!
The parameters in EmitSound match the settings that the "Weapon_Pistol.Empty" soundscript would use (except the channel), so it sounds exactly the same pitch and volume wise.