### PR TITLE
Scoreboard/Specs: Changed Groups for Scoreboard Search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed a nil compare error in the DrawHUD function in weapon_tttbasegrenade (by @mexikoedi)
 - Fixed players sometimes not receiving their role if they joined late to the game (by @TimGoll)
 - Fixed weapon dryfire sound interrupting the weapon's gunshot sound (by @TW1STaL1CKY)
+- Fixed scoreboard not showing any body search info on players that changed to forced spec during a round (by @TimGoll)
 
 ### Removed
 

--- a/gamemodes/terrortown/gamemode/client/vgui/cl_sb_row.lua
+++ b/gamemodes/terrortown/gamemode/client/vgui/cl_sb_row.lua
@@ -323,7 +323,7 @@ function PANEL:SetPlayer(ply)
             self.info:SetPlayer(ply)
 
             self:InvalidateLayout()
-        elseif g == GROUP_FOUND or g == GROUP_NOTFOUND then
+        else
             self.info = vgui.Create("TTTScorePlayerInfoSearch", self)
             self.info:SetPlayer(ply)
 


### PR DESCRIPTION
Fixes #1483

When a player is dead and confirmed, you can see the search info in the scoreboard when clicking on their name. This did not work for players that died because they forced themselves as a spectator. This is because of this `if/else` structure that did not handle `GROUP_SPEC`.

As there only exists these four groups:
```lua
GROUP_TERROR = 1
GROUP_NOTFOUND = 2
GROUP_FOUND = 3
GROUP_SPEC = 4
```

I decided to just changes this to an `else`. The only sideeffect is that you are now able to click on any spectator in the scoreboard and it says that this player has no search information available. To me this seems like a valid solution.