### PR TITLE
Update addonchecker

### DIFF
--- a/gamemodes/terrortown/gamemode/server/sv_addonchecker.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_addonchecker.lua
@@ -194,9 +194,9 @@ addonChecker.curatedList = {
         reason = "Overwrites stock TTT2 crowbar which causes problems with doors and ttt_map_settings entity.",
         type = ADDON_INCOMPATIBLE,
     },
-    ["278185787"] = { -- Death Note by Blue-Pentagram
-        alternative = "3118796974",
-        reason = "Prints only Detectives in TTT2. Roles are hard coded.",
+    ["3118796974"] = { -- Death Note by Blue-Pentagram
+        alternative = "278185787",
+        reason = "Old Addon got massive update and works now with TTT2. The version with the workaround will be discontinued.",
         type = ADDON_INCOMPATIBLE,
     },
     ["2758610950"] = { -- Death Note TTT2 Fixed Edition by pat201290

--- a/gamemodes/terrortown/gamemode/server/sv_addonchecker.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_addonchecker.lua
@@ -194,21 +194,6 @@ addonChecker.curatedList = {
         reason = "Overwrites stock TTT2 crowbar which causes problems with doors and ttt_map_settings entity.",
         type = ADDON_INCOMPATIBLE,
     },
-    ["3118796974"] = { -- Death Note by Blue-Pentagram
-        alternative = "278185787",
-        reason = "Old Addon got massive update and works now with TTT2. The version with the workaround will be discontinued.",
-        type = ADDON_INCOMPATIBLE,
-    },
-    ["2758610950"] = { -- Death Note TTT2 Fixed Edition by pat201290
-        alternative = "3118796974",
-        reason = "Prints only Detectives in TTT2. Roles are hard coded.",
-        type = ADDON_INCOMPATIBLE,
-    },
-    ["110148946"] = { -- Death Note by SmokeTheBanana
-        alternative = "3118796974",
-        reason = "Prints only Detectives in TTT2. Roles are hard coded.",
-        type = ADDON_INCOMPATIBLE,
-    },
     ["110148946"] = { -- ttt_broken_hand_fix by Jolez
         reason = "Already built in into TTT2",
         type = ADDON_INCOMPATIBLE,
@@ -670,6 +655,21 @@ addonChecker.curatedList = {
     ["899488990"] = { -- Mirror fate by Keksgesicht
         alternative = "3229789817",
         reason = "Broken model, no UI feedback for affected people, no integration into TTT2 systems.",
+        type = ADDON_OUTDATED,
+    },
+    ["3118796974"] = { -- Death Note by Xopez
+        alternative = "278185787",
+        reason = "Old Addon got massive update and works now with TTT2. The version with the workaround will be discontinued.",
+        type = ADDON_OUTDATED,
+    },
+    ["2758610950"] = { -- Death Note TTT2 Fixed Edition by pat201290
+        alternative = "278185787",
+        reason = "Prints only Detectives in TTT2. Roles are hard coded.",
+        type = ADDON_OUTDATED,
+    },
+    ["110148946"] = { -- Death Note by SmokeTheBanana
+        alternative = "278185787",
+        reason = "Prints only Detectives in TTT2. Roles are hard coded.",
         type = ADDON_OUTDATED,
     },
 }


### PR DESCRIPTION
Original Death note got ttt2 support 4 months ago. I discontinue my old fix: https://steamcommunity.com/sharedfiles/filedetails/changelog/278185787
https://github.com/BluePentagram/Death_Note/commit/81b3a8823d7ecc1398c07be2f8571af59e6eb5cd