### PR TITLE
Fixed the new voicehud's embossing effect overlapping the profile picture

### DIFF
--- a/gamemodes/terrortown/gamemode/shared/hud_elements/tttvoice/pure_skin_voice.lua
+++ b/gamemodes/terrortown/gamemode/shared/hud_elements/tttvoice/pure_skin_voice.lua
@@ -59,6 +59,14 @@ if CLIENT then
 
         draw.Box(xPos + self.padding, yPos + self.padding, w - self.padding, heightBar, color)
 
+        self:DrawLines(
+            xPos + self.padding,
+            yPos + self.padding,
+            w - self.padding,
+            heightBar,
+            color.a
+        )
+
         for i = 1, #data do
             local yValue = math.floor(data[i] * 0.5 * heightBar - 4 * self.scale)
 
@@ -149,14 +157,6 @@ if CLIENT then
                 colorVoiceLine
             )
         end
-
-        self:DrawLines(
-            xPos + self.padding,
-            yPos + self.padding,
-            w - self.padding,
-            heightBar,
-            color.a
-        )
     end
 
     function HUDELEMENT:Draw()


### PR DESCRIPTION
Before:
![Embossing effect overlaps profile picture](https://github.com/TTT-2/TTT2/assets/1499739/11678492-cdf3-401e-95bb-2cf11f61e314)

After:
![Embossing effect goes behind profile picture](https://github.com/TTT-2/TTT2/assets/1499739/acb4d67c-be11-400b-831c-0f075aaca1be)
