### PR TITLE
Weapons: Fixed crowbar attack animation not being visible to the local player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed a null entity error in the ShootBullet function in weapon_tttbase (by @mexikoedi)
 - Fixed a nil compare error in the DrawHUD function in weapon_tttbasegrenade (by @mexikoedi)
 - Fixed players sometimes not receiving their role if they joined late to the game (by @TimGoll)
+- Fixed crowbar attack animation not being visible to the player swinging it (by @TW1STaL1CKY)
 - Fixed weapon dryfire sound interrupting the weapon's gunshot sound (by @TW1STaL1CKY)
 - Fixed incendiaries sometimes exploding without fire (by @TimGoll)
 - Fixed scoreboard not showing any body search info on players that changed to forced spec during a round (by @TimGoll)

--- a/gamemodes/terrortown/entities/weapons/weapon_zm_improvised.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_zm_improvised.lua
@@ -166,6 +166,7 @@ function SWEP:PrimaryAttack()
     local hitEnt = tr_main.Entity
 
     self:EmitSound(sound_single)
+    owner:SetAnimation(PLAYER_ATTACK1)
 
     if IsValid(hitEnt) or tr_main.HitWorld then
         self:SendWeaponAnim(ACT_VM_HITCENTER)
@@ -215,8 +216,6 @@ function SWEP:PrimaryAttack()
         })
 
         local trEnt = tr_all.Entity
-
-        owner:SetAnimation(PLAYER_ATTACK1)
 
         if IsValid(hitEnt) then
             if self:OpenEnt(hitEnt) == OPEN_NO and IsValid(trEnt) then
@@ -274,7 +273,6 @@ function SWEP:SecondaryAttack()
             pushvel.z = math.Clamp(pushvel.z, 50, 100) -- limit the upward force to prevent launching
 
             ply:SetVelocity(ply:GetVelocity() + pushvel)
-            owner:SetAnimation(PLAYER_ATTACK1)
 
             ply.was_pushed = {
                 att = owner,
@@ -286,6 +284,8 @@ function SWEP:SecondaryAttack()
 
         self:EmitSound(sound_single)
         self:SendWeaponAnim(ACT_VM_HITCENTER)
+        owner:SetAnimation(PLAYER_ATTACK1)
+
         self:SetNextSecondaryFire(CurTime() + self.Secondary.Delay)
     end
 


### PR DESCRIPTION
Minor visual fix

Swinging your crowbar in thirdperson would have no animation (everyone else sees it fine). This PR fixes that for both primary and secondary attack