### PR TITLE
fixed spectator voice duck convar typo

### DIFF
--- a/gamemodes/terrortown/gamemode/client/cl_voice.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_voice.lua
@@ -27,7 +27,7 @@ VOICE.cv = {
     ---
     -- @realm client
     -- stylua: ignore
-    duck_spectator_amount = CreateConVar("ttt2_voice_cvDuckSpectator_amount", "0", { FCVAR_ARCHIVE }),
+    duck_spectator_amount = CreateConVar("ttt2_voice_duck_spectator_amount", "0", { FCVAR_ARCHIVE }),
 
     ---
     -- @realm client


### PR DESCRIPTION
Fixed the issue that the spectator voice duck amount setting wasn't working as expected because of a typo in the convar name.