### PR TITLE
fixed nil error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed weapon dryfire sound interrupting the weapon's gunshot sound (by @TW1STaL1CKY)
 - Fixed incendiaries sometimes exploding without fire (by @TimGoll)
 - Fixed scoreboard not showing any body search info on players that changed to forced spec during a round (by @TimGoll)
+- Fixed a nil error in the PreDrop function in weapon_ttt_cse (by @mexikoedi)
 
 ### Removed
 

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_cse.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_cse.lua
@@ -92,13 +92,13 @@ function SWEP:PreDrop(isdeath)
         return
     end
 
-    local cse = self:DropDevice()
+    if SERVER then
+        local cse = ents.Create("ttt_cse_proj")
 
-    if not IsValid(cse) then
-        return
+        if cse:ThrowEntity(self:GetOwner()) then
+            self:Remove()
+        end
     end
-
-    cse:SetDetonateTimer(self.DeathScanDelay or 10)
 end
 
 ---


### PR DESCRIPTION
This fixes the following issue:
```
[TTT2 (Base) - v0.13.2b] gamemodes/terrortown/entities/weapons/weapon_ttt_cse.lua:95: attempt to call method 'DropDevice' (a nil value)
  1. PreDrop - gamemodes/terrortown/entities/weapons/weapon_ttt_cse.lua:95
   2. DropNotifiedWeapon - gamemodes/terrortown/gamemode/server/sv_weaponry.lua:626
    3. unknown - gamemodes/terrortown/gamemode/server/sv_player.lua:730
```
This issue was caused because the DropDevice function doesn't exist anymore. It was removed here: https://github.com/TTT-2/TTT2/commit/b83216e0fedf1454e31f54cffd9f340a3d082600#diff-4e2900ec902da3fc854104b03d5e314aa0187a1cae52fd7a2ccdd9d782b64434L102

I tested it and it works. The visualizer drops on death without creating an error.