### PR TITLE
Voice: fix panel colors and voice chat not working after round start

### DIFF
--- a/gamemodes/terrortown/gamemode/client/cl_voice.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_voice.lua
@@ -10,7 +10,7 @@ local player = player
 local IsValid = IsValid
 local hook = hook
 
-VOCIE_MODE_GLOBAL = 0
+VOICE_MODE_GLOBAL = 0
 VOICE_MODE_TEAM = 1
 VOICE_MODE_SPEC = 2
 
@@ -222,8 +222,8 @@ local function VoiceTeamTryEnable()
     end
 end
 
-local function VoiceTeamTryDisable()
-    if not VOICE.isTeam then
+local function VoiceTeamTryDisable(forceReenable)
+    if not VOICE.isTeam and not forceReenable then
         return
     end
 
@@ -232,7 +232,8 @@ local function VoiceTeamTryDisable()
         permissions.EnableVoiceChat(false)
         VOICE.isTeam = false
 
-        timer.Simple(0, function()
+        -- for some reason using a 0-delay timer here is inconsistent and won't always call GM:PlayerStartVoice
+        timer.Simple(0.05, function()
             permissions.EnableVoiceChat(true)
         end)
 
@@ -242,6 +243,11 @@ local function VoiceTeamTryDisable()
         permissions.EnableVoiceChat(false)
     end
 end
+
+-- disable team voice on team change (and maybe re-enable global voice chat)
+hook.Add("TTT2UpdateTeam", "TTT2DisableTeamVoice", function()
+    VoiceTeamTryDisable(true)
+end)
 
 ---
 -- Checks if a player can enable the team voice chat.
@@ -429,25 +435,6 @@ local function ReceiveVoiceState()
     ply[tm .. "_gvoice"] = isGlobal
 end
 net.Receive("TTT_RoleVoiceState", ReceiveVoiceState)
-
----
--- Called when @{Player} stops using voice chat.
--- @param Player ply @{Player} who stopped talking
--- @hook
--- @realm client
--- @ref https://wiki.facepunch.com/gmod/GM:PlayerEndVoice
--- @local
-function GM:PlayerEndVoice(ply)
-    if not IsValid(ply) then
-        return
-    end
-
-    local plyTeam = ply:GetTeam()
-
-    if plyTeam ~= TEAM_NONE and not TEAMS[plyTeam].alone then
-        ply[plyTeam .. "_gvoice"] = false
-    end
-end
 
 --local MuteStates = {MUTE_NONE, MUTE_TERROR, MUTE_ALL, MUTE_SPEC}
 


### PR DESCRIPTION
`GM:PlayerEndVoice` was resetting players' team voice state even if they were still talking in team voice chat because `GM:PlayerEndVoice` is called client-side whenever a player stops audibly talking (not when they are actually done using voice chat). This was unnecessary anyway so I removed the hook.

There were also multiple issues related to stuff not being updated on round start / team change (panel colors not being updated and your panel being shown but you weren't actually speaking). The simplest solution I found was forcibly re-enabling voice chat on team change.
Unfortunately I discovered that using 0s timers for re-enabling voice chat is inconsistent for whatever reason and wouldn't always call `GM:PlayerStartVoice`.
I didn't fine-tune the timing but using 0.05s (2 or 3 ticks?) seemed to fix this.