### PR TITLE
Markervision: Fix Unknown Teams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed `table.FullCopy(tbl)` behaviour when `tbl` contained a Vector or Angle (by @Histalek)
 - Fixed the bodysearch showing a wrong player icon when searching a fake body (by @TimGoll)
 - Fixed players respawned with `ply:Revive` sometimes spawning on a fake corpse (by @TimGoll)
+- Fiyed markerVision elements being visible to team mates of unknown teams (such as team Innocent) (by @TimGoll)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed `table.FullCopy(tbl)` behaviour when `tbl` contained a Vector or Angle (by @Histalek)
 - Fixed the bodysearch showing a wrong player icon when searching a fake body (by @TimGoll)
 - Fixed players respawned with `ply:Revive` sometimes spawning on a fake corpse (by @TimGoll)
-- Fiyed markerVision elements being visible to team mates of unknown teams (such as team Innocent) (by @TimGoll)
+- Fixed markerVision elements being visible to team mates of unknown teams (such as team Innocent) (by @TimGoll)
 
 ### Removed
 

--- a/gamemodes/terrortown/gamemode/shared/sh_marker_vision_element.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_marker_vision_element.lua
@@ -176,7 +176,15 @@ if SERVER then
             end
         elseif self.data.visibleFor == VISIBLE_FOR_TEAM then
             if IsPlayer(self.data.owner) then
-                self.receiverList = GetTeamFilter(self.data.owner:GetTeam(), false, true)
+                local team = self.data.owner:GetTeam()
+                local subRoleData = self.data.owner:GetSubRoleData()
+
+                -- visible for team is restricted when the team is unknown
+                if subRoleData.unknownTeam or team == TEAM_NONE or TEAMS[team].alone then
+                    self.receiverList = { self.data.owner }
+                else
+                    self.receiverList = GetTeamFilter(team, false, true)
+                end
             else
                 -- handle static team
                 self.receiverList = GetTeamFilter(self.data.owner, false, true)


### PR DESCRIPTION
Fixes #1477 by making sure that the whole team is only notified if the player knows about their team mates.