### PR TITLE
Bindings: Fixed Undefined Bindings Breaking Gamemode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed `table.FullCopy(tbl)` behaviour when `tbl` contained a Vector or Angle (by @Histalek)
 - Fixed the bodysearch showing a wrong player icon when searching a fake body (by @TimGoll)
 - Fixed players respawned with `ply:Revive` sometimes spawning on a fake corpse (by @TimGoll)
+- Fixed undefined Keys breaking the gamemode (by @TimGoll)
 
 ### Removed
 

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_binoculars.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_binoculars.lua
@@ -270,7 +270,7 @@ if CLIENT then
     -- @ignore
     function SWEP:Initialize()
         self:AddTTT2HUDHelp("binoc_help_pri", "binoc_help_sec")
-        self:AddHUDHelpLine("binoc_help_reload", Key("+reload", "R"))
+        self:AddHUDHelpLine("binoc_help_reload", Key("+reload", "undefined_key"))
 
         BaseClass.Initialize(self)
     end

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_spawneditor.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_spawneditor.lua
@@ -368,8 +368,8 @@ if CLIENT then
         self.selectedMode = 1
 
         self:AddTTT2HUDHelp("spawneditor_place", "spawneditor_remove")
-        self:AddHUDHelpLine("spawneditor_change", Key("+reload", "R"))
-        self:AddHUDHelpLine("spawneditor_ammo_edit", Key("+walk", "WALK"))
+        self:AddHUDHelpLine("spawneditor_change", Key("+reload", "undefined_key"))
+        self:AddHUDHelpLine("spawneditor_ammo_edit", Key("+walk", "undefined_key"))
 
         hook.Add("PostDrawTranslucentRenderables", "RenderWeaponSpawnEdit", RenderHook)
     end

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_wtester.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_wtester.lua
@@ -510,7 +510,7 @@ if CLIENT then
         self:SetSubMaterial(0, "!scanner_screen_mat")
 
         self:AddTTT2HUDHelp("dna_help_primary", "dna_help_secondary")
-        self:AddHUDHelpLine("dna_help_reload", Key("+reload", "R"))
+        self:AddHUDHelpLine("dna_help_reload", Key("+reload", "undefined_key"))
 
         return BaseClass.Initialize(self)
     end

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -555,6 +555,9 @@ if CLIENT then
             local isIcon = false
 
             if isstring(binding) then
+                -- attempt to translate binding in case it can be translated
+                bindig = TryT(binding)
+
                 local wKey, hKey = draw.GetTextSize(binding, "weapon_hud_help_key", scale)
 
                 wBinding = wKey + 2 * padXKey * scale
@@ -710,11 +713,11 @@ if CLIENT then
         self:ClearHUDHelp()
 
         if primary then
-            self:AddHUDHelpLine(primary, Key("+attack", "MOUSE1"))
+            self:AddHUDHelpLine(primary, Key("+attack", "undefined_key"))
         end
 
         if secondary then
-            self:AddHUDHelpLine(secondary, Key("+attack2", "MOUSE2"))
+            self:AddHUDHelpLine(secondary, Key("+attack2", "undefined_key"))
         end
     end
 
@@ -727,11 +730,11 @@ if CLIENT then
         self:ClearHUDHelp()
 
         if primary then
-            self:AddHUDHelpLine(primary, Key("+attack", "MOUSE1"))
+            self:AddHUDHelpLine(primary, Key("+attack", "undefined_key"))
         end
 
         if secondary then
-            self:AddHUDHelpLine(secondary, Key("+attack2", "MOUSE2"))
+            self:AddHUDHelpLine(secondary, Key("+attack2", "undefined_key"))
         end
     end
 

--- a/lua/terrortown/lang/en.lua
+++ b/lua/terrortown/lang/en.lua
@@ -2341,3 +2341,6 @@ The minimum weight, therefore, effectively controls how much each round affects 
 
 Changes to this value will not take effect until players reconnect or the map changes.]]
 L.label_roles_derandomize_min_weight = "Derandomization minimum weight"
+
+-- 2024-08-17
+L.undefined_key = "UNK"

--- a/lua/terrortown/lang/en.lua
+++ b/lua/terrortown/lang/en.lua
@@ -2343,4 +2343,4 @@ Changes to this value will not take effect until players reconnect or the map ch
 L.label_roles_derandomize_min_weight = "Derandomization minimum weight"
 
 -- 2024-08-17
-L.undefined_key = "UNK"
+L.undefined_key = "???"

--- a/lua/ttt2/extensions/input.lua
+++ b/lua/ttt2/extensions/input.lua
@@ -18,5 +18,11 @@ local inputLookupBinding = input.LookupBinding
 -- @return boolean Returns true if the binding is pressed
 -- @realm client
 function input.IsBindingDown(binding)
-    return inputIsButtonDown(inputGetKeyCode(inputLookupBinding(binding)))
+    local bindingLookup = inputLookupBinding(binding)
+
+    if not bindingLookup then
+        return false
+    end
+
+    return inputIsButtonDown(inputGetKeyCode(bindingLookup))
 end


### PR DESCRIPTION
Fixed #1571

Made sure that undefined bindings do not cause errors. While I was at it, I replaced the hardcoded fallbacks with "UNK" (undefined key) so the user is less confused when nothing happens