### PR TITLE
Equipment Editor: Fix Inverted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed players respawned with `ply:Revive` sometimes spawning on a fake corpse (by @TimGoll)
 - Fixed undefined Keys breaking the gamemode (by @TimGoll)
 - Fixed markerVision elements being visible to team mates of unknown teams (such as team Innocent) (by @TimGoll)
+- Fixed inverted settings being inverted twice in the equipment editor (by @TimGoll)
 
 ### Removed
 

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcheckboxlabel_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcheckboxlabel_ttt2.lua
@@ -189,11 +189,11 @@ function PANEL:SetDefaultValue(value)
     local noDefault = true
 
     if isbool(value) then
-        if self.inverted then
-            value = not value
-        end
+        -- note: even when it is inverted, the default is not inverted here
+        -- as it is inverted when the default button is pressed
 
         self.default = value
+
         noDefault = false
     else
         self.default = nil


### PR DESCRIPTION
The old implementation double inverted the value, when pressing reset, resulting in inverted outputs.