### PR TITLE
MapVote: Readded compatibility with old mapvote addons

### DIFF
--- a/lua/ttt2/libraries/gameloop.lua
+++ b/lua/ttt2/libraries/gameloop.lua
@@ -672,6 +672,18 @@ if SERVER then
 
         events.Trigger(EVENT_GAME, state)
     end
+
+    hook.Add("TTT2LoadNextMap", "MapVoteCompat", function(nextMap, roundsLeft, timeLeft)
+        if not isfunction(CheckForMapSwitch) then
+            return
+        end
+
+        ErrorNoHalt(
+            "[TTT2] Using deprecated map vote overwrite. Replace your map vote addon and contact the addon developer."
+        )
+
+        CheckForMapSwitch()
+    end)
 end
 
 if CLIENT then

--- a/lua/ttt2/libraries/gameloop.lua
+++ b/lua/ttt2/libraries/gameloop.lua
@@ -683,6 +683,8 @@ if SERVER then
         )
 
         CheckForMapSwitch()
+
+        return true
     end)
 end
 


### PR DESCRIPTION
Most mapvote addons work by overwriting the `LoadNextMap()` function. However in a recent rework, the TTT2 gameloop got completely reworked which broke that way of hooking into it.

The easiest solution here is to add a fallback mode that calls the overwritten function if defined. This is done here. Additionally I raise an error to make sure the server owner is aware of the problem.

When this function is called, the next map condition is already met. And since these functions are all based on the old TTT function, the condition will still be met inside it, even if the round counter is decreased by one more. Therefore we don't have to modify any values here.

By doing it that way it is pretty clean and safe to call deprecated map vote trigger functions, without hacking too much into the TTT2 gameloop.