### PR TITLE
Fetch: Removed fetching avatar icons from Steam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed undefined Keys breaking the gamemode (by @TimGoll)
 - Fixed markerVision elements being visible to team mates of unknown teams (such as team Innocent) (by @TimGoll)
 - Fixed inverted settings being inverted twice in the equipment editor (by @TimGoll)
+- Fixed missing avatar icons if fetching from Steam fails (by @mexikoedi)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Updated Russian and English localization files (by @Satton2)
 - Made `ply:IsReviving` a shared player variable (by @TimGoll)
 - Updated and improved the Simplified Chinese localization file (by @sbzlzh and @TheOnly8Z)
+- Avatar icons are not fetched anymore but instead created with `AvatarImage` (fixes missing icons for chinese players) (by @mexikoedi)
 
 ### Fixed
 
@@ -106,7 +107,6 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed undefined Keys breaking the gamemode (by @TimGoll)
 - Fixed markerVision elements being visible to team mates of unknown teams (such as team Innocent) (by @TimGoll)
 - Fixed inverted settings being inverted twice in the equipment editor (by @TimGoll)
-- Fixed missing avatar icons if fetching from Steam fails (by @mexikoedi)
 
 ### Removed
 
@@ -120,6 +120,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Renamed `TTT2ModifyVoiceChatColor(ply, clr)` to `TTT2ModifyVoiceChatMode(ply, mode)`
 - Renamed `ply:GetHeightVector()` to `ply:GetHeadPosition()`
 - Removed the `TIPS` module and replaced it with a new `tips` module
+- Removed `draw.WebImage(url, x, y, width, height, color, angle, cornerorigin)` and `draw.SeamlessWebImage(url, parentwidth, parentheight, xrep, yrep, color)` from the `draw` module
 
 ## [v0.13.2b](https://github.com/TTT-2/TTT2/tree/0.13.2b) (2024-03-10)
 

--- a/lua/autorun/client/b-draw_lib.lua
+++ b/lua/autorun/client/b-draw_lib.lua
@@ -32,6 +32,101 @@ local math = math
 local mats = {}
 local fetched_avatar_urls = {}
 
+---
+-- Captures the content of a render target as a PNG image
+-- @param RenderTarget renderTarget The render target to capture
+-- @param Material material The material to use for rendering
+-- @param number width The width of the capture
+-- @param number height The height of the capture
+-- @return string The captured PNG data
+-- @realm client
+local function CaptureRenderTarget(renderTarget, material, width, height)
+    render.PushRenderTarget(renderTarget)
+    cam.Start2D()
+    surface.SetMaterial(material)
+    cam.End2D()
+
+    local data = render.Capture({
+        format = "png",
+        x = 0,
+        y = 0,
+        w = width,
+        h = height
+    })
+
+    render.PopRenderTarget()
+
+    return data
+end
+
+---
+-- Creates an avatar material for a given SteamID64 if it doesn't exist
+-- @param string id64 The SteamID64 of the user
+-- @return Material The created avatar material or nil if creation failed
+-- @realm client
+local function CreateAvatarMaterial(id64)
+    local size = 184 -- maximum allowed size
+    local renderTargetName = id64 .. size
+    local crcUrl = crc(renderTargetName)
+    local filePath = "downloaded_assets/" .. crcUrl .. ".png"
+
+    if exists(filePath, "DATA") then
+        return Material("data/" .. filePath)
+    end
+
+    local avatarImage = vgui.Create("AvatarImage")
+    avatarImage:SetSize(size, size)
+    avatarImage:SetSteamID(id64, size)
+    avatarImage:SetPaintedManually(true)
+
+    local renderTarget = GetRenderTargetEx(
+        renderTargetName,
+        size,
+        size,
+        RT_SIZE_NO_CHANGE,
+        MATERIAL_RT_DEPTH_NONE,
+        16,
+        CREATERENDERTARGETFLAGS_HDR,
+        IMAGE_FORMAT_RGBA8888
+    )
+
+    if not renderTarget then
+        avatarImage:Remove()
+
+        return nil
+    end
+
+    render.PushRenderTarget(renderTarget)
+    cam.Start2D()
+    avatarImage:PaintManual(true)
+    cam.End2D()
+    render.PopRenderTarget()
+
+    local material = CreateMaterial(id64 .. size, "UnlitGeneric", {
+        ["$basetexture"] = renderTargetName,
+        ["$nodecal"] = 1,
+        ["$nolod"] = 1,
+        ["$translucent"] = 1,
+        ["$vertexalpha"] = 1,
+        ["$vertexcolor"] = 1,
+    })
+
+    local data = CaptureRenderTarget(renderTarget, material, size, size)
+
+    if data then
+        write(filePath, data)
+    end
+
+    avatarImage:Remove()
+
+    return material
+end
+
+---
+-- Fetches an asset from the specified URL and caches it if successful
+-- @param string url The URL of the asset
+-- @return Material The material for the fetched asset
+-- @realm client
 local function FetchAsset(url)
     if not url then
         return
@@ -56,6 +151,12 @@ local function FetchAsset(url)
     end)
 end
 
+---
+-- Fetches an avatar asset for a given SteamID64 and size, with fallback support
+-- @param string id64 The SteamID64 of the user
+-- @param string size The size of the avatar, can be <code>small</code>, <code>medium</code> or <code>large</code>
+-- @return Material The avatar material if available or a fallback material if fetching fails
+-- @realm client
 local function FetchAvatarAsset(id64, size)
     if not id64 then
         return _bot_avatar
@@ -84,7 +185,9 @@ local function FetchAvatarAsset(id64, size)
         return
     end
 
-    fetch("http://steamcommunity.com/profiles/" .. id64 .. "/?xml=1", function(body)
+    local url = "http://steamcommunity.com/profiles/" .. id64 .. "/?xml=1"
+
+    fetch(url, function(body)
         local link = body:match("<avatarIcon><%!%[CDATA%[(.-)%]%]><%/avatarIcon>")
 
         if not link then
@@ -93,7 +196,16 @@ local function FetchAvatarAsset(id64, size)
 
         fetched_avatar_urls[key] = link:Replace(".jpg", size .. ".jpg")
         FetchAsset(fetched_avatar_urls[key])
+    end, function()
+        -- Fallback if fetching from Steam fails
+        local material = CreateAvatarMaterial(id64)
+
+        if material then
+            mats[key] = material
+        end
     end)
+
+    return mats[key]
 end
 
 ---
@@ -130,7 +242,7 @@ end
 
 ---
 -- Draws an Image
--- @param string url the url to the WebImage
+-- @param Material material the material to draw
 -- @param number x
 -- @param number y
 -- @param number width

--- a/lua/autorun/client/b-draw_lib.lua
+++ b/lua/autorun/client/b-draw_lib.lua
@@ -70,7 +70,7 @@ local function CreateAvatarMaterial(id64, size)
 
     if size == "large" then
         avatarSize = 184
-    elseif "medium" then
+    elseif size == "medium" then
         avatarSize = 64
     end
 
@@ -78,8 +78,14 @@ local function CreateAvatarMaterial(id64, size)
     local crcUrl = crc(renderTargetName)
     local filePath = "downloaded_assets/" .. crcUrl .. ".png"
 
+    if mats[renderTargetName] then
+        return mats[renderTargetName]
+    end
+
     if exists(filePath, "DATA") then
-        return Material("data/" .. filePath)
+        mats[renderTargetName] = Material("data/" .. filePath)
+
+        return mats[renderTargetName]
     end
 
     ---
@@ -89,8 +95,9 @@ local function CreateAvatarMaterial(id64, size)
 
     if data then
         write(filePath, data)
+        mats[renderTargetName] = Material("data/" .. filePath)
 
-        return Material("data/" .. filePath)
+        return mats[renderTargetName]
     end
 
     local avatarImage = vgui.Create("AvatarImage")
@@ -163,7 +170,7 @@ function draw.DropCacheAvatar(id64, size)
 
     if size == "large" then
         avatarSize = 184
-    elseif "medium" then
+    elseif size == "medium" then
         avatarSize = 64
     end
 

--- a/lua/autorun/client/b-draw_lib.lua
+++ b/lua/autorun/client/b-draw_lib.lua
@@ -51,7 +51,7 @@ local function CaptureRenderTarget(renderTarget, material, width, height)
         x = 0,
         y = 0,
         w = width,
-        h = height
+        h = height,
     })
 
     render.PopRenderTarget()

--- a/lua/ttt2/libraries/gameloop.lua
+++ b/lua/ttt2/libraries/gameloop.lua
@@ -672,6 +672,20 @@ if SERVER then
 
         events.Trigger(EVENT_GAME, state)
     end
+
+    hook.Add("TTT2LoadNextMap", "MapVoteCompat", function(nextMap, roundsLeft, timeLeft)
+        if not isfunction(CheckForMapSwitch) then
+            return
+        end
+
+        ErrorNoHalt(
+            "[TTT2] Using deprecated map vote overwrite. Replace your map vote addon and contact the addon developer."
+        )
+
+        CheckForMapSwitch()
+
+        return true
+    end)
 end
 
 if CLIENT then


### PR DESCRIPTION
Avatar icons are no longer fetched from Steam and are being created via [AvatarImage](https://wiki.facepunch.com/gmod/AvatarImage) instead.
The icon should appear much faster than before and therefore the player will always see an icon. (The fetching from Steam took a while and it was possible to see the default icon instead before the real avatar icon was shown.)
Should also solve the issue which some players from China had because Steam is blocked there.
Tested it on v0.14 and it seemed to work great (saving/loading also works).