### PR TITLE
Player/Roles: Added Fallback Colors

### DIFF
--- a/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
@@ -228,11 +228,7 @@ end
 -- @return Color
 -- @realm shared
 function plymeta:GetRoleColor()
-    if not self.roleColor then
-        self.roleColor = roles.NONE.color
-    end
-
-    return self.roleColor
+    return self.roleColor or roles.NONE.color
 end
 
 ---
@@ -251,7 +247,7 @@ end
 -- @return Color
 -- @realm shared
 function plymeta:GetRoleDkColor()
-    return self.roleDkColor
+    return self.roleDkColor or roles.NONE.dkcolor
 end
 
 ---
@@ -270,7 +266,7 @@ end
 -- @return Color
 -- @realm shared
 function plymeta:GetRoleLtColor()
-    return self.roleLtColor
+    return self.roleLtColor or roles.NONE.ltcolor
 end
 
 ---
@@ -289,7 +285,7 @@ end
 -- @return Color
 -- @realm shared
 function plymeta:GetRoleBgColor()
-    return self.roleBgColor
+    return self.roleBgColor or roles.NONE.bgcolor
 end
 
 ---


### PR DESCRIPTION
Fixed an issue @sbzlzh noticed where there are errors on color access in the first round. Strangely this only happens if it is the first round and ROLE_NONE. This fix looks kinda hacky imho, but the issue here seems to be rooted way deeper. I think it has probebaly something to do with our role syncing and that the default is alredy ROLE_NONE, so a role change is never triggered.

Moreover the same hacky solution was already implemented for the default role color call. In my opinion this solution is fine, but we should keep this issue in mind in case we refactor the role syncing at some point.

This issue also probably existed since our introduction of ROLE_NONE. Nobody noticed it, because the default player amount is 2. And with two players, there are roles assigned.