### PR TITLE
Sidebar: Added translation to OldTTT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed undefined Keys breaking the gamemode (by @TimGoll)
 - Fixed markerVision elements being visible to team mates of unknown teams (such as team Innocent) (by @TimGoll)
 - Fixed inverted settings being inverted twice in the equipment editor (by @TimGoll)
+- Fixed OldTTT HUD sidebar elements missing translation (by @TimGoll)
 
 ### Removed
 

--- a/gamemodes/terrortown/gamemode/shared/hud_elements/tttsidebar/old_ttt_sidebar.lua
+++ b/gamemodes/terrortown/gamemode/shared/hud_elements/tttsidebar/old_ttt_sidebar.lua
@@ -10,6 +10,8 @@ DEFINE_BASECLASS(base)
 HUDELEMENT.Base = base
 
 if CLIENT then
+    local TryT = LANG.TryTranslation
+
     local size = 64
 
     local const_defaults = {
@@ -90,7 +92,7 @@ if CLIENT then
             )
 
             if isfunction(item.DrawInfo) then
-                local info = item:DrawInfo()
+                local info = TryT(item:DrawInfo())
                 if info then
                     -- right bottom corner
                     local tx = pos.x + size


### PR DESCRIPTION
When adding translation support to sidebar info elements, it was forgotten to also add it to OldTTT. This is now fixed.