### PR TITLE
Fetch: Fixed refreshing of avatar icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Added role derandomization options for perceptually fairer role distribution, enabled by default (by @nike4613)
 - Added targetID to buttons (by @TimGoll)
 - Added force role admin command (by @mexikoedi)
-- Added `draw.RefreshAvatars(id64)` to refresh avater icons (by @mexikoedi)
+- Added `draw.RefreshAvatars(id64)` to refresh avatar icons (by @mexikoedi)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Added role derandomization options for perceptually fairer role distribution, enabled by default (by @nike4613)
 - Added targetID to buttons (by @TimGoll)
 - Added force role admin command (by @mexikoedi)
+- Added `draw.RefreshAvatars(id64)` to refresh avater icons (by @mexikoedi)
 
 ### Changed
 
@@ -108,6 +109,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed markerVision elements being visible to team mates of unknown teams (such as team Innocent) (by @TimGoll)
 - Fixed inverted settings being inverted twice in the equipment editor (by @TimGoll)
 - Fixed OldTTT HUD sidebar elements missing translation (by @TimGoll)
+- Fixed avatar icons not refreshing if they were changed on Steam (by @mexikoedi)
 
 ### Removed
 

--- a/gamemodes/terrortown/gamemode/client/cl_main.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_main.lua
@@ -335,6 +335,15 @@ function GM:InitPostEntity()
 
     RunConsoleCommand("_ttt_request_serverlang")
     RunConsoleCommand("_ttt_request_rolelist")
+
+    -- deletes old avatars and caches new ones
+    timer.Simple(0, function()
+        local plys = playerGetAll()
+        for i = 1, #plys do
+            local plyid64 = plys[i]:SteamID64()
+            draw.RefreshAvatars(plyid64)
+        end
+    end)
 end
 
 ---

--- a/gamemodes/terrortown/gamemode/client/cl_main.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_main.lua
@@ -335,15 +335,6 @@ function GM:InitPostEntity()
 
     RunConsoleCommand("_ttt_request_serverlang")
     RunConsoleCommand("_ttt_request_rolelist")
-
-    -- deletes old avatars and caches new ones
-    timer.Simple(0, function()
-        local plys = playerGetAll()
-        for i = 1, #plys do
-            local plyid64 = plys[i]:SteamID64()
-            draw.RefreshAvatars(plyid64)
-        end
-    end)
 end
 
 ---
@@ -960,11 +951,6 @@ net.Receive("TTT2PlayerAuthedShared", function(len)
     if steamid64 == "" then
         steamid64 = nil
     end
-
-    -- deletes old avatars and caches new ones
-    timer.Simple(0, function()
-        draw.RefreshAvatars(steamid64)
-    end)
 
     ---
     -- @realm shared

--- a/gamemodes/terrortown/gamemode/client/cl_main.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_main.lua
@@ -329,17 +329,6 @@ function GM:InitPostEntity()
         self:ClearClientState()
     end
 
-    -- cache players avatar
-    local plys = playerGetAll()
-    for i = 1, #plys do
-        local plyid64 = plys[i]:SteamID64()
-
-        -- caching
-        draw.CacheAvatar(plyid64, "small")
-        draw.CacheAvatar(plyid64, "medium")
-        draw.CacheAvatar(plyid64, "large")
-    end
-
     timer.Create("cache_ents", 1, 0, function()
         self:DoCacheEnts()
     end)
@@ -963,10 +952,10 @@ net.Receive("TTT2PlayerAuthedShared", function(len)
         steamid64 = nil
     end
 
-    -- cache avatars
-    draw.CacheAvatar(steamid64, "small")
-    draw.CacheAvatar(steamid64, "medium")
-    draw.CacheAvatar(steamid64, "large")
+    -- deletes old avatars and caches new ones
+    timer.Simple(0, function()
+        draw.RefreshAvatars(steamid64)
+    end)
 
     ---
     -- @realm shared

--- a/gamemodes/terrortown/gamemode/client/cl_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_player_ext.lua
@@ -238,8 +238,8 @@ end
 net.Receive("TTT_Equipment", UpdateEquipment)
 
 -- Deletes old avatars and caches new ones
-local function CacheAllPlayerAvatars()
-    local plys = player.GetAll()
+local function CacheAllPlayerAvatars(ply)
+    local plys = IsPlayer(ply) and {ply} or player.GetAll()
 
     for i = 1, #plys do
         local plyid64 = plys[i]:SteamID64()
@@ -291,7 +291,7 @@ function GM:SetupMove(ply, mv, cmd)
     end
 
     -- Cache avatars for all players currently on the server
-    CacheAllPlayerAvatars()
+    CacheAllPlayerAvatars(ply)
 end
 
 net.Receive("TTT2NotifyPlayerReadyOnClients", function()
@@ -308,8 +308,8 @@ net.Receive("TTT2NotifyPlayerReadyOnClients", function()
     -- stylua: ignore
     hook.Run("TTT2PlayerReady", ply)
 
-    -- Cache avatars for all players currently on the server (with the new player included)
-    CacheAllPlayerAvatars()
+    -- Cache avatar of the new player
+    CacheAllPlayerAvatars(ply)
 end)
 
 ---

--- a/gamemodes/terrortown/gamemode/client/cl_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_player_ext.lua
@@ -237,6 +237,16 @@ local function UpdateEquipment()
 end
 net.Receive("TTT_Equipment", UpdateEquipment)
 
+-- Deletes old avatars and caches new ones
+local function CacheAllPlayerAvatars()
+    local plys = player.GetAll()
+
+    for i = 1, #plys do
+        local plyid64 = plys[i]:SteamID64()
+        draw.RefreshAvatars(plyid64)
+    end
+end
+
 ---
 -- SetupMove is called before the engine process movements. This allows us
 -- to override the players movement.
@@ -279,6 +289,9 @@ function GM:SetupMove(ply, mv, cmd)
         -- stylua: ignore
         hook.Run("OnScreenSizeChanged", oldScrW, oldScrH)
     end
+
+    -- Cache avatars for all players currently on the server
+    CacheAllPlayerAvatars()
 end
 
 net.Receive("TTT2NotifyPlayerReadyOnClients", function()
@@ -294,6 +307,9 @@ net.Receive("TTT2NotifyPlayerReadyOnClients", function()
     -- @realm shared
     -- stylua: ignore
     hook.Run("TTT2PlayerReady", ply)
+
+    -- Cache avatars for all players currently on the server (with the new player included)
+    CacheAllPlayerAvatars()
 end)
 
 ---

--- a/gamemodes/terrortown/gamemode/client/cl_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_player_ext.lua
@@ -239,7 +239,7 @@ net.Receive("TTT_Equipment", UpdateEquipment)
 
 -- Deletes old avatars and caches new ones
 local function CacheAllPlayerAvatars(ply)
-    local plys = IsPlayer(ply) and {ply} or player.GetAll()
+    local plys = IsPlayer(ply) and { ply } or player.GetAll()
 
     for i = 1, #plys do
         local plyid64 = plys[i]:SteamID64()

--- a/lua/autorun/client/b-draw_lib.lua
+++ b/lua/autorun/client/b-draw_lib.lua
@@ -82,12 +82,6 @@ local function CreateAvatarMaterial(id64, size)
         return mats[renderTargetName]
     end
 
-    if exists(filePath, "DATA") then
-        mats[renderTargetName] = Material("data/" .. filePath)
-
-        return mats[renderTargetName]
-    end
-
     ---
     -- @realm client
     -- stylua: ignore
@@ -147,6 +141,19 @@ local function CreateAvatarMaterial(id64, size)
     mats[renderTargetName] = material
 
     return material
+end
+
+---
+-- Refreshes the avatar images by deleting old cached images and generating new ones
+-- @param string id64 The steamid64 of the player
+-- @realm client
+function draw.RefreshAvatars(id64)
+    draw.DropCacheAvatar(id64, "small")
+    draw.DropCacheAvatar(id64, "medium")
+    draw.DropCacheAvatar(id64, "large")
+    draw.CacheAvatar(id64, "small")
+    draw.CacheAvatar(id64, "medium")
+    draw.CacheAvatar(id64, "large")
 end
 
 ---


### PR DESCRIPTION
Avatar icons are now being refreshed.

It works like this:
If you don't have any icons saved then new ones will be created, cached and used.
Otherwise the already existing icons will be deleted, then they will be created, cached and used.

So if the player changes his avatar icon the already existing ones will be replaced with the new one.

Tested it on v0.14 and it seemed to work.
(The part with the "exists" is not needed anymore because they are always cached or they don't exit.)