### PR TITLE
Loadingscreen: Cleanup

### DIFF
--- a/lua/ttt2/libraries/gameloop.lua
+++ b/lua/ttt2/libraries/gameloop.lua
@@ -162,6 +162,10 @@ if SERVER then
             gameloop.SetLevelStartTime(CurTime())
         end
 
+        -- make sure that the duration of the loading screen is added to the
+        -- duration of the prep time
+        timePrepPhase = timePrepPhase + loadingscreen.GetDuration()
+
         gameloop.mapWinType = WIN_NONE
 
         -- reset the role of all players on the server and client

--- a/lua/ttt2/libraries/loadingscreen.lua
+++ b/lua/ttt2/libraries/loadingscreen.lua
@@ -56,9 +56,6 @@ function loadingscreen.End()
     end
 
     if SERVER then
-        print(loadingscreen.timeBegin)
-        print(SysTime())
-        print(loadingscreen.GetDuration())
         local duration = loadingscreen.timeBegin - SysTime() + loadingscreen.GetDuration()
 
         -- this timer makes sure the loading screen is displayed for at least the

--- a/lua/ttt2/libraries/loadingscreen.lua
+++ b/lua/ttt2/libraries/loadingscreen.lua
@@ -61,6 +61,8 @@ function loadingscreen.End()
         print(loadingscreen.GetDuration())
         local duration = loadingscreen.timeBegin - SysTime() + loadingscreen.GetDuration()
 
+        -- this timer makes sure the loading screen is displayed for at least the
+        -- time that is set as the minimum time
         timer.Create("TTT2LoadingscreenEndTime", duration, 1, function()
             loadingscreen.isShown = false
 
@@ -85,10 +87,18 @@ if SERVER then
         end
     end)
 
+    ---
+    -- Reads the minimum time that a loadingscreen should have.
+    -- @return number The minimum time
+    -- @realm server
     function loadingscreen.GetDuration()
         return loadingscreen.duration or 4
     end
 
+    ---
+    -- Sets the minimum time that a loadingscreen should have.
+    -- @param number duration The minimum time in seconds
+    -- @realm server
     function loadingscreen.SetDuration(duration)
         loadingscreen.duration = duration
     end
@@ -181,6 +191,8 @@ if CLIENT then
                 - math.min((SysTime() - loadingscreen.timeStateChange) / durationStateChange, 1.0)
         end
 
+        -- stop rendering the loadingscreen if the progress is close to 0, this removes
+        -- an ugly step when transitioning from blurry to sharp
         if progress < 0.01 then
             return
         end


### PR DESCRIPTION
As requested on Discord I added a minimum render time, by default it is 4 seconds. For now you can't change it via convar, you have to call `loadingscreen.SetDuration` to edit that.

Moreover I cleaned up the rendering of the loadingscreen, mostly by improving the blurry-ness