### PR TITLE
PlayerReady: Extended Syncing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Made `ply:IsReviving` a shared player variable (by @TimGoll)
 - Updated and improved the Simplified Chinese localization file (by @sbzlzh and @TheOnly8Z)
 - Avatar icons are not fetched anymore but instead created with `AvatarImage` (fixes missing icons for chinese players) (by @mexikoedi)
+- `GM:TTT2PlayerReady` is now called for every player even on clients (by @TimGoll)
 
 ### Fixed
 
@@ -122,6 +123,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Renamed `ply:GetHeightVector()` to `ply:GetHeadPosition()`
 - Removed the `TIPS` module and replaced it with a new `tips` module
 - Removed `draw.WebImage(url, x, y, width, height, color, angle, cornerorigin)` and `draw.SeamlessWebImage(url, parentwidth, parentheight, xrep, yrep, color)` from the `draw` module
+- Due to `GM:TTT2PlayerReady` now being called for every player, addon devs have to make sure to check the player on the client
 
 ## [v0.13.2b](https://github.com/TTT-2/TTT2/tree/0.13.2b) (2024-03-10)
 

--- a/gamemodes/terrortown/gamemode/client/cl_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_player_ext.lua
@@ -284,7 +284,9 @@ end
 net.Receive("TTT2NotifyPlayerReadyOnClients", function()
     local ply = net.ReadPlayer()
 
-    if not IsValid(ply) then return end
+    if not IsValid(ply) then
+        return
+    end
 
     ply.isReady = true
 

--- a/gamemodes/terrortown/gamemode/client/cl_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_player_ext.lua
@@ -252,7 +252,13 @@ function GM:SetupMove(ply, mv, cmd)
         return
     end
 
-    ply.isReady = true
+    -- we make the assumption that every player, that already is connected
+    -- is ready. We can't tell for sure, but this is the best we can do here
+    local plys = player.GetAll()
+
+    for i = 1, #plys do
+        plys[i].isReady = true
+    end
 
     net.Start("TTT2SetPlayerReady")
     net.SendToServer()

--- a/gamemodes/terrortown/gamemode/client/cl_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_player_ext.lua
@@ -275,6 +275,19 @@ function GM:SetupMove(ply, mv, cmd)
     end
 end
 
+net.Receive("TTT2NotifyPlayerReadyOnClients", function()
+    local ply = net.ReadPlayer()
+
+    if not IsValid(ply) then return end
+
+    ply.isReady = true
+
+    ---
+    -- @realm shared
+    -- stylua: ignore
+    hook.Run("TTT2PlayerReady", ply)
+end)
+
 ---
 -- Sets a revival reason that is displayed in the revival HUD element.
 -- It supports a language identifier for translated strings.

--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -22,6 +22,7 @@ local soundWeaponPickup = Sound("items/ammo_pickup.wav")
 util.AddNetworkString("StartDrowning")
 util.AddNetworkString("TTT2TargetPlayer")
 util.AddNetworkString("TTT2SetPlayerReady")
+util.AddNetworkString("TTT2NotifyPlayerReadyOnClients")
 util.AddNetworkString("TTT2SetRevivalReason")
 util.AddNetworkString("TTT2RevivalStopped")
 util.AddNetworkString("TTT2RevivalUpdate_IsReviving")
@@ -1710,6 +1711,15 @@ local function SetPlayerReady(_, ply)
     -- @realm server
     -- stylua: ignore
     hook.Run("TTT2PlayerReady", ply)
+
+    -- notify all other players as well that this player is ready
+    local receipients = return GetPlayerFilter(function(p)
+        return p ~= ply and p:IsReady()
+    end)
+
+    net.Start("TTT2NotifyPlayerReadyOnClients")
+    net.WritePlayer(ply)
+    net.Send(receipients)
 end
 net.Receive("TTT2SetPlayerReady", SetPlayerReady)
 

--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -1713,13 +1713,13 @@ local function SetPlayerReady(_, ply)
     hook.Run("TTT2PlayerReady", ply)
 
     -- notify all other players as well that this player is ready
-    local receipients = GetPlayerFilter(function(p)
+    local recipients = GetPlayerFilter(function(p)
         return p ~= ply and p:IsReady()
     end)
 
     net.Start("TTT2NotifyPlayerReadyOnClients")
     net.WritePlayer(ply)
-    net.Send(receipients)
+    net.Send(recipients)
 end
 net.Receive("TTT2SetPlayerReady", SetPlayerReady)
 

--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -1713,7 +1713,7 @@ local function SetPlayerReady(_, ply)
     hook.Run("TTT2PlayerReady", ply)
 
     -- notify all other players as well that this player is ready
-    local receipients = return GetPlayerFilter(function(p)
+    local receipients = GetPlayerFilter(function(p)
         return p ~= ply and p:IsReady()
     end)
 

--- a/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
@@ -1067,6 +1067,9 @@ end
 -- Returns whether the player is ready. A player is ready when he is able to look
 -- around and move (first call of @{GM:SetupMove}). A bot player is always considered
 -- as ready.
+-- @note If called on the client, it is only 100% reliable for the local player. While the
+-- restult for other players is most likely still true, it can have some issues in certain
+-- scenarios.
 -- @return boolean
 -- @realm shared
 function plymeta:IsReady()

--- a/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_player_ext.lua
@@ -1067,7 +1067,7 @@ end
 -- Returns whether the player is ready. A player is ready when he is able to look
 -- around and move (first call of @{GM:SetupMove}). A bot player is always considered
 -- as ready.
--- @note If called on the client, it is only 100% reliable for the local player. While the
+-- @warning If called on the client, it is only 100% reliable for the local player. While the
 -- restult for other players is most likely still true, it can have some issues in certain
 -- scenarios.
 -- @return boolean


### PR DESCRIPTION
As discussed with @mexikoedi, I made `GM:TTT2PlayerReady` fully shared to be used in his #1600 PR. This might cause issues with third party addons, but at least for our addons, the change is fine. And I'm pretty sure nobody else is using that hook anyway.

To test:
- is `GM:SetupMove` only called for the local player on clients? I think so, but it has to be confirmed
- does this work at all?
- is every player on the client marked as ready, no matter the order in which the players connected?