### PR TITLE
Buttons: Further Fixes

### DIFF
--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -931,7 +931,6 @@ end
 -- @realm server
 function GM:TTT2PlayerFinishedReloading(ply)
     map.SyncToClient(ply)
-    button.SyncToClient(ply)
 end
 
 ---

--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -1697,7 +1697,6 @@ local function SetPlayerReady(_, ply)
     entspawnscript.TransmitToPlayer(ply)
 
     map.SyncToClient(ply)
-    button.SyncToClient(ply)
 
     gameloop.PlayerReady(ply)
 

--- a/gamemodes/terrortown/gamemode/shared/sh_entity.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_entity.lua
@@ -18,29 +18,11 @@ function entmeta:IsPlayerRagdoll()
 end
 
 ---
--- Sets the information if this entity is a default button.
--- @note: This function does not network the information.
--- @param boolean state The new state
--- @realm shared
-function entmeta:SetDefaultButton(state)
-    self.isDefaultButton = state
-end
-
----
 -- Returns true if this entity is a default button.
 -- @return boolean Returns true if default button
 -- @realm shared
 function entmeta:IsDefaultButton()
-    return self.isDefaultButton or false
-end
-
----
--- Sets the information if this entity is a rotating button.
--- @note: This function does not network the information.
--- @param boolean state The new state
--- @realm shared
-function entmeta:SetRotatingButton(state)
-    self.isRotatingButton = state
+    return button.IsClass(self, "func_button")
 end
 
 ---
@@ -48,7 +30,7 @@ end
 -- @return boolean Returns true if rotating button
 -- @realm shared
 function entmeta:IsRotatingButton()
-    return self.isRotatingButton or false
+    return button.IsClass(self, "func_rot_button")
 end
 
 ---

--- a/lua/ttt2/libraries/buttons.lua
+++ b/lua/ttt2/libraries/buttons.lua
@@ -14,31 +14,7 @@ local validButtons = {
     "func_rot_button",
 }
 
-local function UpdateStates(foundButtons)
-    for class, list in pairs(foundButtons) do
-        for i = 1, #list do
-            local ent = list[i]
-
-            if not IsValid(ent) then
-                continue
-            end
-
-            if class == "func_button" then
-                ent:SetDefaultButton(true)
-            end
-
-            if class == "func_rot_button" then
-                ent:SetRotatingButton(true)
-            end
-
-            ent:SetNotSolid(false)
-        end
-    end
-end
-
 if SERVER then
-    local foundButtons = {}
-
     ---
     -- Setting up all buttons found on a map, this is done on every map reset (on prepare round).
     -- @internal
@@ -46,27 +22,26 @@ if SERVER then
     function button.SetUp()
         for i = 1, #validButtons do
             local classButton = validButtons[i]
+            local buttonsTable = ents.FindByClass(classButton)
 
-            foundButtons[classButton] = ents.FindByClass(classButton)
+            for j = 1, #buttonsTable do
+                local foundButton = buttonsTable[j]
+
+                foundButton:SetNotSolid(false)
+                foundButton:SetSolid(SOLID_BSP)
+
+                foundButton:SetNWInt("button_class", i)
+            end
         end
-
-        -- sync to client and set state
-        UpdateStates(foundButtons)
-        net.SendStream("TTT2SyncButtonEntities", foundButtons)
-    end
-
-    ---
-    -- Resyncs button states to the client if they late connect or hotreload.
-    -- @param Player ply The player to sync to
-    -- @internal
-    -- @realm server
-    function button.SyncToClient(ply)
-        net.SendStream("TTT2SyncButtonEntities", foundButtons, ply)
     end
 end
 
-if CLIENT then
-    net.ReceiveStream("TTT2SyncButtonEntities", function(foundButtons)
-        UpdateStates(foundButtons)
-    end)
+function button.IsClass(ent, class)
+    local classID = ent:GetNWInt("button_class")
+
+    if not classID or classID > #validButtons then
+        return
+    end
+
+    return validButtons[classID] == class
 end

--- a/lua/ttt2/libraries/buttons.lua
+++ b/lua/ttt2/libraries/buttons.lua
@@ -36,6 +36,15 @@ if SERVER then
     end
 end
 
+---
+-- Checks if a given button entity has the provided class.
+-- @note This is checked like this, because buttons and levers
+-- lose their specific class name on the client and therefore use custom
+-- syncing here.
+-- @param Entity ent The button entity that should be checked
+-- @param string class The class name
+-- @return boolean Returns true if the entity matches the provided class name
+-- @realm shared
 function button.IsClass(ent, class)
     local classID = ent:GetNWInt("button_class")
 


### PR DESCRIPTION
This pullrequest introduces a further fix to buttons that were introduced by the move of use calls to the client. It fixes the same issue the last PR (#1580) attempted to fix, but this time it improves upon this. Two things are done in this PR:

- added `foundButton:SetSolid(SOLID_BSP)` to make sure all buttons on the map can be actually hit by a trace. This also fixes the issue introduced in the last PR, where some buttons now had a hitbox the player could collide with
- rewrote the syncing to the client as it was a nightmare. Many entites are NULL entities on the client if the player is too far away. This new approach with NWInts fixes this because it makes use of the internal GMod systems.