### PR TITLE
Buttons: Changed Trace Mask

### DIFF
--- a/gamemodes/terrortown/gamemode/client/cl_keys.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_keys.lua
@@ -84,7 +84,7 @@ function GM:PlayerBindPress(ply, bindName, pressed)
                 start = ply:GetShootPos(),
                 endpos = ply:GetShootPos() + ply:GetAimVector() * 100,
                 filter = ply,
-                mask = MASK_SHOT,
+                mask = MASK_ALL,
             })
 
             useEnt = tr.Entity

--- a/lua/ttt2/libraries/targetid.lua
+++ b/lua/ttt2/libraries/targetid.lua
@@ -100,7 +100,7 @@ function targetid.FindEntityAlongView(pos, dir, filter)
     local trace = util.TraceLine({
         start = pos,
         endpos = endpos,
-        mask = MASK_SHOT,
+        mask = MASK_ALL,
         filter = filter,
     })
 


### PR DESCRIPTION
Changed trace mask to `MASK_ALL`. I did the same for targetID, so that it reliably shows the targetID as well. Seems to fix all issues for minecraft based maps.