### PR TITLE
Buttons: Added Cancelable Hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Added targetID to buttons (by @TimGoll)
 - Added force role admin command (by @mexikoedi)
 - Added `draw.RefreshAvatars(id64)` to refresh avatar icons (by @mexikoedi)
+- Added `GM:TTT2OnButtonUse(ply, ent, oldState)`: a hook that is triggered when a button is pressed and that is able to prevent that button press (by @TimGoll)
 
 ### Changed
 

--- a/gamemodes/terrortown/gamemode/server/sv_player.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player.lua
@@ -595,7 +595,7 @@ end)
 ---
 -- A hook that is called before a button is pressed. Can be used to cancel the event by returning false.
 -- @param Player ply The player that pressed the button
--- @param Entity ent The button entitiy
+-- @param Entity ent The button entity
 -- @param boolean oldState The old toggle state of the button before it was pressed
 -- @return boolean return false to prevent the player from using that button
 -- @hook

--- a/gamemodes/terrortown/gamemode/server/sv_player.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player.lua
@@ -548,6 +548,15 @@ net.Receive("TTT2PlayerUseEntity", function(len, ply)
         return
     end
 
+    if
+        ---
+        -- @realm server
+        -- stylua: ignore
+        hook.Run("TTT2OnButtonUse", ply, ent, ent:GetInternalVariable("m_toggle_state")) == false
+    then
+        return
+    end
+
     ---
     -- Enable addons to allow handling PlayerUse
     -- Otherwise default to old IsTerror Check
@@ -559,6 +568,7 @@ net.Receive("TTT2PlayerUseEntity", function(len, ply)
 
     if ply:IsSpec() then
         SpecUseKey(ply, ent)
+
         return
     end
 
@@ -580,6 +590,16 @@ net.Receive("TTT2PlayerUseEntity", function(len, ply)
         ply:SafePickupWeapon(ent, false, true, true, nil)
     end
 end)
+
+---
+-- A hook that is called before a button is pressed. Can be used to cancel the event by returning false.
+-- @param Player ply The player that pressed the button
+-- @param Entity ent The button entitiy
+-- @param boolean oldState The old toggle state of the button before it was pressed
+-- @return boolean return false to prevent the player from using that button
+-- @hook
+-- @realm server
+function GM:TTT2OnButtonUse(ply, ent, oldState) end
 
 ---
 -- Called when a @{Player} leaves the server. See the <a href="https://wiki.facepunch.com/gmod/gameevent/player_disconnect">player_disconnect gameevent</a> for a shared version of this hook.

--- a/gamemodes/terrortown/gamemode/server/sv_player.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player.lua
@@ -553,7 +553,8 @@ net.Receive("TTT2PlayerUseEntity", function(len, ply)
         ---
         -- @realm server
         -- stylua: ignore
-        and hook.Run("TTT2OnButtonUse", ply, ent, ent:GetInternalVariable("m_toggle_state")) == false
+        and hook.Run("TTT2OnButtonUse", ply, ent, ent:GetInternalVariable("m_toggle_state"))
+            == false
     then
         return
     end

--- a/gamemodes/terrortown/gamemode/server/sv_player.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player.lua
@@ -549,10 +549,11 @@ net.Receive("TTT2PlayerUseEntity", function(len, ply)
     end
 
     if
+        ent:IsButton()
         ---
         -- @realm server
         -- stylua: ignore
-        hook.Run("TTT2OnButtonUse", ply, ent, ent:GetInternalVariable("m_toggle_state")) == false
+        and hook.Run("TTT2OnButtonUse", ply, ent, ent:GetInternalVariable("m_toggle_state")) == false
     then
         return
     end


### PR DESCRIPTION
Added a cancelable hook that is triggered on button use. This is needed for an addon that I want to create that adds further info to buttons (like a description of the button depending on its state)

```lua
---
-- A hook that is called before a button is pressed. Can be used to cancel the event by returning false.
-- @param Player ply The player that pressed the button
-- @param Entity ent The button entitiy
-- @param boolean oldState The old toggle state of the button before it was pressed
-- @return boolean return false to prevent the player from using that button
-- @hook
-- @realm server
function GM:TTT2OnButtonUse(ply, ent, oldState)
```