### PR TITLE
Buttons: Added Serverside Fallback

### DIFF
--- a/gamemodes/terrortown/gamemode/client/cl_keys.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_keys.lua
@@ -88,6 +88,7 @@ function GM:PlayerBindPress(ply, bindName, pressed)
             })
 
             useEnt = tr.Entity
+
             if not tr.Hit or not IsValid(useEnt) then
                 useEnt = nil
             end

--- a/gamemodes/terrortown/gamemode/client/cl_keys.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_keys.lua
@@ -89,10 +89,10 @@ function GM:PlayerBindPress(ply, bindName, pressed)
 
             useEnt = tr.Entity
             if not tr.Hit or not IsValid(useEnt) then
-                return
+                useEnt = nil
             end
 
-            if isfunction(useEnt.ClientUse) then
+            if useEnt and isfunction(useEnt.ClientUse) then
                 isClientOnly = useEnt:ClientUse()
             end
         elseif isfunction(useEnt.RemoteUse) then
@@ -107,6 +107,7 @@ function GM:PlayerBindPress(ply, bindName, pressed)
         end
 
         net.Start("TTT2PlayerUseEntity")
+        net.WriteBool(useEnt ~= nil)
         net.WriteEntity(useEnt)
         net.WriteBool(isRemote)
         net.SendToServer()

--- a/gamemodes/terrortown/gamemode/server/sv_entity.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_entity.lua
@@ -2,6 +2,12 @@
 -- @ref https://wiki.facepunch.com/gmod/Entity
 -- @class Entity
 
+-- Caps taken from here: https://github.com/ValveSoftware/source-sdk-2013/blob/55ed12f8d1eb6887d348be03aee5573d44177ffb/mp/src/game/shared/baseentity_shared.h#L21-L38
+FCAP_IMPULSE_USE = 16
+FCAP_CONTINUOUS_USE = 32
+FCAP_ONOFF_USE = 64
+FCAP_DIRECTIONAL_USE = 128
+
 local safeCollisionGroups = {
     [COLLISION_GROUP_WEAPON] = true,
 }
@@ -68,4 +74,29 @@ function entmeta:Spawn()
     end
 
     oldSpawn(self)
+end
+
+---
+-- Checks if the entity has any use functionality activated.
+-- @param[default=0] number requiredCaps Use caps that are required for this entity
+-- @return boolean Returns true if the entity is usable by the player
+-- @ref https://github.com/ValveSoftware/source-sdk-2013/blob/0d8dceea4310fde5706b3ce1c70609d72a38efdf/sp/src/game/server/player.cpp#L2766C71-L2781
+-- @realm server
+function entmeta:IsUsableEntity(requiredCaps)
+    requiredCaps = requiredCaps or 0
+
+    local caps = self:ObjectCaps()
+
+    if
+        bit.band(
+                caps,
+                bit.bor(FCAP_IMPULSE_USE, FCAP_CONTINUOUS_USE, FCAP_ONOFF_USE, FCAP_DIRECTIONAL_USE)
+            )
+            > 0
+        and bit.band(caps, requiredCaps) == requiredCaps
+    then
+        return true
+    end
+
+    return false
 end

--- a/gamemodes/terrortown/gamemode/server/sv_entity.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_entity.lua
@@ -77,7 +77,7 @@ function entmeta:Spawn()
 end
 
 ---
--- Checks if the entity has any use functionality activated.
+-- Checks if the entity has any use functionality attached.
 -- @param[default=0] number requiredCaps Use caps that are required for this entity
 -- @return boolean Returns true if the entity is usable by the player
 -- @ref https://github.com/ValveSoftware/source-sdk-2013/blob/0d8dceea4310fde5706b3ce1c70609d72a38efdf/sp/src/game/server/player.cpp#L2766C71-L2781

--- a/gamemodes/terrortown/gamemode/server/sv_player.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player.lua
@@ -530,7 +530,7 @@ net.Receive("TTT2PlayerUseEntity", function(len, ply)
     local ent = net.ReadEntity()
     local isRemote = net.ReadBool()
 
-    if not hasEnt then
+    if not hasEnt or not ent:IsUsableEntity() then
         ent = ply:GetUseEntity()
     end
 

--- a/gamemodes/terrortown/gamemode/server/sv_player.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player.lua
@@ -526,8 +526,13 @@ end
 -- @realm server
 -- @internal
 net.Receive("TTT2PlayerUseEntity", function(len, ply)
+    local hasEnt = net.ReadBool()
     local ent = net.ReadEntity()
     local isRemote = net.ReadBool()
+
+    if not hasEnt then
+        ent = ply:GetUseEntity()
+    end
 
     if not IsValid(ent) then
         return

--- a/lua/ttt2/libraries/targetid.lua
+++ b/lua/ttt2/libraries/targetid.lua
@@ -606,7 +606,7 @@ function targetid.HUDDrawTargetIDButtons(tData)
         or not client:IsTerror()
         or not IsValid(ent)
         or not ent:IsButton()
-        or tData:GetEntityDistance() > 90
+        or tData:GetEntityDistance() > 100
     then
         return
     end


### PR DESCRIPTION
Since there were still issues with clientside use detection (at least on the map `ttt_mc_jondome` one button refused to work), I added a serverside fallback. If the client doesn't detect any entity on use press, the server uses the engine function to detect any use entity close by. This works.

Only downside is that it triggers uses for entities where the targetID is just slightly out of range. However this is how it has been in 0.13.2 and earlier as well.

Update: In the last commit I implmented `IsUsableEntity` from the sourceSDK in lua. All important links to the original code are in the added code. I had to do this because enties without a `+use` assigned could block the trace. Now it uses the aforementioned serverside fallback if an entity has no use.

![image](https://github.com/user-attachments/assets/e5943562-5cee-44d8-ae11-9d1e3e583d77)

https://discord.com/channels/442107660955942932/467653559408656384/1285124499401998356