### PR TITLE
Buttons: Post Button Init Hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Added force role admin command (by @mexikoedi)
 - Added `draw.RefreshAvatars(id64)` to refresh avatar icons (by @mexikoedi)
 - Added `GM:TTT2OnButtonUse(ply, ent, oldState)`: a hook that is triggered when a button is pressed and that is able to prevent that button press (by @TimGoll)
+- Added `GM:TTT2PostButtonInitialization(buttonList)`: a hook that is called after all buttons on the map have been initialized (by @TimGoll)
 
 ### Changed
 

--- a/lua/ttt2/libraries/buttons.lua
+++ b/lua/ttt2/libraries/buttons.lua
@@ -20,9 +20,13 @@ if SERVER then
     -- @internal
     -- @realm server
     function button.SetUp()
+        local buttonList = {}
+
         for i = 1, #validButtons do
             local classButton = validButtons[i]
             local buttonsTable = ents.FindByClass(classButton)
+
+            buttonList[classButton] = buttonsTable
 
             for j = 1, #buttonsTable do
                 local foundButton = buttonsTable[j]
@@ -33,7 +37,20 @@ if SERVER then
                 foundButton:SetNWInt("button_class", i)
             end
         end
+
+        ---
+        -- @realm server
+        -- stylua: ignore
+        hook.Run("TTT2PostButtonInitialization", buttonList)
     end
+
+    ---
+    -- Hook that is called after all buttons were initialized on the map. This happens after
+    -- a map cleanup when a new round starts or when the list is rebuilt after a hotreload.
+    -- @param table buttonList A table with all buttons found on the map
+    -- @hook
+    -- @realm server
+    function GM:TTT2PostButtonInitialization(buttonList) end
 end
 
 ---


### PR DESCRIPTION
Added a hook that is called AFTER all buttons on the map are initialized. This happens on hotreload and post map cleanup. I added this hook because I need it in my button name addon so that I don't have to rebuilt the existing list again.

```lua
---
-- Hook that is called after all buttons were initialized on the map. This happens after
-- a map cleanup when a new round starts or when the list is rebuilt after a hotreload.
-- @param table buttonList A table with all buttons found on the map
-- @hook
-- @realm server
function GM:TTT2PostButtonInitialization(buttonList)
```