### PR TITLE
OverHeadIcon: Add Safeguard Check

### DIFF
--- a/gamemodes/terrortown/gamemode/client/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_targetid.lua
@@ -85,6 +85,10 @@ local sizeIconOverHeadIcon = 0.7 * sizeOverHeadIcon
 -- @param Color colorRole The role color for the background
 -- @realm client
 function DrawOverheadRoleIcon(client, ply, iconRole, colorRole)
+    if not IsValid(client) or not IsValid(ply) then
+        return
+    end
+
     local ang = client:EyeAngles()
     local pos = ply:GetPos() + ply:GetHeadPosition()
     pos.z = pos.z + offsetOverHeadIcon


### PR DESCRIPTION
Recently a user on discord had problems with an error that was spammed. It was because a faulty addon tried to draw the OHI without a valid player. To ensure that the game is still playable, I added a simple validity check here.

Should be merged before the release PR.