### PR TITLE
Shopeditor: Item Buyability Broken due to Cache State

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed avatar icons not refreshing if they were changed on Steam (by @mexikoedi)
 - Fixed a wrong label for the sprint speed multiplier in the F1 menu (by @TimGoll)
 - Fixed own player name being shown in targetID when in vehicle (by @TimGoll)
+- Fixed `ShopEditor.BuildValidEquipmentCache()` being called to early on the client, resulting in a wrong cache state (Thanks to @12problems)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,7 +120,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed avatar icons not refreshing if they were changed on Steam (by @mexikoedi)
 - Fixed a wrong label for the sprint speed multiplier in the F1 menu (by @TimGoll)
 - Fixed own player name being shown in targetID when in vehicle (by @TimGoll)
-- Fixed `ShopEditor.BuildValidEquipmentCache()` being called to early on the client, resulting in a wrong cache state (Thanks to @12problems)
+- Fixed `ShopEditor.BuildValidEquipmentCache()` being called too early on the client, resulting in a wrong cache state (Thanks to @12problems)
 
 ### Removed
 

--- a/gamemodes/terrortown/gamemode/client/cl_changes.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_changes.lua
@@ -2190,6 +2190,7 @@ function CreateChanges()
             <li>Avatar icons not refreshing if they were changed on Steam</li>
             <li>A wrong label for the sprint speed multiplier in the F1 menu</li>
             <li>Own player name being shown in targetID when in vehicle</li>
+            <li>Fixed <code>ShopEditor.BuildValidEquipmentCache()</code> being called to early on the client, resulting in a wrong cache state</li>
         </ul>
         <h2>Removed</h2>
         <ul>

--- a/gamemodes/terrortown/gamemode/client/cl_changes.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_changes.lua
@@ -2190,7 +2190,7 @@ function CreateChanges()
             <li>Avatar icons not refreshing if they were changed on Steam</li>
             <li>A wrong label for the sprint speed multiplier in the F1 menu</li>
             <li>Own player name being shown in targetID when in vehicle</li>
-            <li>Fixed <code>ShopEditor.BuildValidEquipmentCache()</code> being called to early on the client, resulting in a wrong cache state</li>
+            <li>Fixed <code>ShopEditor.BuildValidEquipmentCache()</code> being called too early on the client, resulting in a wrong cache state</li>
         </ul>
         <h2>Removed</h2>
         <ul>

--- a/gamemodes/terrortown/gamemode/client/cl_main.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_main.lua
@@ -206,8 +206,6 @@ function GM:Initialize()
 
     keyhelp.InitializeBasicKeys()
 
-    ShopEditor.BuildValidEquipmentCache()
-
     tips.Initialize()
 
     ---
@@ -291,6 +289,8 @@ function GM:InitPostEntity()
 
     -- initialize fallback shops
     InitFallbackShops()
+
+    ShopEditor.BuildValidEquipmentCache()
 
     ---
     -- @realm client


### PR DESCRIPTION
This pullrequest fixes the issue where items (not weapons) had the wrong state if a custom show was created. This means that they were always marked as selected, even if they weren't. This was due to the caching being done too early, before the items were initialized at all.

The issue didn't exist for weapons because their setup is done in the engine before any lua init code is executed.