### PR TITLE
Rework the outline library and fix the outstanding issues with it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Added option to enable team name next to role name on the HUD (by @milkwxter)
 - Added score event for winning with configurable role parameter (by @MrXonte)
 - Added ExplosiveSphereDamage game effect for easy calculation of explosion damage through walls (by @MrXonte)
+- Added support for outlines of different thickness (by @Wardenpotato)
 
 ### Fixed
 
@@ -42,6 +43,8 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed issue in new Ammo dropping that could cause an error when dropping for modified weapon bases. (by @MrXonte)
 - Fixed C4 not showing the correct inflictor when the player is killed (by @TimGoll)
 - Fixed M16 Ironsight misalignment (by @SvveetMavis) 
+- Fixed outline interactions with certain weapon scopes
+- Fixed outlines not rendering uniformly
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,8 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed issue in new Ammo dropping that could cause an error when dropping for modified weapon bases. (by @MrXonte)
 - Fixed C4 not showing the correct inflictor when the player is killed (by @TimGoll)
 - Fixed M16 Ironsight misalignment (by @SvveetMavis) 
-- Fixed outline interactions with certain weapon scopes
-- Fixed outlines not rendering uniformly
+- Fixed outline interactions with certain weapon scopes (by @WardenPotato)
+- Fixed outlines not rendering uniformly (by @WardenPotato)
 
 ### Changed
 

--- a/lua/ttt2/libraries/outline.lua
+++ b/lua/ttt2/libraries/outline.lua
@@ -60,9 +60,6 @@ local ENTS = 1
 local COLOR = 2
 local MODE = 3
 
---FIXME: You can decide if you want this to be a option for users, should be adressed before merge
-local enable_thin_line_workaround = false
-
 local function SetRenderType(render_type)
     if
         render_type ~= OUTLINE_RENDERTYPE_BEFORE_VM
@@ -394,7 +391,7 @@ local function Render()
     -- when its only 1px thick, so if AA is on we add 1px to compensate.
     -- This is done in all cases to still differentiate between 1px and 2px outlines
     local outline_thickness = OutlineThickness
-    if enable_thin_line_workaround and cvMaterialAntialias:GetInt() ~= 0 then
+    if cvMaterialAntialias:GetInt() ~= 0 then
         outline_thickness = outline_thickness + 1
     end
 

--- a/lua/ttt2/libraries/outline.lua
+++ b/lua/ttt2/libraries/outline.lua
@@ -184,7 +184,7 @@ function outline.Add(ents, color, mode, render_type, outline_thickness)
 
     -- Support for passing Entity as first argument
     if not istable(ents) then
-        ents = {ents}
+        ents = { ents }
     end
 
     -- Do not pass empty tables

--- a/lua/ttt2/libraries/outline.lua
+++ b/lua/ttt2/libraries/outline.lua
@@ -217,8 +217,8 @@ function outline.RenderedEntity()
 end
 
 local function RenderModels(render_ents)
-    for j = 1, #render_ents do
-        local ent = render_ents[j]
+    for i = 1, #render_ents do
+        local ent = render_ents[i]
 
         if IsValid(ent) then
             RenderEnt = ent

--- a/lua/ttt2/libraries/outline.lua
+++ b/lua/ttt2/libraries/outline.lua
@@ -441,6 +441,7 @@ end)
 
 ---
 -- A rendering hook that is run in @{GM:PostDrawEffects}, @{GM:PreDrawEffects} and @{GM:PreDrawViewModels} before the outlines are rendered.
+-- @param number render_type [OUTLINE_RENDERTYPE_BEFORE_VM, OUTLINE_RENDERTYPE_BEFORE_EF, OUTLINE_RENDERTYPE_AFTER_EF]
 -- @2D
 -- @hook
 -- @realm client

--- a/lua/ttt2/libraries/outline.lua
+++ b/lua/ttt2/libraries/outline.lua
@@ -1,12 +1,17 @@
 ---
--- @author https://github.com/ShadowBonnieRUS
+-- @author https://github.com/WardenPotato and https://github.com/ShadowBonnieRUS
 -- @module outline
 
+local istable = istable
 local render = render
-local cam = cam
-local surface = surface
-local hook = hook
 local Material = Material
+local CreateMaterial = CreateMaterial
+local hook = hook
+local cam = cam
+local ScrW = ScrW
+local ScrH = ScrH
+local IsValid = IsValid
+local surface = surface
 
 if SERVER then
     AddCSLuaFile()
@@ -20,29 +25,164 @@ OUTLINE_MODE_BOTH = 0
 OUTLINE_MODE_NOTVISIBLE = 1
 OUTLINE_MODE_VISIBLE = 2
 
-local List, ListSize = {}, 0
-local RenderEnt = NULL
+OUTLINE_RENDERTYPE_BEFORE_VM = 0	-- Render before drawing the view model
+OUTLINE_RENDERTYPE_BEFORE_EF = 1	-- Render before drawing all effects (after drawing the viewmodel)
+OUTLINE_RENDERTYPE_AFTER_EF = 2		-- Render after drawing all effects
 
-local outlineMatSettings = {
-    ["$ignorez"] = 1,
-    ["$alphatest"] = 1,
+local Lists = {
+    [OUTLINE_RENDERTYPE_BEFORE_VM] = {},
+    [OUTLINE_RENDERTYPE_BEFORE_EF] = {},
+    [OUTLINE_RENDERTYPE_AFTER_EF] = {}
 }
 
-local copyMat = Material("pp/copy")
-local outlineMat = CreateMaterial("OutlineMat", "UnlitGeneric", outlineMatSettings)
-local storeTexture = render.GetScreenEffectTexture(0)
-local drawTexture = render.GetScreenEffectTexture(1)
+local ListsSize = {
+    [OUTLINE_RENDERTYPE_BEFORE_VM] = {},
+    [OUTLINE_RENDERTYPE_BEFORE_EF] = {},
+    [OUTLINE_RENDERTYPE_AFTER_EF] = {}
+}
+local RenderEnt = NULL
+local RenderType = OUTLINE_RENDERTYPE_AFTER_EF
+local OutlineThickness = 1
+local texture_store = render.GetScreenEffectTexture(0)
+local texture_draw = render.GetScreenEffectTexture(1)
+
+local outline_mat_settings = {
+    ["$basetexture"] = texture_draw:GetName(),
+    ["$ignorez"] = 1,
+    ["$alphatest"] = 1,
+    ["$smooth"] = 0
+}
+local outline_mat = CreateMaterial("ttt2_outline", "UnlitGeneric", outline_mat_settings)
+
+local copy_mat = Material("pp/copy")
 
 local ENTS = 1
 local COLOR = 2
 local MODE = 3
+
+--FIXME: You can decide if you want this to be a option for users, should be adressed before merge
+local enable_thin_line_workaround = false
+
+local function SetRenderType(render_type)
+    if (
+        render_type ~= OUTLINE_RENDERTYPE_BEFORE_VM and
+        render_type ~= OUTLINE_RENDERTYPE_BEFORE_EF and
+        render_type ~= OUTLINE_RENDERTYPE_AFTER_EF
+    ) then
+        return
+    end
+
+    RenderType = render_type
+
+    return true
+end
+
+local function GetRenderType()
+    return RenderType
+end
+
+
+local function GetOutlineThickness()
+    return OutlineThickness
+end
+
+local function SetOutlineThickness(thickness)
+    if thickness < 1 then
+        return
+    end
+
+    OutlineThickness = thickness
+
+    return true
+end
+
+
+local function GetCurrentLists()
+    return Lists[GetRenderType()]
+end
+
+local function GetCurrentListsSize()
+    return ListsSize[GetRenderType()]
+end
+
+
+local function GetCurrentList()
+    return Lists[GetRenderType()][GetOutlineThickness()]
+end
+
+local function GetCurrentListSize()
+    return ListsSize[GetRenderType()][GetOutlineThickness()]
+end
+
+
+local function ResetCurrentLists()
+    Lists[GetRenderType()] = {}
+end
+
+local function ResetCurrentListsSize()
+    ListsSize[GetRenderType()] = {}
+end
+
+
+local function SetCurrentList(value)
+    Lists[GetRenderType()] = value
+end
+
+local function SetCurrentListSize(size)
+    ListsSize[GetRenderType()][GetOutlineThickness()] = size
+end
+
+
+local function InitializeCurrentListIfNeeded()
+    local render_type, outline_thickness = GetRenderType(), GetOutlineThickness()
+
+    if not Lists[render_type] then
+        Lists[render_type] = {}
+    end
+
+    if not ListsSize[render_type] then
+        ListsSize[render_type] = {}
+    end
+
+    if not Lists[render_type][outline_thickness] then
+        Lists[render_type][outline_thickness] = {}
+    end
+
+    if not ListsSize[render_type][outline_thickness] then
+        ListsSize[render_type][outline_thickness] = 0
+    end
+end
 
 ---
 -- @param table ents List of @{Entity}
 -- @param Color color
 -- @param number mode [OUTLINE_MODE_BOTH, OUTLINE_MODE_NOTVISIBLE, OUTLINE_MODE_VISIBLE]
 -- @realm client
-function outline.Add(ents, color, mode)
+function outline.Add(ents, color, mode, render_type, outline_thickness)
+    -- Make the default behaviour comply with older revisions
+    if not render_type then
+        render_type = OUTLINE_RENDERTYPE_AFTER_EF
+    end
+
+    if not outline_thickness then
+        outline_thickness = 1
+    end
+
+    -- Check for a validity
+    if not SetRenderType(render_type) then
+        return
+    end
+
+    if not SetOutlineThickness(outline_thickness) then
+        return
+    end
+
+    -- Create list if it doesnt exist
+    InitializeCurrentListIfNeeded()
+
+    -- Get List and ListSize for this render type and outline thickness
+    local List, ListSize = GetCurrentList(), GetCurrentListSize()
+
     -- Maximum 255 reference values
     if ListSize >= 255 then
         return
@@ -50,7 +190,7 @@ function outline.Add(ents, color, mode)
 
     -- Support for passing Entity as first argument
     if not istable(ents) then
-        ents = { ents }
+        ents = {ents}
     end
 
     -- Do not pass empty tables
@@ -65,6 +205,7 @@ function outline.Add(ents, color, mode)
     }
 
     ListSize = ListSize + 1
+    SetCurrentListSize(ListSize)
     List[ListSize] = t
 end
 
@@ -75,136 +216,237 @@ function outline.RenderedEntity()
     return RenderEnt
 end
 
-local function Render()
-    local client = LocalPlayer()
-    local IsLineOfSightClear = client.IsLineOfSightClear
-    local scene = render.GetRenderTarget()
+local function RenderModels(render_ents)
+    for j = 1, #render_ents do
+        local ent = render_ents[j]
 
-    render.CopyRenderTargetToTexture(storeTexture)
-
-    local w = ScrW()
-    local h = ScrH()
-
-    render.Clear(0, 0, 0, 0, true, true)
-
-    -- start stencil modification
-    render.SetStencilEnable(true)
-
-    cam.IgnoreZ(true)
-
-    render.SuppressEngineLighting(true)
-
-    render.SetStencilWriteMask(0xFF)
-    render.SetStencilTestMask(0xFF)
-
-    render.SetStencilCompareFunction(STENCIL_ALWAYS)
-    render.SetStencilFailOperation(STENCIL_KEEP)
-    render.SetStencilZFailOperation(STENCIL_REPLACE)
-    render.SetStencilPassOperation(STENCIL_REPLACE)
-
-    -- start cam modification
-    cam.Start3D()
-
-    for i = 1, ListSize do
-        local v = List[i]
-        local mode = v[MODE]
-        local ents = v[ENTS]
-
-        render.SetStencilReferenceValue(i)
-
-        for j = 1, #ents do
-            local ent = ents[j]
-
-            if
-                not IsValid(ent)
-                or mode == OUTLINE_MODE_NOTVISIBLE and IsLineOfSightClear(client, ent)
-                or mode == OUTLINE_MODE_VISIBLE and not IsLineOfSightClear(client, ent)
-            then
-                continue
-            end
-
+        if IsValid(ent) then
             RenderEnt = ent
-
-            ent:DrawModel()
+            ent:DrawModel(STUDIO_RENDER + STUDIO_NOSHADOWS)
         end
     end
-
-    RenderEnt = NULL
-
-    cam.End3D()
-    -- end cam modification
-
-    render.SetStencilCompareFunction(STENCIL_EQUAL)
-
-    -- start cam modification
-    cam.Start2D()
-
-    for i = 1, ListSize do
-        render.SetStencilReferenceValue(i)
-
-        surface.SetDrawColor(List[i][COLOR])
-        surface.DrawRect(0, 0, w, h)
-    end
-
-    cam.End2D()
-    -- end cam modification
-
-    render.SuppressEngineLighting(false)
-
-    cam.IgnoreZ(false)
-
-    render.SetStencilEnable(false)
-    -- end stencil modification
-
-    render.CopyRenderTargetToTexture(drawTexture)
-
-    render.SetRenderTarget(scene)
-
-    copyMat:SetTexture("$basetexture", storeTexture)
-
-    render.SetMaterial(copyMat)
-    render.DrawScreenQuad()
-
-    -- start stencil modification
-    render.SetStencilEnable(true)
-
-    render.SetStencilReferenceValue(0)
-    render.SetStencilCompareFunction(STENCIL_EQUAL)
-
-    outlineMat:SetTexture("$basetexture", drawTexture)
-
-    render.SetMaterial(outlineMat)
-
-    render.DrawScreenQuadEx(-1, -1, w, h)
-    render.DrawScreenQuadEx(-1, 0, w, h)
-    render.DrawScreenQuadEx(-1, 1, w, h)
-    render.DrawScreenQuadEx(0, -1, w, h)
-    render.DrawScreenQuadEx(0, 1, w, h)
-    render.DrawScreenQuadEx(1, 1, w, h)
-    render.DrawScreenQuadEx(1, 0, w, h)
-    render.DrawScreenQuadEx(1, 1, w, h)
-
-    render.SetStencilEnable(false)
-    -- end stencil modification
 end
 
-hook.Add("PostDrawEffects", "RenderOutlines", function()
-    ---
-    -- @realm client
-    hook.Run("PreDrawOutlines")
+local MATERIAL_WHITE = Material("models/debug/debugwhite")
+local mat_antialias = GetConVar("mat_antialias")
+local function Render()
+    local scene = render.GetRenderTarget()
 
-    if ListSize == 0 then
-        return
+    -- Only draw inside of the actual main screen RT, prevents breaking addons and other rendering
+    if scene ~= nil then return end
+
+    -- Copy the current RT to another RT so we can restore this later on
+    -- the way the drawing of this library works is as follows:
+    -- 1. Store Current Screen in the "store" rendertarget.
+    -- 2. Render all the entities that need to be outlined to just the stencil
+    -- 3. Clear the main rendertarget to be fully transparent
+    -- 4. Loop through all stencil values and draw the appropiate color, essentially each value in the stencil buffer (0-255) represent a list index,
+    --    which contains the entities to render and their color, using this info we then draw to the color buffer for that set of entities.
+    -- 5. Copy the main render target which right now consists of solidly colored versions of all the entities we wanted to be outlined into the "draw" rendertarget
+    -- 6. Put the contents of the "store" rendertarget back onto our main rendertarget
+    -- 7. Configure the stencil to only allow drawing on the pixels that our previous rendering didnt touch, right now thats the solidly colored entities, what this does
+    --    is essentially create a mask that only allows drawing right outside of those entities but not over them.
+    -- 8. Now draw what we stored in the "draw" rendertarget back onto the main render target 8 times using the stencil we configured in step 7
+    --    but the important part is that we offset it to each side and corner of a square, essentially if you took a keyboard numpad the entity would be at
+    --    the key 5 while 1 2 3 4 6 7 8 9 would be offset positions we draw back the solidly colored entity, this is what creates our final outline.
+    --    because of this approach where a solid version of the entity is just offset by a certain amount of pixels it becomes less pretty and accurate the thicker you go.
+    render.CopyRenderTargetToTexture(texture_store)
+
+
+    local w, h = ScrW(), ScrH()
+    local List, ListSize = GetCurrentList(), GetCurrentListSize()
+    local reference = 0
+
+    -- Make sure we got a 3D context for our model rendering
+    cam.Start3D()
+        -- Clear out the stencil
+        render.ClearStencil()
+
+        -- Start stencil modification
+        render.SetStencilEnable(true)
+            -- Render using a cheap material
+            render.MaterialOverride(MATERIAL_WHITE)
+            -- We dont need lighting
+            render.SuppressEngineLighting(true)
+            -- We dont need color
+            render.OverrideColorWriteEnable(true, false)
+            -- We dont need depth
+            render.OverrideDepthEnable(true, false)
+
+            -- reset everything to known good values
+            render.SetStencilWriteMask(0xFF)
+            render.SetStencilTestMask(0xFF)
+            render.SetStencilReferenceValue(0)
+            render.SetStencilCompareFunction(STENCIL_GREATER)
+            render.SetStencilPassOperation(STENCIL_KEEP)
+            render.SetStencilFailOperation(STENCIL_KEEP)
+            render.SetStencilZFailOperation(STENCIL_KEEP)
+
+            -- Render the models onto the stencil
+            render.SetBlend(1)
+            for i = 1, ListSize do
+                -- Determine our reference value based on the list index
+                reference = 0xFF - (i - 1)
+
+                -- Get the data we need for this list index
+                local data = List[i]
+                local mode = data[MODE]
+                local render_ents = data[ENTS]
+
+                -- Set our reference value
+                render.SetStencilReferenceValue(reference)
+
+                if mode == OUTLINE_MODE_BOTH or mode == OUTLINE_MODE_VISIBLE then
+                    -- Setup the stencil for hidden or parts or the entire thing
+                    render.SetStencilCompareFunction(STENCIL_GREATER)
+                    render.SetStencilZFailOperation(mode == OUTLINE_MODE_BOTH and STENCIL_REPLACE or STENCIL_KEEP)
+                    render.SetStencilFailOperation(STENCIL_KEEP)
+                    render.SetStencilPassOperation(STENCIL_KEEP)
+
+                    RenderModels(render_ents)
+                elseif mode == OUTLINE_MODE_NOTVISIBLE then
+                    -- Setup the stencil for 2-pass rendering where we first determine what is hidden and then what is shown to prevent self z-fail
+                    render.SetStencilCompareFunction(STENCIL_GREATER)
+                    render.SetStencilZFailOperation(STENCIL_REPLACE)
+                    render.SetStencilFailOperation(STENCIL_KEEP)
+                    render.SetStencilPassOperation(STENCIL_KEEP)
+
+                    RenderModels(render_ents)
+
+                    -- Setup the stencil for the second pass
+                    render.SetStencilCompareFunction(STENCIL_EQUAL)
+                    render.SetStencilZFailOperation(STENCIL_KEEP)
+                    render.SetStencilFailOperation(STENCIL_KEEP)
+                    render.SetStencilPassOperation(STENCIL_ZERO)
+
+                    RenderModels(render_ents)
+                end
+            end
+
+            -- Undo color override
+            render.OverrideColorWriteEnable(false)
+
+            -- We are not rendering anything specific anymore
+            RenderEnt = NULL
+
+            -- Setup the stencil to override the color of values equal to reference
+            -- this makes sure we can only touch pixels that the previous rendering operations have touched
+            render.SetStencilCompareFunction(STENCIL_EQUAL)
+            render.SetStencilZFailOperation(STENCIL_KEEP)
+            render.SetStencilFailOperation(STENCIL_KEEP)
+            render.SetStencilPassOperation(STENCIL_KEEP)
+
+            -- Make the screen transparent, on opaque RT's this will make it black instead, all the main game RT's in source are RGB888 wich is opaque,
+            -- but the actual RT inside of D3D has alpha support, its merely the ones that source uses which are RGB888, those are not the actual RT,
+            -- because its just something the result is copied over to during the rendering process.
+            -- The halo library does not suffer from this given it uses additive/subtractive rendering where you can use a black/white background as a psuedo transparent layer,
+            -- but such an approach is only desirable for a brightening glow.
+            render.Clear(0, 0, 0, 0, false, false)
+
+            -- Render the color onto the RT using our stencil values
+            for i = 1, ListSize do
+                reference = 0xFF - (i - 1)
+
+                render.SetStencilReferenceValue(reference)
+                local col = List[i][COLOR]
+
+                -- While clearing the buffer would be proper here for some reason the base color of the RT bleeds through which makes me believe this
+                -- somehow talks to the gmod RT and not what we got in D3D, its really hard to say but using surface works fine
+                -- otherwise we could have done: render.ClearBuffersObeyStencil(col.r, col.g, col.b, col.a, false)
+                cam.Start2D()
+                    surface.SetDrawColor(col)
+                    surface.DrawRect(0, 0, w, h)
+                cam.End2D()
+            end
+
+            --Undo the rest of the overrides
+            render.SuppressEngineLighting(false)
+            render.MaterialOverride(nil)
+            render.OverrideDepthEnable(false)
+        -- End stencil modification
+        render.SetStencilEnable(false)
+    cam.End3D()
+
+    -- Copy solidly colored result to draw texture
+    render.CopyRenderTargetToTexture(texture_draw)
+
+    -- Set the correct basetexture
+    copy_mat:SetTexture("$basetexture", texture_store)
+
+    -- Prevent leaking through anything to pp/copy
+    copy_mat:SetString("$color", "1 1 1")
+    copy_mat:SetString("$alpha", "1")
+
+    -- Draw the old screen back onto our current
+    render.SetMaterial(copy_mat)
+    render.DrawScreenQuad()
+
+    -- Draw the outlines
+    render.SetStencilEnable(true)
+        -- Setup the stencil to only draw pixels when the reference is 0,
+        -- this basically means that we can only draw outside of outlined objects
+        render.SetStencilReferenceValue(0)
+        render.SetStencilCompareFunction(STENCIL_EQUAL)
+
+        outline_mat:SetTexture("$basetexture", texture_draw)
+
+        -- Set our outline material
+        render.SetMaterial(outline_mat)
+
+        -- When antiliasing is on we run into the problem of the transparency looking very off
+        -- when its only 1px thick, so if AA is on we add 1px to compensate.
+        -- This is done in all cases to still differentiate between 1px and 2px outlines
+        local outline_thickness = OutlineThickness
+        if enable_thin_line_workaround and mat_antialias:GetInt() ~= 0 then outline_thickness = outline_thickness + 1 end
+
+        -- Draw each corner/side of the outline.
+        -- We use the Ex version because the non Ex has some alignment issues.
+        render.DrawScreenQuadEx(-outline_thickness, -outline_thickness, w ,h)
+        render.DrawScreenQuadEx(-outline_thickness, 0, w, h)
+        render.DrawScreenQuadEx(-outline_thickness, outline_thickness, w, h)
+        render.DrawScreenQuadEx(0, -outline_thickness, w, h)
+        render.DrawScreenQuadEx(0, outline_thickness, w, h)
+        render.DrawScreenQuadEx(outline_thickness, -outline_thickness, w, h)
+        render.DrawScreenQuadEx(outline_thickness, 0, w, h)
+        render.DrawScreenQuadEx(outline_thickness, outline_thickness, w, h)
+    render.SetStencilEnable(false)
+end
+
+local function RenderOutlines()
+    hook.Run("PreDrawOutlines", GetRenderType())
+
+    local listSizes = GetCurrentListsSize()
+    for outlineThickness, renderEnts in pairs(GetCurrentLists()) do
+        if not listSizes[outlineThickness] or listSizes[outlineThickness] == 0 then
+            continue
+        end
+        SetOutlineThickness(outlineThickness)
+        Render()
     end
 
-    Render()
+    ResetCurrentLists()
+    ResetCurrentListsSize()
+end
 
-    List, ListSize = {}, 0
+hook.Add("PreDrawViewModels", "RenderOutlines", function()
+    SetRenderType(OUTLINE_RENDERTYPE_BEFORE_VM)
+    RenderOutlines()
 end)
 
+hook.Add("PreDrawEffects", "RenderOutlines", function()
+    SetRenderType(OUTLINE_RENDERTYPE_BEFORE_EF)
+    RenderOutlines()
+end)
+
+hook.Add("PostDrawEffects", "RenderOutlines", function()
+    SetRenderType(OUTLINE_RENDERTYPE_AFTER_EF)
+    RenderOutlines()
+end)
+
+
 ---
--- A rendering hook that is run in @{GM:PostDrawEffects} before the outlines are rendered.
+-- A rendering hook that is run in @{GM:PostDrawEffects}, @{GM:PreDrawEffects} and @{GM:PreDrawViewModels} before the outlines are rendered.
 -- @2D
 -- @hook
 -- @realm client
-function GM:PreDrawOutlines() end
+function GM:PreDrawOutlines(render_type) end

--- a/lua/ttt2/libraries/outline.lua
+++ b/lua/ttt2/libraries/outline.lua
@@ -116,10 +116,6 @@ local function ResetCurrentListsSize()
     ListsSize[GetRenderType()] = {}
 end
 
-local function SetCurrentList(value)
-    Lists[GetRenderType()] = value
-end
-
 local function SetCurrentListSize(size)
     ListsSize[GetRenderType()][GetOutlineThickness()] = size
 end

--- a/lua/ttt2/libraries/outline.lua
+++ b/lua/ttt2/libraries/outline.lua
@@ -184,7 +184,7 @@ function outline.Add(ents, color, mode, render_type, outline_thickness)
 
     -- Support for passing Entity as first argument
     if not istable(ents) then
-        ents = { ents }
+        ents = {ents}
     end
 
     -- Do not pass empty tables

--- a/lua/ttt2/libraries/outline.lua
+++ b/lua/ttt2/libraries/outline.lua
@@ -227,8 +227,8 @@ local function RenderModels(render_ents)
     end
 end
 
-local MATERIAL_WHITE = Material("models/debug/debugwhite")
-local mat_antialias = GetConVar("mat_antialias")
+local materialDebugWhite = Material("models/debug/debugwhite")
+local cvMaterialAntialias = GetConVar("mat_antialias")
 local function Render()
     local scene = render.GetRenderTarget()
 
@@ -265,7 +265,7 @@ local function Render()
         -- Start stencil modification
         render.SetStencilEnable(true)
             -- Render using a cheap material
-            render.MaterialOverride(MATERIAL_WHITE)
+            render.MaterialOverride(materialDebugWhite)
             -- We dont need lighting
             render.SuppressEngineLighting(true)
             -- We dont need color
@@ -397,7 +397,7 @@ local function Render()
         -- when its only 1px thick, so if AA is on we add 1px to compensate.
         -- This is done in all cases to still differentiate between 1px and 2px outlines
         local outline_thickness = OutlineThickness
-        if enable_thin_line_workaround and mat_antialias:GetInt() ~= 0 then outline_thickness = outline_thickness + 1 end
+        if enable_thin_line_workaround and cvMaterialAntialias:GetInt() ~= 0 then outline_thickness = outline_thickness + 1 end
 
         -- Draw each corner/side of the outline.
         -- We use the Ex version because the non Ex has some alignment issues.

--- a/lua/ttt2/libraries/outline.lua
+++ b/lua/ttt2/libraries/outline.lua
@@ -141,9 +141,12 @@ local function InitializeCurrentListIfNeeded()
 end
 
 ---
+-- Adds an outline to a given list of entities.
 -- @param table ents List of @{Entity}
--- @param Color color
+-- @param Color color The color of the added outline
 -- @param number mode [OUTLINE_MODE_BOTH, OUTLINE_MODE_NOTVISIBLE, OUTLINE_MODE_VISIBLE]
+-- @param number render_type [OUTLINE_RENDERTYPE_BEFORE_VM, OUTLINE_RENDERTYPE_BEFORE_EF, OUTLINE_RENDERTYPE_AFTER_EF]
+-- @param number outline_thickness The thickness of the added outline in pixels
 -- @realm client
 function outline.Add(ents, color, mode, render_type, outline_thickness)
     -- Make the default behaviour comply with older revisions
@@ -405,6 +408,7 @@ local function Render()
 end
 
 local function RenderOutlines()
+    -- @realm client
     hook.Run("PreDrawOutlines", GetRenderType())
 
     local listSizes = GetCurrentListsSize()


### PR DESCRIPTION
Its finally here, the rework of the outline library which started because of https://github.com/TTT-2/TTT2/issues/1411
Ive spent quite some time on this trying over 50 different approaches, running into various setbacks each time.
Some of them got solved: https://github.com/Facepunch/garrysmod-issues/issues/5744
And some didnt: https://github.com/Facepunch/garrysmod-requests/issues/2308

But this is what i consider the best thats possible in gmod today in respect to functionality and performance.

This rework includes(i may have forgotten some, its been a while):
- A switch to using the zbuffer instead of line of sight checking every single entity
- Outline thickness option
- Multiple render types for outlines
- More performant drawing
- Drawing not breaking when scopes are used in weapon addons
- Full documentation
- Fixed outlines being thinner on one side than the other

The comments in the code explain a lot so i hope those answer most questions.