### PR TITLE
Translation: Fixed missing translation for None role error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ## Unreleased
 
+### Fixed
+
+- Fixed missing translation for None role error by removing it (by @mexikoedi)
+
 ## [v0.14.0b](https://github.com/TTT-2/TTT2/tree/v0.14.0b) (2024-09-20)
 
 ### Added

--- a/gamemodes/terrortown/gamemode/client/cl_popups.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_popups.lua
@@ -87,7 +87,7 @@ local function RoundStartPopup()
     end
 
     local client = LocalPlayer()
-    if not client then
+    if not client or client:GetRole() == ROLE_NONE then
         return
     end
 


### PR DESCRIPTION
This PR fixes #1631 . 
I tested it and the missing translation error for the None role doesn't appear anymore.