### PR TITLE
Translation: Fixed translation of muting terrorists and spectators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ### Fixed
 
 - Fixed missing translation for None role error by removing it (by @mexikoedi)
+- Fixed translation of muting Terrorists and Spectators (by @mexikoedi)
 
 ## [v0.14.0b](https://github.com/TTT-2/TTT2/tree/v0.14.0b) (2024-09-20)
 

--- a/gamemodes/terrortown/gamemode/server/sv_voice.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_voice.lua
@@ -259,9 +259,9 @@ local function MuteTeam(ply, state)
         LANG.Msg(ply, "mute_off", nil, MSG_CHAT_PLAIN)
     else
         LANG.Msg(
-            ply, 
-            "mute_team", 
-            { team = LANG.NameParam(string.lower(team.GetName(state))) }, 
+            ply,
+            "mute_team",
+            { team = LANG.NameParam(string.lower(team.GetName(state))) },
             MSG_CHAT_PLAIN
         )
     end

--- a/gamemodes/terrortown/gamemode/server/sv_voice.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_voice.lua
@@ -258,7 +258,7 @@ local function MuteTeam(ply, state)
     elseif state == MUTE_NONE or state == TEAM_UNASSIGNED or not team.Valid(state) then
         LANG.Msg(ply, "mute_off", nil, MSG_CHAT_PLAIN)
     else
-        LANG.Msg(ply, "mute_team", { team = team.GetName(state) }, MSG_CHAT_PLAIN)
+        LANG.Msg(ply, "mute_team", { team = LANG.NameParam(string.lower(team.GetName(state))) }, MSG_CHAT_PLAIN)
     end
 end
 

--- a/gamemodes/terrortown/gamemode/server/sv_voice.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_voice.lua
@@ -258,7 +258,12 @@ local function MuteTeam(ply, state)
     elseif state == MUTE_NONE or state == TEAM_UNASSIGNED or not team.Valid(state) then
         LANG.Msg(ply, "mute_off", nil, MSG_CHAT_PLAIN)
     else
-        LANG.Msg(ply, "mute_team", { team = LANG.NameParam(string.lower(team.GetName(state))) }, MSG_CHAT_PLAIN)
+        LANG.Msg(
+            ply, 
+            "mute_team", 
+            { team = LANG.NameParam(string.lower(team.GetName(state))) }, 
+            MSG_CHAT_PLAIN
+        )
     end
 end
 


### PR DESCRIPTION
This PR fixes #1629 .
I tested it and the missing translations for Terrorists and Spectators if you try muting them with F2 are now working correctly.