### PR TITLE
Loadingscreen: Fixed loading screen alignment and text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ### Fixed
 
 - Fixed missing translation for None role error by removing it (by @mexikoedi)
+- Fixed loading screen alignment and text issue (by @mexikoedi)
 
 ## [v0.14.0b](https://github.com/TTT-2/TTT2/tree/v0.14.0b) (2024-09-20)
 

--- a/lua/ttt2/libraries/loadingscreen.lua
+++ b/lua/ttt2/libraries/loadingscreen.lua
@@ -206,9 +206,9 @@ if CLIENT then
         local colorTip = table.Copy(util.GetDefaultColor(colorLoadingScreen))
         colorTip.a = 255 * progress
 
-        draw.BlurredBox(0, 0, ScrW(), ScrH(), progress * 10)
-        draw.BlurredBox(0, 0, ScrW(), ScrH(), progress * 3)
-        draw.Box(0, 0, ScrW(), ScrH(), colorLoadingScreen)
+        draw.BlurredBox(-1, -1, ScrW() * 1.5, ScrH() * 1.5, progress * 10)
+        draw.BlurredBox(-1, -1, ScrW() * 1.5, ScrH() * 1.5, progress * 3)
+        draw.Box(-1, -1, ScrW() * 1.5, ScrH() * 1.5, colorLoadingScreen)
 
         draw.AdvancedText(
             LANG.TryTranslation("loadingscreen_round_restart_title"),
@@ -251,6 +251,14 @@ if CLIENT then
             return
         end
 
+        -- Scale values that are multiples of 0.2 cause artifacts above the tips, while non-multiples do not
+        local tipsScale = appearance.GetGlobalScale()
+        -- Check if tipsScale is close to a multiple of 0.2
+        local isMultipleOfTwo = math.abs(tipsScale % 0.2) < 0.01 -- Tolerance for floating-point numbers
+        if isMultipleOfTwo then
+            tipsScale = tipsScale + 0.1
+        end
+
         local textWrapped, _, heightText = draw.GetWrappedText(
             LANG.TryTranslation("tips_panel_tip")
                 .. " "
@@ -260,7 +268,7 @@ if CLIENT then
                 ),
             0.6 * ScrW(),
             "PureSkinRole",
-            appearance.GetGlobalScale()
+            tipsScale
         )
 
         local heightLine = heightText / #textWrapped
@@ -275,7 +283,7 @@ if CLIENT then
                 TEXT_ALIGN_CENTER,
                 TEXT_ALIGN_CENTER,
                 true,
-                appearance.GetGlobalScale()
+                tipsScale
             )
         end
     end


### PR DESCRIPTION
This PR fixes #1630 .
I tested it and the loading screen fills the whole screen now (the position and the height/width was adjusted) and the text has no artifacts above it anymore.
The issue with the text artifacts was caused because of the scale value.
If the scale is a multiple of 0.2 then the artifacts appear above the text otherwise not.
Maybe the issue lies in `draw.AdvancedText` and how it scales (vector).
I couldn't find the issue there but if someone sees the issue there or if someone knows a better way to fix the text then I can adjust the code.
Screenshot:
![ttt2_loading_screen](https://github.com/user-attachments/assets/aa37a762-13a6-44e9-9b5d-2dc571da0cd0)