### PR TITLE
Lua ent use fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ### Fixed
 
 - Fixed missing translation for None role error by removing it (by @mexikoedi)
+- Fixed sometimes entity use triggering the wrong or none entity (by @TimGoll)
 
 ## [v0.14.0b](https://github.com/TTT-2/TTT2/tree/v0.14.0b) (2024-09-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ### Fixed
 
 - Fixed missing translation for None role error by removing it (by @mexikoedi)
-- Fixed sometimes entity use triggering the wrong or none entity (by @TimGoll)
+- Fixed sometimes entity use triggering the wrong or no entity (by @TimGoll)
 - Fixed translation of muting Terrorists and Spectators (by @mexikoedi)
 
 ## [v0.14.0b](https://github.com/TTT-2/TTT2/tree/v0.14.0b) (2024-09-20)

--- a/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
@@ -14,6 +14,8 @@ ENT.isDestructible = true
 
 ENT.pickupWeaponClass = nil
 
+ENT.CanUseKey = true
+
 local soundDeny = Sound("HL2Player.UseDeny")
 
 ---

--- a/gamemodes/terrortown/entities/entities/ttt_hat_deerstalker.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_hat_deerstalker.lua
@@ -11,6 +11,8 @@ ENT.PrintName = "hat_deerstalker_name"
 ENT.Model = Model("models/ttt/deerstalker.mdl")
 ENT.CanHavePrints = false
 
+ENT.CanUseKey = true
+
 ---
 -- @realm shared
 function ENT:SetupDataTables()

--- a/gamemodes/terrortown/entities/entities/ttt_health_station.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_health_station.lua
@@ -27,6 +27,8 @@ ENT.NextHeal = 0
 ENT.HealRate = 1
 ENT.HealFreq = 0.2
 
+ENT.CanUseKey = true
+
 ---
 -- @realm shared
 function ENT:SetupDataTables()

--- a/gamemodes/terrortown/gamemode/server/sv_entity.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_entity.lua
@@ -94,7 +94,7 @@ function entmeta:IsUsableEntity(requiredCaps)
     local caps = self:ObjectCaps()
 
     -- special case: TTT specific lua based use interactions
-    -- when were looking for specfically the lua use, return false it not set
+    -- when were looking for specifically the lua use, return false it not set
     if
         bit.band(FCAP_USE_LUA, requiredCaps) > 0
         and not (self.CanUseKey or self.player_ragdoll or self:IsWeapon())

--- a/gamemodes/terrortown/gamemode/server/sv_entity.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_entity.lua
@@ -7,6 +7,11 @@ FCAP_IMPULSE_USE = 16
 FCAP_CONTINUOUS_USE = 32
 FCAP_ONOFF_USE = 64
 FCAP_DIRECTIONAL_USE = 128
+FCAP_USE_ONGROUND = 256
+FCAP_USE_IN_RADIUS = 512
+
+-- custom FCAPS possible from 2048 to 268435456
+FCAP_USE_LUA = 2048
 
 local safeCollisionGroups = {
     [COLLISION_GROUP_WEAPON] = true,
@@ -77,7 +82,8 @@ function entmeta:Spawn()
 end
 
 ---
--- Checks if the entity has any use functionality attached.
+-- Checks if the entity has any use functionality attached. This can be attached in the engine/via hammer or by
+-- setting `.CanUseKey` to true. Player ragdolls and weapons always have use functionality attached.
 -- @param[default=0] number requiredCaps Use caps that are required for this entity
 -- @return boolean Returns true if the entity is usable by the player
 -- @ref https://github.com/ValveSoftware/source-sdk-2013/blob/0d8dceea4310fde5706b3ce1c70609d72a38efdf/sp/src/game/server/player.cpp#L2766C71-L2781
@@ -86,6 +92,17 @@ function entmeta:IsUsableEntity(requiredCaps)
     requiredCaps = requiredCaps or 0
 
     local caps = self:ObjectCaps()
+
+    -- special case: TTT specific lua based use interactions
+    -- when were looking for specfically the lua use, return false it not set
+    if
+        bit.band(FCAP_USE_LUA, requiredCaps) > 0
+        and not (self.CanUseKey or self.player_ragdoll or self:IsWeapon())
+    then
+        return false
+    elseif requiredCaps == 0 and (self.CanUseKey or self.player_ragdoll or self:IsWeapon()) then
+        return true
+    end
 
     if
         bit.band(


### PR DESCRIPTION
This fixes #1634 and #1635

The issue this PR fixes is that previously the fallback was called for all SENTs (scripted entities) because they lack any engine related use flags. Therefore the clientside trace was completely ignored for this kind of entity.

I added support for our SENTs to `entmeta:IsUsableEntity`. This might look a bit hacky, but let me explain:
- First, the obvious, if an entity has `.CanUseKey` set to true, it has a use functionality attached. This is a good check, because this is a flag that was needed in vanilla TTT as well, so it has good compatibility.
- Second, there are special cases for weapons and ragdolls. This is a bit hacky indeed. However it is handled the same way in the server use handler, so I guess it is fine

![image](https://github.com/user-attachments/assets/2e94940b-c365-4d17-9a7f-986e8741aee9)
