### PR TITLE
Loadingscreen: Render Hook Change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed missing translation for None role error by removing it (by @mexikoedi)
 - Fixed sometimes entity use triggering the wrong or no entity (by @TimGoll)
 - Fixed translation of muting Terrorists and Spectators (by @mexikoedi)
+- Fixed rendering glitches in the loading screen (by @TimGoll)
 
 ### Changed
 

--- a/gamemodes/terrortown/gamemode/client/cl_hud_manager.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_hud_manager.lua
@@ -89,7 +89,15 @@ end
 -- @local
 function GM:PostDrawHUD()
     vguihandler.DrawBackground()
+end
 
+---
+-- Called after all other 2D draw hooks are called. Draws over all VGUI Panels and HUDs.
+-- @2D
+-- @hook
+-- @realm client
+-- @ref https://wiki.facepunch.com/gmod/GM:DrawOverlay
+function GM:DrawOverlay()
     loadingscreen.Handler()
 end
 


### PR DESCRIPTION
Fixes #1630

Fixes the loadingscreen rendering issues that appeared because no true 2D rendering context was provided. This now also means that everything is blurred, even vgui. I think that is fine.

It would be nice if @mexikoedi could confirm that this also fixes the issue on his PC.

![image](https://github.com/user-attachments/assets/f3349c90-0c1b-41d5-86ff-146ff1102693)
