### PR TITLE
refactor(targetid): Use `Vehicle:GetDriver` instead of NWEntity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 - Updated French translation (by @MisterClems)
 - Updated Turkish localization (by @NovaDiablox)
+- Updated targetID to use `Vehicle:GetDriver` instead of the `ttt_driver` NWEntity (by @Histalek)
 
 ## [v0.14.0b](https://github.com/TTT-2/TTT2/tree/v0.14.0b) (2024-09-20)
 

--- a/lua/ttt2/libraries/targetid.lua
+++ b/lua/ttt2/libraries/targetid.lua
@@ -110,8 +110,8 @@ function targetid.FindEntityAlongView(pos, dir, filter)
     local ent = trace.Entity
 
     -- if a vehicle, we identify the driver instead
-    if IsValid(ent) then
-        local driver = ent:GetNWEntity("ttt_driver", nil)
+    if IsValid(ent) and ent:IsVehicle() then
+        local driver = ent:GetDriver()
 
         if IsValid(driver) and driver ~= client then
             ent = driver


### PR DESCRIPTION
This replaces the usage of the ttt specific `ttt_driver` NWEntity with the
base gmod `Vehicle:GetDriver` [1] function to determine the driver of a
targeted vehicle.

The ttt solution of keeping track of a vehicle's driver via a networked Entity
on the vehicle has existed since forever (12+ years). So i'm sure it has had
its reasons to exist.
But for at least 5 years base gmod has had the ability to get the driver of a
specific vehicle so this should be the way we determine this going forward.

I would love to rip the whole `ttt_driver` NWEntity out of the code completely.
Not only because we definitely have better ways of handling this without
increasing networking churn, but also because setting the driver to the vehicle
itself, when the driver exits the vehicle, is questionable at best.

Given that some addon will without a doubt depend on this behaviour i'm not
changing this though.

[1] https://wiki.facepunch.com/gmod/Vehicle:GetDriver