### PR TITLE
chore(git-blame): Ignore stylua commit from git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,4 +3,4 @@
 # Run stylua formatter on entire codebase
 df7bf4216cf31d680c0d95bd576e46193ce2dcd6
 # Run stylua after removing many `-- stylua: ignore` statements
-4745fda13b027488bbf62c228c9a882bf92e1f24
+cd4b56c390418d14bfa69e511ea9b8405eff12a0


### PR DESCRIPTION
I should've just did this in 2 PRs from the beginning, but oh well.