### PR TITLE
Fix weapon pickup through walls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed the loadingscreen disable causing an error (by @TimGoll)
 - Fixed the rounds left always displaying one less than actually left (by @TimGoll)
 - Fixed rendering glitches in the loading screen (by @TimGoll)
+- Fixed weapon pickup through walls (by @MrXonte)
 
 ### Changed
 

--- a/gamemodes/terrortown/gamemode/server/sv_weaponry.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_weaponry.lua
@@ -92,7 +92,7 @@ function GM:PlayerCanPickupWeapon(ply, wep, dropBlockingWeapon, isPickupProbe)
             mask = MASK_SOLID,
         }, wep)
 
-        if tr.Fraction == 1.0 or tr.Entity == ply then
+        if (tr.Fraction == 1.0 or tr.Entity == ply) and not tr.StartSolid then
             wep:SetPos(ply:GetShootPos())
         end
     end


### PR DESCRIPTION
Add check for trace start solid to prevent teleporting weapon through walls.

Edgecases can occur where weapons can be picked up through walls (even thick 16 unit walls didn't prevent this). This is because the trace can start solid (most likely if the weapon is too large for the space its resting, in my case a relatively small func_detail shelf) and then the tr.Fraction will return 1.0 through a solid wall, causing weapons the be teleported and picked up.