### PR TITLE
Spectators no longer visible in thermalvision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed the rounds left always displaying one less than actually left (by @TimGoll)
 - Fixed rendering glitches in the loading screen (by @TimGoll)
 - Fixed weapon pickup through walls (by @MrXonte)
+- Fixed spectating player still being visible through thermalvision after killing that player (by @MrXonte)
 
 ### Changed
 

--- a/lua/ttt2/libraries/thermalvision.lua
+++ b/lua/ttt2/libraries/thermalvision.lua
@@ -139,7 +139,7 @@ local function RenderHook()
             local entry = thermalvisionList[i]
             local ent = entry.ent
 
-            if not IsValid(ent) or (ent:IsPlayer() and (ent:IsSpec() or ent:IsGhost())) then
+            if not IsValid(ent) or (ent:IsPlayer() and not ent:IsTerror()) then
                 continue
             end
 

--- a/lua/ttt2/libraries/thermalvision.lua
+++ b/lua/ttt2/libraries/thermalvision.lua
@@ -139,7 +139,7 @@ local function RenderHook()
             local entry = thermalvisionList[i]
             local ent = entry.ent
 
-            if not IsValid(ent) then
+            if not IsValid(ent) or (ent:IsPlayer() and not ent:Alive()) then
                 continue
             end
 

--- a/lua/ttt2/libraries/thermalvision.lua
+++ b/lua/ttt2/libraries/thermalvision.lua
@@ -138,8 +138,8 @@ local function RenderHook()
         for i = 1, #thermalvisionList do
             local entry = thermalvisionList[i]
             local ent = entry.ent
-
-            if not IsValid(ent) or (ent:IsPlayer() and not ent:Alive()) then
+            
+            if not IsValid(ent) or (ent:IsPlayer() and (ent:IsSpec() or ent:IsGhost())) then
                 continue
             end
 

--- a/lua/ttt2/libraries/thermalvision.lua
+++ b/lua/ttt2/libraries/thermalvision.lua
@@ -138,7 +138,7 @@ local function RenderHook()
         for i = 1, #thermalvisionList do
             local entry = thermalvisionList[i]
             local ent = entry.ent
-            
+
             if not IsValid(ent) or (ent:IsPlayer() and (ent:IsSpec() or ent:IsGhost())) then
                 continue
             end


### PR DESCRIPTION
A check was added to prevent spectators from being displayed with thermal vision. This is relevant in cases where players are highlighted by TV and then killed, as they are not automatically removed from the entity list. Also prevents SpecDM players from being seen.