### PR TITLE
fix(map): Streamline behaviour for the ttt2_enable_map_prefix_ convars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Updated targetID to use `Vehicle:GetDriver` instead of the `ttt_driver` NWEntity (by @Histalek)
 - Updated Russian and English localization files (by @Satton2)
 - Updated old TTT HUD to show name of spectated player (by @somefnfplayerlol)
+- Changes to the enabled map prefixes will not be announced to players anymore (by @Histalek)
+- By default only `ttt` and `ttt2` map prefixes are enabled (by @Histalek)
 
 ## [v0.14.0b](https://github.com/TTT-2/TTT2/tree/v0.14.0b) (2024-09-20)
 

--- a/lua/ttt2/libraries/map.lua
+++ b/lua/ttt2/libraries/map.lua
@@ -502,19 +502,32 @@ local mapsPrefixes = {}
 local mapsWSIDs = {}
 
 if SERVER then
-    -- by default cs, de and test maps should be hidden
+    -- by default cs, de, gm and test maps should be hidden
+    -- while ttt and ttt2 maps should be shown
 
     ---
     -- @realm server
-    CreateConVar("ttt2_enable_map_prefix_cs", "0", { FCVAR_ARCHIVE, FCVAR_NOTIFY })
+    CreateConVar("ttt2_enable_map_prefix_cs", "0", { FCVAR_ARCHIVE })
 
     ---
     -- @realm server
-    CreateConVar("ttt2_enable_map_prefix_de", "0", { FCVAR_ARCHIVE, FCVAR_NOTIFY })
+    CreateConVar("ttt2_enable_map_prefix_de", "0", { FCVAR_ARCHIVE })
 
     ---
     -- @realm server
-    CreateConVar("ttt2_enable_map_prefix_test", "0", { FCVAR_ARCHIVE, FCVAR_NOTIFY })
+    CreateConVar("ttt2_enable_map_prefix_gm", "0", { FCVAR_ARCHIVE })
+
+    ---
+    -- @realm server
+    CreateConVar("ttt2_enable_map_prefix_test", "0", { FCVAR_ARCHIVE })
+
+    ---
+    -- @realm server
+    CreateConVar("ttt2_enable_map_prefix_ttt", "1", { FCVAR_ARCHIVE })
+
+    ---
+    -- @realm server
+    CreateConVar("ttt2_enable_map_prefix_ttt2", "1", { FCVAR_ARCHIVE })
 
     ---
     -- Initializes the map list. Searches the file system for available maps, scans those maps
@@ -570,7 +583,7 @@ if SERVER then
 
             ---
             -- @realm server
-            CreateConVar(convarName, "1", { FCVAR_ARCHIVE, FCVAR_NOTIFY })
+            CreateConVar(convarName, "0", { FCVAR_ARCHIVE })
 
             -- because these convars are generated dynamically, replicated convars do not work here
             SetGlobalBool(convarName, GetConVar(convarName):GetBool())


### PR DESCRIPTION
Updated changes after a few iterations are now the following:

* Unconditionally create gm, ttt and ttt2 prefixes

We can reasonably assume `gm` maps to be present on the server, the same
goes for `ttt` and `ttt2` maps.

Creating convars dynamically if we find more map prefixes is still
done. And only prefixes for installed maps will be shown anyway.

* Disable all map prefixes but `ttt` and `ttt2` by default

We will assume people only want to run maps intended for ttt(2).

Given that the prefix selection can be modified on the same admin
settings page that is (currently) the only one using these convars this
seems fine.

* Drop FCVAR_NOTIFY for all `map_prefix_enabled` convars

Given that these are purely used in an admin context there is no need to
announce changes to all users on the server.

The last changes especially fixes the original Issue https://github.com/TTT-2/TTT2/issues/1632