### PR TITLE
Fixed error when trying to drop ammo for weapons without AmmoEnt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed rendering glitches in the loading screen (by @TimGoll)
 - Fixed weapon pickup through walls (by @MrXonte)
 - Fixed spectating player still being visible through thermalvision after killing that player (by @MrXonte)
-- Fixed console error when dropping ammo for weapons with no AmmoEnt. (by @MrXonte)
+- Fixed console error when dropping ammo for weapons with no AmmoEnt (by @MrXonte)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed rendering glitches in the loading screen (by @TimGoll)
 - Fixed weapon pickup through walls (by @MrXonte)
 - Fixed spectating player still being visible through thermalvision after killing that player (by @MrXonte)
+- Fixed console error when dropping ammo for weapons with no AmmoEnt. (by @MrXonte)
 
 ### Changed
 

--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -1410,6 +1410,10 @@ function plymeta:CanSafeDropAmmo(wep)
     if not IsValid(self) or not (IsValid(wep) and wep.AmmoEnt) then
         return false
     end
+    
+	if wep.AmmoEnt == "" then
+		return false
+	end
 
     local tr = TraceAmmoDrop(self)
 

--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -1407,11 +1407,10 @@ end
 -- @return boolean Returns if this weapon's ammo can be dropped
 -- @realm server
 function plymeta:CanSafeDropAmmo(wep)
-    if not IsValid(self) or not (IsValid(wep) and wep.AmmoEnt) then
-        return false
-    end
-
-    if wep.AmmoEnt == "" then
+    -- We explicitly check for the two common non-existent ammo ents (`nil` and `empty string`) here
+    -- to prevent these from leading to a console error later once they are fed into `ents.Create`.
+    -- There is currently no way to check if the AmmoEnt exists, so this is the best we can do.
+    if not IsValid(self) or not IsValid(wep) or not wep.AmmoEnt or wep.AmmoEnt == "" then
         return false
     end
 

--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -1410,10 +1410,10 @@ function plymeta:CanSafeDropAmmo(wep)
     if not IsValid(self) or not (IsValid(wep) and wep.AmmoEnt) then
         return false
     end
-    
-	if wep.AmmoEnt == "" then
-		return false
-	end
+
+    if wep.AmmoEnt == "" then
+        return false
+    end
 
     local tr = TraceAmmoDrop(self)
 


### PR DESCRIPTION
When trying to drop ammo on a weapon with no AmmoEnt (aka AmmoEnt = ""), an error appears in the console from trying to create a non-existent entity.