### PR TITLE
HUD: Show name of spectated player in old TTT HUD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Updated Turkish localization (by @NovaDiablox)
 - Updated targetID to use `Vehicle:GetDriver` instead of the `ttt_driver` NWEntity (by @Histalek)
 - Updated Russian and English localization files (by @Satton2)
+- Updated old TTT HUD to show name of spectated player (by @somefnfplayerlol)
 
 ## [v0.14.0b](https://github.com/TTT-2/TTT2/tree/v0.14.0b) (2024-09-20)
 

--- a/gamemodes/terrortown/gamemode/shared/hud_elements/tttinfopanel/old_ttt_info.lua
+++ b/gamemodes/terrortown/gamemode/shared/hud_elements/tttinfopanel/old_ttt_info.lua
@@ -266,11 +266,12 @@ if CLIENT then
             local hastewidth = self.hastewidth
             local bg_colors = self.bg_colors
             local round_y = y + height - self.bgheight
+            local screenwidth = ScrW()
 
             height = self.bgheight
 
             -- move up a little on low resolutions to allow space for spectator hints
-            if ScrW() < 1000 then
+            if screenwidth < 1000 then
                 round_y = round_y - 15
             end
 
@@ -303,6 +304,20 @@ if CLIENT then
                 COLOR_WHITE,
                 TEXT_ALIGN_CENTER
             )
+
+            -- Draw name of spectated player
+            local tgt = client:GetObserverTarget()
+            if IsValid(tgt) and tgt:IsPlayer() then
+                self:ShadowedText(
+                    tgt:Nick(),
+                    "TimeLeft",
+                    screenwidth / 2,
+                    margin,
+                    COLOR_WHITE,
+                    TEXT_ALIGN_CENTER,
+                    TEXT_ALIGN_TOP
+                )
+            end
         end
     end
 end


### PR DESCRIPTION
This is a feature from the original TTT reimplemented in TTT2.