### PR TITLE
Magneto Stick C_Hands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed rendering glitches in the loading screen (by @TimGoll)
 - Fixed weapon pickup through walls (by @MrXonte)
 - Fixed spectating player still being visible through thermalvision after killing that player (by @MrXonte)
+- Fixed Magneto-stick not using C_Hands (by @SvveetMavis)
 
 ### Changed
 

--- a/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_zm_carry.lua
@@ -28,6 +28,7 @@ if CLIENT then
     SWEP.Icon = "vgui/ttt/icon_magneto_stick"
 
     SWEP.ViewModelFlip = false
+    SWEP.ViewModelFOV = 54
 end
 
 SWEP.Base = "weapon_tttbase"
@@ -36,7 +37,8 @@ SWEP.AutoSpawnable = false
 
 SWEP.notBuyable = true
 
-SWEP.ViewModel = Model("models/weapons/v_stunbaton.mdl")
+SWEP.UseHands = true
+SWEP.ViewModel = Model("models/weapons/c_stunstick.mdl")
 SWEP.WorldModel = Model("models/weapons/w_stunbaton.mdl")
 
 SWEP.Primary.ClipSize = -1


### PR DESCRIPTION
Adds working C_Hands to the magneto stick so it not longer uses the default HEV suit hands
![image](https://github.com/user-attachments/assets/e54aa1f6-49d9-4ffc-aede-333e521cd3eb)

(accidentally deleted the first pull request because idk how github works all the way yet sorry)