### PR TITLE
fix(cl_main): Prevent client lua error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed spectating player still being visible through thermalvision after killing that player (by @MrXonte)
 - Fixed Magneto-stick not using C_Hands (by @SvveetMavis)
 - Fixed console error when dropping ammo for weapons with no AmmoEnt (by @MrXonte)
+- Fixed client error for a not fully initialized client (by @Histalek)
 
 ### Changed
 

--- a/gamemodes/terrortown/gamemode/client/cl_main.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_main.lua
@@ -484,7 +484,7 @@ function GM:ClearClientState()
 
     local client = LocalPlayer()
 
-    if not client:IsReady() then
+    if not IsValid(client) or not client:IsReady() then
         return
     end
 


### PR DESCRIPTION
This fixes #1648 in cases where not all entities have been initialized for a client.