### PR TITLE
fix(random_shop): Do not put minimum player limited equip in random shop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed spectating player still being visible through thermalvision after killing that player (by @MrXonte)
 - Fixed Magneto-stick not using C_Hands (by @SvveetMavis)
 - Fixed console error when dropping ammo for weapons with no AmmoEnt (by @MrXonte)
+- Fixed randomshop containing equipment which minimum playeramount was not satisfied (by @Histalek)
 
 ### Changed
 

--- a/gamemodes/terrortown/gamemode/shared/sh_equip_items.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_equip_items.lua
@@ -568,6 +568,8 @@ if SERVER then
                 RANDOMSHOP[ply] = RANDOMTEAMSHOPS[GetShopFallback(srd.index)]
             end
         else -- every player has his own shop
+            local activePlys = util.GetActivePlayers()
+
             for i = 1, #tmpTbl do
                 local ply = tmpTbl[i]
                 local srd = ply:GetSubRoleData()
@@ -587,6 +589,14 @@ if SERVER then
                     local equip = cachedTbl[k]
 
                     if equip.notBuyable then
+                        continue
+                    end
+
+                    if
+                        equip.minPlayers
+                        and equip.minPlayers > 1
+                        and #activePlys < equip.minPlayersthen
+                    then
                         continue
                     end
 


### PR DESCRIPTION
This fixes #1679, very well aware that other limitations (team/global limited) are still not respected and might still show up.