### PR TITLE
fix(targetid): Respect enabled `ttt_identify_body_woconfirm`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed spectating player still being visible through thermalvision after killing that player (by @MrXonte)
 - Fixed Magneto-stick not using C_Hands (by @SvveetMavis)
 - Fixed console error when dropping ammo for weapons with no AmmoEnt (by @MrXonte)
+- Fixed the targetID corpse hint not respecting `ttt_identify_body_woconfirm` (by @Histalek)
 
 ### Changed
 

--- a/lua/terrortown/lang/en.lua
+++ b/lua/terrortown/lang/en.lua
@@ -2366,3 +2366,6 @@ L.label_loadingscreen_min_duration = "Minimum loading screen display time"
 L.label_keyhelper_leave_vehicle = "leave vehicle"
 L.name_vehicle = "Vehicle"
 L.vehicle_enter = "Press [{usekey}] to enter vehicle"
+
+-- 2024-11-27
+L.corpse_hint_without_confirm = "Press [{usekey}] to search."

--- a/lua/ttt2/libraries/targetid.lua
+++ b/lua/ttt2/libraries/targetid.lua
@@ -560,6 +560,11 @@ function targetid.HUDDrawTargetIDRagdolls(tData)
         then
             tData:SetSubtitle(ParT("corpse_hint_inspect_limited", key_params))
             tData:AddDescriptionLine(TryT("corpse_hint_inspect_limited_details"))
+        elseif
+            bodysearch.GetInspectConfirmMode() == 0
+            and GetConVar("ttt_identify_body_woconfirm"):GetBool()
+        then
+            tData:SetSubtitle(ParT("corpse_hint_without_confirm", key_params))
         else
             tData:SetSubtitle(ParT("corpse_hint", key_params))
         end

--- a/lua/ttt2/libraries/targetid.lua
+++ b/lua/ttt2/libraries/targetid.lua
@@ -562,7 +562,7 @@ function targetid.HUDDrawTargetIDRagdolls(tData)
             tData:AddDescriptionLine(TryT("corpse_hint_inspect_limited_details"))
         elseif
             bodysearch.GetInspectConfirmMode() == 0
-            and GetConVar("ttt_identify_body_woconfirm"):GetBool()
+            and not GetConVar("ttt_identify_body_woconfirm"):GetBool()
         then
             tData:SetSubtitle(ParT("corpse_hint_without_confirm", key_params))
         else


### PR DESCRIPTION
Before this change when looking at a corpse targetID would show the same hint whether `ttt_identify_body_woconfirm` was enabled or not.

This change introduces a new language string that does neither mention corpse confirmation nor searching covertly.