### PR TITLE
fix(beacon): Use translation for entity instead of hardcoded name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed spectating player still being visible through thermalvision after killing that player (by @MrXonte)
 - Fixed Magneto-stick not using C_Hands (by @SvveetMavis)
 - Fixed console error when dropping ammo for weapons with no AmmoEnt (by @MrXonte)
+- Fixed the beacon not being properly translated when placed (by @Histalek)
 
 ### Changed
 

--- a/gamemodes/terrortown/entities/entities/ttt_beacon.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_beacon.lua
@@ -10,7 +10,7 @@ DEFINE_BASECLASS("ttt_base_placeable")
 
 if CLIENT then
     ENT.Icon = "vgui/ttt/icon_beacon"
-    ENT.PrintName = "Beacon"
+    ENT.PrintName = "beacon_name"
 end
 
 ENT.Base = "ttt_base_placeable"


### PR DESCRIPTION
This fixes #1652