### PR TITLE
TargetID: Make `ttt_idenfity_body_woconfirm` replicated; move and clean up additional ConVars surrounding corpses/ragdolls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed console error when dropping ammo for weapons with no AmmoEnt (by @MrXonte)
 - Fixed client error for a not fully initialized client (by @Histalek)
 - Fixed the targetID corpse hint not respecting `ttt_identify_body_woconfirm` (by @Histalek)
-- Fixed networked values for `ttt_identify_body_woconfirm` and `ttt2_confirm_team` not being updated properly when changed (by @Wryyyong)
 - Fixed the beacon not being properly translated when placed (by @Histalek)
 
 ### Changed
@@ -37,6 +36,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Updated old TTT HUD to show name of spectated player (by @somefnfplayerlol)
 - Changes to the enabled map prefixes will not be announced to players anymore (by @Histalek)
 - By default only `ttt` and `ttt2` map prefixes are enabled (by @Histalek)
+- Updated `ttt_identify_body_woconfirm` to be replicated across the server and client (by @Wryyyong)
 
 ## [v0.14.0b](https://github.com/TTT-2/TTT2/tree/v0.14.0b) (2024-09-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed console error when dropping ammo for weapons with no AmmoEnt (by @MrXonte)
 - Fixed client error for a not fully initialized client (by @Histalek)
 - Fixed the targetID corpse hint not respecting `ttt_identify_body_woconfirm` (by @Histalek)
+- Fixed networked values for `ttt_identify_body_woconfirm` and `ttt2_confirm_team` not being updated properly when changed (by @Wryyyong)
 - Fixed the beacon not being properly translated when placed (by @Histalek)
 
 ### Changed

--- a/gamemodes/terrortown/gamemode/server/sv_corpse.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_corpse.lua
@@ -58,6 +58,24 @@ CORPSE.cv.announce_body_found = CreateConVar(
 
 ---
 -- @realm server
+CORPSE.cv.confirm_team = CreateConVar(
+    "ttt2_confirm_team",
+    "0",
+    { FCVAR_NOTIFY, FCVAR_ARCHIVE },
+    "Show team of confirmed player"
+)
+
+---
+-- @realm server
+CORPSE.cv.confirm_killlist = CreateConVar(
+    "ttt2_confirm_killlist",
+    "1",
+    { FCVAR_NOTIFY, FCVAR_ARCHIVE },
+    "Confirm players in kill list"
+)
+
+---
+-- @realm server
 CORPSE.cv.ragdoll_collide = CreateConVar("ttt_ragdoll_collide", "0", { FCVAR_NOTIFY, FCVAR_ARCHIVE })
 
 -- networked data abstraction layer
@@ -167,7 +185,7 @@ function CORPSE.IdentifyBody(ply, rag, searchUID)
         local rd = roles.GetByIndex(subrole)
         local roletext = "body_found_" .. rd.abbr
         local clr = rag.role_color
-        local bool = GetGlobalBool("ttt2_confirm_team")
+        local bool = config.confirm_team:GetBool()
 
         net.Start("TTT2SendConfirmMsg")
 
@@ -201,7 +219,7 @@ function CORPSE.IdentifyBody(ply, rag, searchUID)
         net.Broadcast()
     end
 
-    if GetConVar("ttt2_confirm_killlist"):GetBool() then
+    if config.confirm_killlist:GetBool() then
         -- Handle kill list
         local ragKills = rag.kills
 

--- a/gamemodes/terrortown/gamemode/server/sv_corpse.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_corpse.lua
@@ -76,7 +76,8 @@ CORPSE.cv.confirm_killlist = CreateConVar(
 
 ---
 -- @realm server
-CORPSE.cv.ragdoll_collide = CreateConVar("ttt_ragdoll_collide", "0", { FCVAR_NOTIFY, FCVAR_ARCHIVE })
+CORPSE.cv.ragdoll_collide =
+    CreateConVar("ttt_ragdoll_collide", "0", { FCVAR_NOTIFY, FCVAR_ARCHIVE })
 
 -- networked data abstraction layer
 local dti = CORPSE.dti

--- a/gamemodes/terrortown/gamemode/server/sv_corpse.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_corpse.lua
@@ -30,19 +30,6 @@ local IsValid = IsValid
 local ConVarExists = ConVarExists
 local hook = hook
 
----
--- @realm server
-local cvBodyfound = CreateConVar(
-    "ttt_announce_body_found",
-    "1",
-    { FCVAR_NOTIFY, FCVAR_ARCHIVE },
-    "If detective mode, announce when someone's body is found"
-)
-
----
--- @realm server
-local cvRagCollide = CreateConVar("ttt_ragdoll_collide", "0", { FCVAR_NOTIFY, FCVAR_ARCHIVE })
-
 local soundsSearch = {
     Sound("player/footsteps/snow1.wav"),
     Sound("player/footsteps/snow2.wav"),
@@ -60,8 +47,22 @@ ttt_include("sh_corpse")
 
 util.AddNetworkString("TTT2SendConfirmMsg")
 
+---
+-- @realm server
+CORPSE.cv.announce_body_found = CreateConVar(
+    "ttt_announce_body_found",
+    "1",
+    { FCVAR_NOTIFY, FCVAR_ARCHIVE },
+    "If detective mode, announce when someone's body is found"
+)
+
+---
+-- @realm server
+CORPSE.cv.ragdoll_collide = CreateConVar("ttt_ragdoll_collide", "0", { FCVAR_NOTIFY, FCVAR_ARCHIVE })
+
 -- networked data abstraction layer
 local dti = CORPSE.dti
+local config = CORPSE.cv
 
 ---
 -- Sets a CORPSE found state
@@ -160,7 +161,7 @@ function CORPSE.IdentifyBody(ply, rag, searchUID)
     end
 
     -- Announce body
-    if cvBodyfound:GetBool() and notConfirmed then
+    if config.announce_body_found:GetBool() and notConfirmed then
         local subrole = rag.was_role
         local team = rag.was_team
         local rd = roles.GetByIndex(subrole)
@@ -278,7 +279,7 @@ function CORPSE.ShowSearch(ply, rag, isCovert, isLongRange)
         end
 
         if
-            GetConVar("ttt_identify_body_woconfirm"):GetBool()
+            config.identify_body_woconfirm:GetBool()
             and gameloop.IsDetectiveMode()
             and not isCovert
         then
@@ -640,7 +641,7 @@ function CORPSE.GetPlayerTeam(rag)
 end
 
 hook.Add("ShouldCollide", "TTT2RagdollCollide", function(ent1, ent2)
-    if cvRagCollide:GetBool() then
+    if config.ragdoll_collide:GetBool() then
         return
     end
 

--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -132,24 +132,6 @@ local map_switch_delay = CreateConVar(
 
 ---
 -- @realm server
-local confirm_team = CreateConVar(
-    "ttt2_confirm_team",
-    "0",
-    { FCVAR_NOTIFY, FCVAR_ARCHIVE },
-    "Show team of confirmed player"
-)
-
----
--- @realm server
-CreateConVar(
-    "ttt2_confirm_killlist",
-    "1",
-    { FCVAR_NOTIFY, FCVAR_ARCHIVE },
-    "Confirm players in kill list"
-)
-
----
--- @realm server
 CreateConVar(
     "ttt_enforce_playermodel",
     "1",
@@ -496,8 +478,6 @@ function GM:SyncGlobals()
         )
     end
 
-    SetGlobalBool(confirm_team:GetName(), confirm_team:GetBool())
-
     ---
     -- @realm server
     hook.Run("TTT2SyncGlobals")
@@ -509,10 +489,6 @@ end)
 
 cvars.AddChangeCallback(idle_enabled:GetName(), function(cv, old, new)
     SetGlobalBool(idle_enabled:GetName(), tobool(tonumber(new)))
-end)
-
-cvars.AddChangeCallback(confirm_team:GetName(), function(cv, old, new)
-    SetGlobalBool(confirm_team:GetName(), tobool(tonumber(new)))
 end)
 
 ---

--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -132,15 +132,6 @@ local map_switch_delay = CreateConVar(
 
 ---
 -- @realm server
-local identify_body_woconfirm = CreateConVar(
-    "ttt_identify_body_woconfirm",
-    "1",
-    { FCVAR_NOTIFY, FCVAR_ARCHIVE },
-    "Toggles whether ragdolls should be confirmed in gameloop.IsDetectiveMode() without clicking on confirm espacially"
-)
-
----
--- @realm server
 local confirm_team = CreateConVar(
     "ttt2_confirm_team",
     "0",
@@ -505,7 +496,6 @@ function GM:SyncGlobals()
         )
     end
 
-    SetGlobalBool(identify_body_woconfirm:GetName(), identify_body_woconfirm:GetBool())
     SetGlobalBool(confirm_team:GetName(), confirm_team:GetBool())
 
     ---
@@ -519,10 +509,6 @@ end)
 
 cvars.AddChangeCallback(idle_enabled:GetName(), function(cv, old, new)
     SetGlobalBool(idle_enabled:GetName(), tobool(tonumber(new)))
-end)
-
-cvars.AddChangeCallback(identify_body_woconfirm:GetName(), function(cv, old, new)
-    SetGlobalBool(identify_body_woconfirm:GetName(), tobool(tonumber(new)))
 end)
 
 cvars.AddChangeCallback(confirm_team:GetName(), function(cv, old, new)

--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -132,7 +132,7 @@ local map_switch_delay = CreateConVar(
 
 ---
 -- @realm server
-CreateConVar(
+local identify_body_woconfirm = CreateConVar(
     "ttt_identify_body_woconfirm",
     "1",
     { FCVAR_NOTIFY, FCVAR_ARCHIVE },
@@ -506,6 +506,7 @@ function GM:SyncGlobals()
     end
 
     SetGlobalBool("ttt2_confirm_team", confirm_team:GetBool())
+    SetGlobalBool(identify_body_woconfirm:GetName(), identify_body_woconfirm:GetBool())
 
     ---
     -- @realm server
@@ -518,6 +519,10 @@ end)
 
 cvars.AddChangeCallback(idle_enabled:GetName(), function(cv, old, new)
     SetGlobalBool(idle_enabled:GetName(), tobool(tonumber(new)))
+end)
+
+cvars.AddChangeCallback(identify_body_woconfirm:GetName(), function(cv, old, new)
+    SetGlobalBool(identify_body_woconfirm:GetName(), tobool(tonumber(new)))
 end)
 
 ---

--- a/gamemodes/terrortown/gamemode/server/sv_main.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_main.lua
@@ -505,8 +505,8 @@ function GM:SyncGlobals()
         )
     end
 
-    SetGlobalBool("ttt2_confirm_team", confirm_team:GetBool())
     SetGlobalBool(identify_body_woconfirm:GetName(), identify_body_woconfirm:GetBool())
+    SetGlobalBool(confirm_team:GetName(), confirm_team:GetBool())
 
     ---
     -- @realm server
@@ -523,6 +523,10 @@ end)
 
 cvars.AddChangeCallback(identify_body_woconfirm:GetName(), function(cv, old, new)
     SetGlobalBool(identify_body_woconfirm:GetName(), tobool(tonumber(new)))
+end)
+
+cvars.AddChangeCallback(confirm_team:GetName(), function(cv, old, new)
+    SetGlobalBool(confirm_team:GetName(), tobool(tonumber(new)))
 end)
 
 ---

--- a/gamemodes/terrortown/gamemode/shared/sh_corpse.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_corpse.lua
@@ -13,6 +13,17 @@ CORPSE.dti = {
     INT_CREDITS = 0,
 }
 
+CORPSE.cv = {
+    ---
+    -- @realm shared
+    identify_body_woconfirm = CreateConVar(
+        "ttt_identify_body_woconfirm",
+        "1",
+        { FCVAR_NOTIFY, FCVAR_ARCHIVE, FCVAR_REPLICATED },
+        "Toggles whether ragdolls should be confirmed in gameloop.IsDetectiveMode() without clicking on confirm espacially"
+    ),
+}
+
 local dti = CORPSE.dti
 
 ---

--- a/lua/autorun/gs_crazyphysics.lua
+++ b/lua/autorun/gs_crazyphysics.lua
@@ -176,7 +176,7 @@ hook.Add("Initialize", "TTT2GSCrazyPhysics", function()
             prop_ragdoll = true,
         }
 
-        cv_ttt_announce_body_found = GetConVar("ttt_announce_body_found")
+        cv_ttt_announce_body_found = CORPSE.cv.announce_body_found
         cv_ttt2_confirm_killlist = GetConVar("ttt2_confirm_killlist")
     end
 end)

--- a/lua/autorun/gs_crazyphysics.lua
+++ b/lua/autorun/gs_crazyphysics.lua
@@ -164,8 +164,7 @@ local tEntitiesToCheck = {
 
 local bTTT
 local tIdentifyEntities
-local cv_ttt_announce_body_found
-local cv_ttt2_confirm_killlist
+local corpseConfig
 
 hook.Add("Initialize", "TTT2GSCrazyPhysics", function()
     -- Change check if your terrortown folder is named something different
@@ -176,8 +175,7 @@ hook.Add("Initialize", "TTT2GSCrazyPhysics", function()
             prop_ragdoll = true,
         }
 
-        cv_ttt_announce_body_found = CORPSE.cv.announce_body_found
-        cv_ttt2_confirm_killlist = GetConVar("ttt2_confirm_killlist")
+        corpseConfig = CORPSE.cv
     end
 end)
 
@@ -281,8 +279,8 @@ local function IdentifyCorpse(pCorpse)
         end
     end
 
-    if cv_ttt_announce_body_found:GetBool() then
-        if GetGlobalBool("ttt2_confirm_team") then -- TODO adjust the new messages
+    if corpseConfig.announce_body_found:GetBool() then
+        if corpseConfig.confirm_team:GetBool() then -- TODO adjust the new messages
             LANG.Msg("body_found", {
                 finder = "The Server",
                 victim = CORPSE.GetPlayerNick(pCorpse, nil) or pPlayer:GetName(),
@@ -298,7 +296,7 @@ local function IdentifyCorpse(pCorpse)
         end
     end
 
-    if cv_ttt2_confirm_killlist:GetBool() then
+    if corpseConfig.confirm_killlist:GetBool() then
         local tKills = pCorpse.kills
         if tKills then
             for i = 1, #tKills do

--- a/lua/ttt2/libraries/bodysearch.lua
+++ b/lua/ttt2/libraries/bodysearch.lua
@@ -115,6 +115,15 @@ if SERVER then
     local mathRound = math.Round
     local mathFloor = math.floor
 
+    local cv_ttt2_confirm_killlist
+
+    hook.Add("Initialize", "TTT2BodySearch", function()
+        -- Change check if your terrortown folder is named something different
+        if engine.ActiveGamemode():lower() == "terrortown" and TTT2 and istable(CORPSE) then
+            cv_ttt2_confirm_killlist = CORPSE.cv.confirm_killlist
+        end
+    end)
+
     util.AddNetworkString("ttt2_client_reports_corpse")
     util.AddNetworkString("ttt2_client_confirm_corpse")
     util.AddNetworkString("ttt2_credits_were_taken")
@@ -356,7 +365,7 @@ if SERVER then
 
         -- build list of people this player killed, but only if convar is enabled
         sceneData.killEntityIDList = {}
-        if GetConVar("ttt2_confirm_killlist"):GetBool() then
+        if cv_ttt2_confirm_killlist:GetBool() then
             local ragKills = rag.kills or {}
 
             for i = 1, #ragKills do

--- a/lua/ttt2/libraries/targetid.lua
+++ b/lua/ttt2/libraries/targetid.lua
@@ -37,6 +37,15 @@ local materialDestructible = Material("vgui/ttt/tid/tid_destructible")
 local materialDNATargetID = Material("vgui/ttt/dnascanner/dna_hud")
 local materialFire = Material("vgui/ttt/tid/tid_onfire")
 
+local cv_ttt_identify_body_woconfirm
+
+hook.Add("Initialize", "TTT2TargetID", function()
+    -- Change check if your terrortown folder is named something different
+    if engine.ActiveGamemode():lower() == "terrortown" and TTT2 and istable(CORPSE) then
+        cv_ttt_identify_body_woconfirm = CORPSE.cv.identify_body_woconfirm
+    end
+end)
+
 ---
 -- This function makes sure local variables, which use other libraries that are not yet initialized, are initialized later.
 -- It gets called after all libraries are included and `cl_targetid.lua` gets included.
@@ -562,7 +571,7 @@ function targetid.HUDDrawTargetIDRagdolls(tData)
             tData:AddDescriptionLine(TryT("corpse_hint_inspect_limited_details"))
         elseif
             bodysearch.GetInspectConfirmMode() == 0
-            and not GetGlobalBool("ttt_identify_body_woconfirm", true)
+            and not cv_ttt_identify_body_woconfirm:GetBool()
         then
             tData:SetSubtitle(ParT("corpse_hint_without_confirm", key_params))
         else

--- a/lua/ttt2/libraries/targetid.lua
+++ b/lua/ttt2/libraries/targetid.lua
@@ -562,7 +562,7 @@ function targetid.HUDDrawTargetIDRagdolls(tData)
             tData:AddDescriptionLine(TryT("corpse_hint_inspect_limited_details"))
         elseif
             bodysearch.GetInspectConfirmMode() == 0
-            and not GetConVar("ttt_identify_body_woconfirm"):GetBool()
+            and not GetGlobalBool("ttt_identify_body_woconfirm", true)
         then
             tData:SetSubtitle(ParT("corpse_hint_without_confirm", key_params))
         else


### PR DESCRIPTION
In #1684, `targetid.HUDDrawTargetIDRagdolls` was updated to check if the `ttt_idenfity_body_woconfirm` ConVar was enabled to determine what hint gets displayed.

Problem is, this ConVar only exists on the server, and the TargetID library is entirely clientside. This resulted in Lua errors being thrown on every frame the function was called and managed to reach that check.

~~This PR adds a GlobalBool and ChangeCallback for `ttt_idenfity_body_woconfirm`, and updates the check to use it instead of a nonexistent ConVar object. It also adds a ChangeCallback for `ttt2_confirm_team`, and changes its initial `SetGlobal` call to grab its name from its ConVar object to be consistent with the other GlobalVars in `SyncGlobals`.~~

This PR adds an additional table to the `CORPSE` namespace for the purpose of storing ConVar objects related to corpses and bodysearching. The following `CreateConVar` calls have been moved from `sv_main`:
- `ttt_idenfity_body_woconfirm` (to `sh_corpse`, with `FCVAR_REPLICATED` added)
- `ttt2_confirm_team` (to `sv_corpse`)
- `ttt2_confirm_killlist` (to `sv_corpse`)

I've also moved the `CreateConVar` calls for `ttt_announce_body_found` and `ttt_ragdoll_collide` into the new table for consistency, and so scripts for other parts of the gamemode can access the ConVar objects directly without having to store their own separate copies (or calling `GetConVar` repeatedly). I've also already adjusted all existing checks for these ConVars across the gamemode accordingly.

The changelog entry is worded the way it is because I just can't think of any other way to describe the results of the changes without going into a level of detail that'd be unnecessary for an end-user, but still useful information for addon developers.