### PR TITLE
Ammo Drop from reserve now tries to drop a full box, instead of, at most, a full clip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Updated old TTT HUD to show name of spectated player (by @somefnfplayerlol)
 - Changes to the enabled map prefixes will not be announced to players anymore (by @Histalek)
 - By default only `ttt` and `ttt2` map prefixes are enabled (by @Histalek)
+- Changed how Ammo is dropped; if drop should be from reserve ammo, now tries to drop a full ammo box instead of a full clip. (by @MrXonte)
 
 ## [v0.14.0b](https://github.com/TTT-2/TTT2/tree/v0.14.0b) (2024-09-20)
 

--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -1465,7 +1465,7 @@ function plymeta:DropAmmo(wep, useClip, amt)
         if useClip then
             amt = wep:Clip1()
         else
-            amt = math.min(wep.Primary.ClipSize, self:GetAmmoCount(wep.Primary.Ammo))
+            amt = math.min(wep.AmmoEnt.AmmoAmount, self:GetAmmoCount(wep.Primary.Ammo))
         end
     end
     local hook_data = { amt }


### PR DESCRIPTION
Ammo dropping from the reserve was a bit weird. You currently drop `Min(Clipsize, Reserve)`, which is fine for default weapons where clip size = box ammo, but for any custom weapon with less ammo, things get increasingly weird.
The worst-case scenario involves weapons with super-low ammo. Consider the often-used pocket rifle, which has only a clip size of 1; here, you must drop ammo 10 times to drop the same as a regular 357 box.
My change makes it so that instead, you now drop `Min(Box Size, Reserve)`, which feels much better and has no downsides I can see. Dropping from the clip remains unchanged as it should.