### PR TITLE
fix(binoculars): Allow zooming to be predicted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed client error for a not fully initialized client (by @Histalek)
 - Fixed the targetID corpse hint not respecting `ttt_identify_body_woconfirm` (by @Histalek)
 - Fixed the beacon not being properly translated when placed (by @Histalek)
+- Fixed binoculars zooming not being predicted (by @Histalek)
 
 ### Changed
 

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_binoculars.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_binoculars.lua
@@ -115,15 +115,12 @@ end
 ---
 -- @ignore
 function SWEP:SetZoomLevel(level)
-    if CLIENT then
-        return
-    end
-
-    local owner = self:GetOwner()
-
     self:SetZoomAmount(level)
 
-    owner:SetFOV(self.ZoomLevels[level], 0.3)
+    local owner = self:GetOwner()
+    if IsValid(owner) then
+        owner:SetFOV(self.ZoomLevels[level], 0.3)
+    end
 end
 
 ---


### PR DESCRIPTION
I've tested this with `net_fakelag 400` and boy does it make a difference.

Additionally this should fix #1625 by doing a sanity check of the binoculars owner before setting the owners FOV.