### PR TITLE
fix(base_placeable): Prevent error on pickup fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed client error for a not fully initialized client (by @Histalek)
 - Fixed the targetID corpse hint not respecting `ttt_identify_body_woconfirm` (by @Histalek)
 - Fixed the beacon not being properly translated when placed (by @Histalek)
+- Fixed an error when trying to pickup a placed equipment (e.g. beacon) (by @Histalek)
 
 ### Changed
 

--- a/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_base_placeable.lua
@@ -69,7 +69,7 @@ if CLIENT then
         end
 
         if not self:PlayerCanPickupWeapon(client) then
-            LANG.Msg(client, "pickup_fail", nil, MSG_MSTACK_WARN)
+            LANG.Msg("pickup_fail", nil, MSG_MSTACK_WARN)
 
             self:EmitSound(soundDeny)
 


### PR DESCRIPTION
We call `LANG.Msg` on the client which doesn't use the first parameter to address a player. This shifts all the parameters to the wrong places.

Fixes #1695