### PR TITLE
Fix: Prevent spectators, covert, and long range corpse searches from making sound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed the beacon not being properly translated when placed (by @Histalek)
 - Fixed binoculars zooming not being predicted (by @Histalek)
 - Fixed an error when trying to pickup a placed equipment (e.g. beacon) (by @Histalek)
+- Fixed corpse searching sound playing when searched by a spectator, searched covertly, or searched long range (by @TW1STaL1CKY)
 
 ### Changed
 

--- a/gamemodes/terrortown/gamemode/server/sv_corpse.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_corpse.lua
@@ -316,11 +316,7 @@ function CORPSE.ShowSearch(ply, rag, isCovert, isLongRange)
     ply.searchID = sceneData.searchUID
 
     -- play sound when the body was searched
-    if
-        ply:IsTerror()
-        and not isCovert
-        and not isLongRange
-    then
+    if ply:IsTerror() and not isCovert and not isLongRange then
         -- note: These sounds are pretty quiet and are therefore played thrice to increase the volume
         local soundSelected = table.Random(soundsSearch)
 

--- a/gamemodes/terrortown/gamemode/server/sv_corpse.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_corpse.lua
@@ -316,12 +316,18 @@ function CORPSE.ShowSearch(ply, rag, isCovert, isLongRange)
     ply.searchID = sceneData.searchUID
 
     -- play sound when the body was searched
-    -- note: These sounds are pretty quiet and are therefore played thrice to increase the volume
-    local soundSelected = table.Random(soundsSearch)
+    if
+        ply:IsTerror()
+        and not isCovert
+        and not isLongRange
+    then
+        -- note: These sounds are pretty quiet and are therefore played thrice to increase the volume
+        local soundSelected = table.Random(soundsSearch)
 
-    rag:EmitSound(soundSelected, 100)
-    rag:EmitSound(soundSelected, 100)
-    rag:EmitSound(soundSelected, 100)
+        rag:EmitSound(soundSelected, 100)
+        rag:EmitSound(soundSelected, 100)
+        rag:EmitSound(soundSelected, 100)
+    end
 
     local roleData = ply:GetSubRoleData()
     if ply:IsActive() and roleData.isPolicingRole and roleData.isPublicRole and not isCovert then


### PR DESCRIPTION
The new corpse searching sounds play when anything searches them in any manner. The main example being spectators - if a spectator examined a body, the body would make a sound seemingly out of nowhere for players who are alive.
Covert searches and long range searches also cause the search sound to play which seems wrong.

The change in this PR fixes that. The sound will now only play if the player is alive (using IsTerror), and if the search wasn't covert or long range.