### PR TITLE
Binds: Added support for "toggle_zoom" binds to trigger the radio commands menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Added Korean translation (by @Kojap)
 - Added diagnostic information to the addonchecker output.
   - This also includes a Garry's Mod version check which triggers a warning if TTT2 is not compatible. First baseline version is '240313' (by @NickCloudAT)
+- Added support for "toggle_zoom" binds to trigger the radio commands menu (by @TW1STaL1CKY)
 
 ### Fixed
 

--- a/gamemodes/terrortown/gamemode/client/cl_keys.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_keys.lua
@@ -115,7 +115,7 @@ function GM:PlayerBindPress(ply, bindName, pressed)
     elseif string.sub(bindName, 1, 4) == "slot" and pressed then
         local idx = tonumber(string.sub(bindName, 5, -1)) or 1
 
-        -- if radiomenu is open, override weapon select
+        -- If radiomenu is open, override weapon select
         if RADIO.Show then
             RADIO:SendCommand(idx)
         else
@@ -123,15 +123,12 @@ function GM:PlayerBindPress(ply, bindName, pressed)
         end
 
         return true
-    elseif bindName == "+zoom" and pressed then
-        -- open or close radio
+    elseif (bindName == "+zoom" or bindName == "toggle_zoom") and pressed then
+        -- Open or close radio
         RADIO:ShowRadioCommands(not RADIO.Show)
 
         return true
-    elseif bindName == "+voicerecord" then
-        -- This blocks the old Garry's Mod bind
-        return true
-    elseif bindName == "-voicerecord" then
+    elseif bindName == "+voicerecord" or bindName == "-voicerecord" then
         -- This blocks the old Garry's Mod bind
         return true
     elseif bindName == "gm_showteam" and pressed and ply:IsSpec() then


### PR DESCRIPTION
There's an alternative zoom command "toggle_zoom" which PlayerBindPress doesn't check for.
This command is now supported and triggers the radio commands menu like the regular +zoom command does.