### PR TITLE
Fix: Fixed the mute button in the scoreboard not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed binoculars zooming not being predicted (by @Histalek)
 - Fixed an error when trying to pickup a placed equipment (e.g. beacon) (by @Histalek)
 - Fixed corpse searching sound playing when searched by a spectator, searched covertly, or searched long range (by @TW1STaL1CKY)
+- Fixed the mute button in the scoreboard not working (by @TW1STaL1CKY)
 
 ### Changed
 

--- a/gamemodes/terrortown/gamemode/client/cl_voice.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_voice.lua
@@ -574,8 +574,8 @@ end
 -- @realm client
 function VOICE.UpdatePlayerVoiceVolume(ply)
     local mute = VOICE.GetPreferredPlayerVoiceMuted(ply)
-    if ply.SetMute then
-        ply:SetMute(mute)
+    if ply.SetMuted then
+        ply:SetMuted(mute)
     end
 
     local vol = VOICE.GetPreferredPlayerVoiceVolume(ply)


### PR DESCRIPTION
The VOICE library function that updates whether someone should be muted has a typo - it's trying to use "SetMute" rather than "[SetMuted](https://wiki.facepunch.com/gmod/Player:SetMuted)". This simply fixes the typo so muting works again.