### PR TITLE
UI: Hide Propspec bind if disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - By default only `ttt` and `ttt2` map prefixes are enabled (by @Histalek)
 - Updated `ttt_identify_body_woconfirm` to be replicated across the server and client (by @Wryyyong)
 - Changed how Ammo is dropped; if drop should be from reserve ammo, now tries to drop a full ammo box instead of a full clip. (by @MrXonte)
+- Updated `ttt_spec_prop_control` to be replicated across the server and client (by @NickCloudAT)
+  - With this, the KeyHelp feature also hides the PropSpec bind if PropSpec is disabled on the server
 
 ## [v0.14.0b](https://github.com/TTT-2/TTT2/tree/v0.14.0b) (2024-09-20)
 

--- a/gamemodes/terrortown/gamemode/server/sv_propspec.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_propspec.lua
@@ -9,9 +9,7 @@ local timer = timer
 
 PROPSPEC = {}
 
----
--- @realm server
-local cvPropspecToggle = CreateConVar("ttt_spec_prop_control", "1", { FCVAR_NOTIFY, FCVAR_ARCHIVE })
+local cvPropspecToggle = GetConVar("ttt_spec_prop_control")
 
 ---
 -- @realm server
@@ -30,14 +28,6 @@ local cvPropspecMax = CreateConVar("ttt_spec_prop_maxbonus", "16", { FCVAR_NOTIF
 -- @realm server
 local cvPropspecDashMulitplier =
     CreateConVar("ttt_spec_prop_dash", "2", { FCVAR_NOTIFY, FCVAR_ARCHIVE })
-
-hook.Add("TTT2SyncGlobals", "AddPropspecGlobals", function()
-    SetGlobalBool(cvPropspecToggle:GetName(), cvPropspecToggle:GetBool())
-end)
-
-cvars.AddChangeCallback(cvPropspecToggle:GetName(), function(cv, old, new)
-    SetGlobalBool(cvPropspecToggle:GetName(), tobool(tonumber(new)))
-end)
 
 ---
 -- Forces a @{Player} to spectate an @{Entity}

--- a/gamemodes/terrortown/gamemode/server/sv_propspec.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_propspec.lua
@@ -31,6 +31,14 @@ local cvPropspecMax = CreateConVar("ttt_spec_prop_maxbonus", "16", { FCVAR_NOTIF
 local cvPropspecDashMulitplier =
     CreateConVar("ttt_spec_prop_dash", "2", { FCVAR_NOTIFY, FCVAR_ARCHIVE })
 
+hook.Add("TTT2SyncGlobals", "AddPropspecGlobals", function()
+    SetGlobalBool(cvPropspecToggle:GetName(), cvPropspecToggle:GetBool())
+end)
+
+cvars.AddChangeCallback(cvPropspecToggle:GetName(), function(cv, old, new)
+    SetGlobalBool(cvPropspecToggle:GetName(), tobool(tonumber(new)))
+end)
+
 ---
 -- Forces a @{Player} to spectate an @{Entity}
 -- @param Player ply

--- a/gamemodes/terrortown/gamemode/shared/sh_cvar_handler.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_cvar_handler.lua
@@ -4,6 +4,9 @@
 -- @realm shared
 CreateConVar("ttt2_radar_charge_time", "30", { FCVAR_NOTIFY, FCVAR_ARCHIVE, FCVAR_REPLICATED })
 
+-- @realm shared
+CreateConVar("ttt_spec_prop_control", "1", { FCVAR_NOTIFY, FCVAR_ARCHIVE, FCVAR_REPLICATED })
+
 ---
 -- @realm shared
 CreateConVar(

--- a/lua/ttt2/libraries/keyhelp.lua
+++ b/lua/ttt2/libraries/keyhelp.lua
@@ -349,7 +349,7 @@ function keyhelp.InitializeBasicKeys()
         KEYHELP_CORE,
         "label_keyhelper_possess_focus_entity",
         function(client)
-            if not client:IsSpec() or IsValid(client:GetObserverTarget()) then
+            if not client:IsSpec() or IsValid(client:GetObserverTarget()) or not GetGlobalBool("ttt_spec_prop_control", true) then
                 return
             end
 

--- a/lua/ttt2/libraries/keyhelp.lua
+++ b/lua/ttt2/libraries/keyhelp.lua
@@ -349,7 +349,11 @@ function keyhelp.InitializeBasicKeys()
         KEYHELP_CORE,
         "label_keyhelper_possess_focus_entity",
         function(client)
-            if not client:IsSpec() or IsValid(client:GetObserverTarget()) or not GetGlobalBool("ttt_spec_prop_control", true) then
+            if
+                not client:IsSpec()
+                or IsValid(client:GetObserverTarget())
+                or not GetConVar("ttt_spec_prop_control"):GetBool()
+            then
                 return
             end
 

--- a/lua/ttt2/libraries/keyhelp.lua
+++ b/lua/ttt2/libraries/keyhelp.lua
@@ -77,6 +77,8 @@ local cvEnableBoxBlur = CreateConVar("ttt2_hud_enable_box_blur", "1", FCVAR_ARCH
 -- @realm client
 local cvEnableDescription = CreateConVar("ttt2_hud_enable_description", "1", FCVAR_ARCHIVE)
 
+local cvPropspecToggle -- Cached later in the key register function
+
 keyhelp = keyhelp or {}
 keyhelp.keyHelpers = {}
 
@@ -349,10 +351,12 @@ function keyhelp.InitializeBasicKeys()
         KEYHELP_CORE,
         "label_keyhelper_possess_focus_entity",
         function(client)
+            cvPropspecToggle = cvPropspecToggle or GetConVar("ttt_spec_prop_control")
+
             if
                 not client:IsSpec()
                 or IsValid(client:GetObserverTarget())
-                or not GetConVar("ttt_spec_prop_control"):GetBool()
+                or not cvPropspecToggle:GetBool()
             then
                 return
             end


### PR DESCRIPTION
This PR would "fix" https://github.com/TTT-2/TTT2/issues/1706

I'm just not sure: Is using globals here a good idea? I though about using a replicated cvar, but that would require at least a cl_propspec.lua file to be added.

Changelog will follow when finished.