### PR TITLE
Markervision fix: Fixed registry table being able to have duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed corpse searching sound playing when searched by a spectator, searched covertly, or searched long range (by @TW1STaL1CKY)
 - Fixed the mute button in the scoreboard not working (by @TW1STaL1CKY)
 - Fixed a few errors in shop error messages (by @Histalek)
+- Fixed `markerVision`'s registry table being able to contain duplicate obsolete entries, thus fixing potential syncing issues with markers (by @TW1STaL1CKY)
 
 ### Changed
 

--- a/lua/ttt2/libraries/marker_vision.lua
+++ b/lua/ttt2/libraries/marker_vision.lua
@@ -31,6 +31,12 @@ markerVision.focussedMarkers = {}
 -- @return MARKER_VISION_ELEMENT The marker vision object that was created
 -- @realm shared
 function markerVision.Add(ent, identifier)
+    local _, index = markerVision.Get(ent, identifier)
+
+    if index ~= -1 then
+        table.remove(markerVision.registry, index)
+    end
+
     local mvObject = table.Copy(MARKER_VISION_ELEMENT)
     mvObject:SetEnt(ent)
     mvObject:SetIdentifier(identifier)


### PR DESCRIPTION
I discovered that when new marker vision objects are made with `markerVision.Add`, it doesn't clear out existing versions of the same object (matching ent and indentifier). This leads to the `markerVision.registry` table being filled up with objects that do not clear themselves, and makes `markerVision.Get` potentially return obsolete markers (mainly observed serverside).

This PR resolves this possible bloat issue in the registry. This also fixes an issue where marker vision objects can incorrectly change to being visible to team or visible to role (clientside), when it's supposed to be visible to everyone.