### PR TITLE
Rolelayering: Show Role Enable Status

### DIFF
--- a/gamemodes/terrortown/gamemode/client/cl_vskin/default_skin.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/default_skin.lua
@@ -1721,11 +1721,70 @@ end
 -- @param number h
 -- @realm client
 function SKIN:PaintRoleImageTTT2(panel, w, h)
+    local widthBorder = 2
+    local widthBorder2 = widthBorder * 2
+    local padding = 3
+    local sizeMode = 18
+    local sizeIconMode = sizeMode - 2 * padding
+    local posIconModeX = w - sizeMode + padding
+    local posIconModeY = h - sizeMode + padding
+
     local colorBackground = panel:GetColor()
     local colorIcon = utilGetDefaultColor(colorBackground)
 
-    drawRoundedBox(sizes.cornerRadius, 0, 0, w, h, colorBackground)
-    drawFilteredShadowedTexture(0, 0, w, h, panel:GetMaterial(), colorIcon.a, colorIcon)
+    local colorBorder = colorCardAdded
+    local iconBorder = materialCardAdded
+
+    if not panel:GetEnabled() then
+        colorBorder = colorCardInheritRemoved
+        iconBorder = materialCardRemoved
+    end
+
+    local colorBorderIcon = utilGetDefaultColor(colorBorder)
+
+    drawRoundedBox(sizes.cornerRadius, 0, 0, w, h, colorBorder)
+
+    drawRoundedBox(
+        sizes.cornerRadius,
+        widthBorder,
+        widthBorder,
+        w - widthBorder2,
+        h - widthBorder2,
+        colorBackground
+    )
+
+    drawFilteredShadowedTexture(
+        widthBorder,
+        widthBorder,
+        w - widthBorder2,
+        h - widthBorder2,
+        panel:GetMaterial(),
+        colorIcon.a,
+        colorIcon
+    )
+
+    drawRoundedBoxEx(
+        sizes.cornerRadius,
+        w - sizeMode,
+        h - sizeMode,
+        sizeMode,
+        sizeMode,
+        colorBorder,
+        true,
+        false,
+        false,
+        true
+    )
+
+    drawFilteredTexture(
+        posIconModeX,
+        posIconModeY,
+        sizeIconMode,
+        sizeIconMode,
+        iconBorder,
+        175,
+        utilGetDefaultColor(colorBorderIcon)
+    )
 end
 
 ---

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/droleimage_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/droleimage_ttt2.lua
@@ -41,6 +41,36 @@ function PANEL:GetMaterial()
 end
 
 ---
+-- @param string cvar
+-- @realm client
+function PANEL:SetConVar(cvar)
+    print(cvar)
+    print(GetConVar(cvar):GetBool())
+    print("-------")
+    self.data.cvar = GetConVar(cvar)
+end
+
+---
+-- @return ConVar
+-- @realm client
+function PANEL:GetConVar()
+    return self.data.cvar
+end
+
+---
+-- @return string
+-- @realm client
+function PANEL:GetEnabled()
+    if not self.data.cvar then
+        return
+    end
+
+    print(self.data.cvar)
+
+    return self.data.cvar:GetBool()
+end
+
+---
 -- @ignore
 function PANEL:Paint(w, h)
     derma.SkinHook("Paint", "RoleImageTTT2", self, w, h)

--- a/lua/terrortown/menus/gamemode/administration/rolelayering.lua
+++ b/lua/terrortown/menus/gamemode/administration/rolelayering.lua
@@ -147,6 +147,7 @@ hook.Add("TTT2ReceivedRolelayerData", "received_layer_data", function(role, laye
         ic:SetColor(roleData.color)
         ic:SetTooltip(roleData.name)
         ic:SetTooltipFixedPosition(0, 64)
+        ic:SetConVar("ttt_" .. roleData.name .. "_enabled")
 
         ic.subrole = subrole
 


### PR DESCRIPTION
Fixes #1700 by showing the enable status of a role.

Looks something like this:
![image](https://github.com/user-attachments/assets/f601699d-ddf6-4860-accb-3c4face6f6df)

Currently I'm struggling with the fact that the role state cvar is server only. Altough sven already implemented a nice system for that, it requires a lot of code duplication to get it working in this UI element as well.

This is how it works for checkboxes: https://github.com/TTT-2/TTT2/blob/master/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcheckboxlabel_ttt2.lua#L90

Best case would be to use inheritance here, but our vgui inheritance is pretty broken.

I'm open for ideas on this!