### PR TITLE
Fixed error in new Ammo drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed the mute button in the scoreboard not working (by @TW1STaL1CKY)
 - Fixed a few errors in shop error messages (by @Histalek)
 - Fixed `markerVision`'s registry table being able to contain duplicate obsolete entries, thus fixing potential syncing issues with markers (by @TW1STaL1CKY)
+- Fixed issue in new Ammo dropping that could cause an error when dropping for modified weapon bases. (by @MrXonte)
 
 ### Changed
 

--- a/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_player_ext.lua
@@ -1465,7 +1465,7 @@ function plymeta:DropAmmo(wep, useClip, amt)
         if useClip then
             amt = wep:Clip1()
         else
-            amt = math.min(wep.AmmoEnt.AmmoAmount, self:GetAmmoCount(wep.Primary.Ammo))
+            amt = math.min(box.AmmoAmount, self:GetAmmoCount(wep.Primary.Ammo))
         end
     end
     local hook_data = { amt }


### PR DESCRIPTION
now references the already created ammo box instead of trying to get data from via weapons ammo entity reference which can return nil.