### PR TITLE
Implement UI scaling in Derma UIs

### DIFF
--- a/gamemodes/terrortown/gamemode/client/cl_help.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_help.lua
@@ -224,13 +224,21 @@ function HELPSCRN:ShowMainMenu()
     local maxHeight = rows * heightMainMenuButton * scale
         + (rows - 1) * padding
         + ((#menusAdmin == 0) and 0 or heightAdminSeperator * scale)
-    local heightScroll = height * scale - vskin.GetHeaderHeight() - vskin.GetBorderSize() - 2 * padding
+    local heightScroll = height * scale
+        - vskin.GetHeaderHeight()
+        - vskin.GetBorderSize()
+        - 2 * padding
 
     local scrollSize = (heightScroll < maxHeight and 20 or 0) * scale
 
     local widthMainMenuButton = (width - 4 * padding - scrollSize) / 3
 
-    AddMenuButtons(menusNormal, dsettings, widthMainMenuButton * scale, heightMainMenuButton * scale)
+    AddMenuButtons(
+        menusNormal,
+        dsettings,
+        widthMainMenuButton * scale,
+        heightMainMenuButton * scale
+    )
 
     -- only show admin section if player is admin and
     -- there are menues to be shown
@@ -351,7 +359,11 @@ function HELPSCRN:ShowSubmenu(menuClass)
     if IsValid(frame) then
         frame:ClearFrame(nil, nil, menuClass.title or menuClass.type)
     else
-        frame = vguihandler.GenerateFrame(width * scale, height * scale, menuClass.title or menuClass.type)
+        frame = vguihandler.GenerateFrame(
+            width * scale,
+            height * scale,
+            menuClass.title or menuClass.type
+        )
     end
 
     -- INIT SUB MENU SPECIFIC STUFF

--- a/gamemodes/terrortown/gamemode/client/cl_help.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_help.lua
@@ -175,18 +175,20 @@ local MAIN_MENU = "main"
 -- @realm client
 function HELPSCRN:ShowMainMenu()
     local frame = self.menuFrame
+    local scale = appearance.GetGlobalScale()
 
     -- IF MENU ELEMENT DOES NOT ALREADY EXIST, CREATE IT
     if IsValid(frame) then
         frame:ClearFrame(nil, nil, "help_title")
     else
-        frame = vguihandler.GenerateFrame(width, height, "help_title")
+        frame = vguihandler.GenerateFrame(width * scale, height * scale, "help_title")
     end
 
     self.menuFrame = frame
 
     -- INIT MAIN MENU SPECIFIC STUFF
-    frame:SetPadding(self.padding, self.padding, self.padding, self.padding)
+    local padding = self.padding * scale
+    frame:SetPadding(padding, padding, padding, padding)
 
     -- MARK AS MAIN MENU
     self.currentMenuId = MAIN_MENU
@@ -198,8 +200,8 @@ function HELPSCRN:ShowMainMenu()
     -- SPLIT FRAME INTO A GRID LAYOUT
     local dsettings = vgui.Create("DIconLayout", scrollPanel)
     dsettings:Dock(FILL)
-    dsettings:SetSpaceX(self.padding)
-    dsettings:SetSpaceY(self.padding)
+    dsettings:SetSpaceX(padding)
+    dsettings:SetSpaceY(padding)
 
     -- SPLIT INTO NORMAL AND ADMIN MENUS
     local menusNormal, menusAdmin = {}, {}
@@ -219,16 +221,16 @@ function HELPSCRN:ShowMainMenu()
     end
 
     local rows = math.ceil(#menusNormal / 3) + math.ceil(#menusAdmin / 3)
-    local maxHeight = rows * heightMainMenuButton
-        + (rows - 1) * self.padding
-        + ((#menusAdmin == 0) and 0 or heightAdminSeperator)
-    local heightScroll = height - vskin.GetHeaderHeight() - vskin.GetBorderSize() - 2 * self.padding
+    local maxHeight = rows * heightMainMenuButton * scale
+        + (rows - 1) * padding
+        + ((#menusAdmin == 0) and 0 or heightAdminSeperator * scale)
+    local heightScroll = height * scale - vskin.GetHeaderHeight() - vskin.GetBorderSize() - 2 * padding
 
-    local scrollSize = (heightScroll < maxHeight and 20 or 0)
+    local scrollSize = (heightScroll < maxHeight and 20 or 0) * scale
 
-    local widthMainMenuButton = (width - 4 * self.padding - scrollSize) / 3
+    local widthMainMenuButton = (width - 4 * padding - scrollSize) / 3
 
-    AddMenuButtons(menusNormal, dsettings, widthMainMenuButton, heightMainMenuButton)
+    AddMenuButtons(menusNormal, dsettings, widthMainMenuButton * scale, heightMainMenuButton * scale)
 
     -- only show admin section if player is admin and
     -- there are menues to be shown
@@ -239,7 +241,7 @@ function HELPSCRN:ShowMainMenu()
     local labelSpacer = dsettings:Add("DLabelTTT2")
     labelSpacer.OwnLine = true
     labelSpacer:SetText("label_menu_admin_spacer")
-    labelSpacer:SetSize(width - 2 * self.padding - scrollSize, heightAdminSeperator)
+    labelSpacer:SetSize(width * scale - 2 * padding - scrollSize, heightAdminSeperator * scale)
     labelSpacer:SetFont("DermaTTT2TextLarge")
     labelSpacer.Paint = function(slf, w, h)
         derma.SkinHook("Paint", "LabelSpacerTTT2", slf, w, h)
@@ -247,7 +249,7 @@ function HELPSCRN:ShowMainMenu()
         return true
     end
 
-    AddMenuButtons(menusAdmin, dsettings, widthMainMenuButton, heightMainMenuButton)
+    AddMenuButtons(menusAdmin, dsettings, widthMainMenuButton * scale, heightMainMenuButton * scale)
 end
 
 ---
@@ -293,6 +295,8 @@ function HELPSCRN:BuildContentArea()
         return
     end
 
+    local scale = appearance.GetGlobalScale()
+
     ---
     -- @realm client
     if
@@ -314,7 +318,7 @@ function HELPSCRN:BuildContentArea()
 
     -- CALCULATE SIZE BASED ON EXISTENCE OF BUTTON PANEL
     if self.submenuClass:HasButtonPanel() then
-        height2 = height2 - heightButtonPanel
+        height2 = height2 - heightButtonPanel * scale
     end
 
     -- ADD CONTENT BOX AND CONTENT
@@ -328,7 +332,7 @@ function HELPSCRN:BuildContentArea()
     -- ADD BUTTON BOX AND BUTTONS
     if self.submenuClass:HasButtonPanel() then
         local buttonArea = vgui.Create("DButtonPanelTTT2", parent)
-        buttonArea:SetSize(width2, heightButtonPanel)
+        buttonArea:SetSize(width2, heightButtonPanel * scale)
         buttonArea:Dock(BOTTOM)
 
         self.submenuClass:PopulateButtonPanel(buttonArea)
@@ -341,12 +345,13 @@ end
 -- @realm client
 function HELPSCRN:ShowSubmenu(menuClass)
     local frame = self.menuFrame
+    local scale = appearance.GetGlobalScale()
 
     -- IF MENU ELEMENT DOES NOT ALREADY EXIST, CREATE IT
     if IsValid(frame) then
         frame:ClearFrame(nil, nil, menuClass.title or menuClass.type)
     else
-        frame = vguihandler.GenerateFrame(width, height, menuClass.title or menuClass.type)
+        frame = vguihandler.GenerateFrame(width * scale, height * scale, menuClass.title or menuClass.type)
     end
 
     -- INIT SUB MENU SPECIFIC STUFF
@@ -360,26 +365,28 @@ function HELPSCRN:ShowSubmenu(menuClass)
     -- MARK AS SUBMENU
     self.currentMenuId = menuClass.type
 
+    local padding = self.padding * scale
+
     -- BUILD GENERAL BOX STRUCTURE
     local navArea = vgui.Create("DNavPanelTTT2", frame)
-    navArea:SetWide(widthNav)
+    navArea:SetWide(widthNav * scale)
     navArea:SetPos(0, 0)
-    navArea:DockPadding(0, self.padding, 1, self.padding)
+    navArea:DockPadding(0, padding, 1, padding)
     navArea:Dock(LEFT)
 
     local contentArea = vgui.Create("DContentPanelTTT2", frame)
     contentArea:SetSize(
-        widthContent,
-        heightContent - vskin.GetHeaderHeight() - vskin.GetBorderSize()
+        widthContent * scale,
+        heightContent * scale - vskin.GetHeaderHeight() - vskin.GetBorderSize()
     )
-    contentArea:SetPos(widthNav, 0)
-    contentArea:DockPadding(self.padding, self.padding, self.padding, self.padding)
+    contentArea:SetPos(widthNav * scale, 0)
+    contentArea:DockPadding(padding, padding, padding, padding)
     contentArea:Dock(TOP)
 
     -- MAKE SEPARATE SUBMENULIST ON THE NAVAREA WITH A CONTENT AREA
     local submenuList = vgui.Create("DSubmenuListTTT2", navArea)
     submenuList:Dock(FILL)
-    submenuList:SetPadding(self.padding)
+    submenuList:SetPadding(padding)
     submenuList:SetBasemenuClass(menuClass, contentArea)
     submenuList:EnableSearchBar(menuClass:HasSearchbar())
 

--- a/gamemodes/terrortown/gamemode/client/cl_scoring.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_scoring.lua
@@ -95,12 +95,13 @@ CLSCORE.sizes = {}
 -- @internal
 -- @realm client
 function CLSCORE:CalculateSizes()
-    self.sizes.width = 1200
-    self.sizes.height = 700
-    self.sizes.padding = 10
+    local scale = appearance.GetGlobalScale()
+    self.sizes.width = 1200 * scale
+    self.sizes.height = 700 * scale
+    self.sizes.padding = 10 * scale
     self.sizes.paddingSmall = 0.5 * self.sizes.padding
 
-    self.sizes.widthMenu = 50 + vskin.GetBorderSize()
+    self.sizes.widthMenu = 50 * scale + vskin.GetBorderSize()
 
     local doublePadding = 2 * self.sizes.padding
 
@@ -110,28 +111,29 @@ function CLSCORE:CalculateSizes()
         - vskin.GetBorderSize()
     self.sizes.widthMainArea = self.sizes.width - self.sizes.widthMenu - doublePadding
 
-    self.sizes.heightHeaderPanel = 120
-    self.sizes.widthTopButton = 140
-    self.sizes.heightTopButton = 30
+    self.sizes.heightHeaderPanel = 120 * scale
+    self.sizes.widthTopButton = 140 * scale
+    self.sizes.heightTopButton = 30 * scale
     self.sizes.widthTopLabel = 0.5 * self.sizes.widthMainArea
         - self.sizes.widthTopButton
         - self.sizes.padding
     self.sizes.heightTopButtonPanel = self.sizes.heightTopButton + doublePadding
-    self.sizes.heightRow = 25
-    self.sizes.heightTitleRow = 30
+    self.sizes.heightRow = 25 * scale
+    self.sizes.heightTitleRow = 30 * scale
 
-    self.sizes.heightButton = 45
-    self.sizes.widthButton = 175
-    self.sizes.heightBottomButtonPanel = self.sizes.heightButton + self.sizes.padding + 1
+    self.sizes.heightButton = 45 * scale
+    self.sizes.widthButton = 175 * scale
+    self.sizes.heightBottomButtonPanel = self.sizes.heightButton + self.sizes.padding + 1 * scale
     self.sizes.heightContentLarge = self.sizes.heightMainArea
         - self.sizes.heightBottomButtonPanel
         - self.sizes.heightTopButtonPanel
         - 3 * self.sizes.padding
     self.sizes.heightContent = self.sizes.heightContentLarge - self.sizes.heightHeaderPanel
-    self.sizes.heightMenuButton = 50
+    self.sizes.heightMenuButton = 50 * scale
 
-    self.sizes.widthKarma = 50
-    self.sizes.widthScore = 35
+    self.sizes.widthKarma = 50 * scale
+    self.sizes.widthScore = 35 * scale
+    self.sizes.scale = scale
 end
 
 ---
@@ -197,7 +199,7 @@ function CLSCORE:CreatePanel()
     local buttonClose = vgui.Create("DButtonTTT2", buttonArea)
     buttonClose:SetText("close")
     buttonClose:SetSize(self.sizes.widthButton, self.sizes.heightButton)
-    buttonClose:SetPos(self.sizes.widthMainArea - self.sizes.widthButton, self.sizes.padding + 1)
+    buttonClose:SetPos(self.sizes.widthMainArea - self.sizes.widthButton, self.sizes.padding + 1 * self.sizes.scale)
     buttonClose.DoClick = function(btn)
         self:HidePanel()
     end
@@ -209,7 +211,7 @@ function CLSCORE:CreatePanel()
         local data = subMenusIndexed[i]
 
         local menuButton = menuBoxGrid:Add("DSubmenuButtonTTT2")
-        menuButton:SetSize(self.sizes.widthMenu - 1, self.sizes.heightMenuButton)
+        menuButton:SetSize(self.sizes.widthMenu - 1 * self.sizes.scale, self.sizes.heightMenuButton)
         menuButton:SetIcon(data.icon)
         menuButton:SetTooltip(data.title)
         menuButton.DoClick = function(slf)

--- a/gamemodes/terrortown/gamemode/client/cl_scoring.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_scoring.lua
@@ -199,7 +199,10 @@ function CLSCORE:CreatePanel()
     local buttonClose = vgui.Create("DButtonTTT2", buttonArea)
     buttonClose:SetText("close")
     buttonClose:SetSize(self.sizes.widthButton, self.sizes.heightButton)
-    buttonClose:SetPos(self.sizes.widthMainArea - self.sizes.widthButton, self.sizes.padding + 1 * self.sizes.scale)
+    buttonClose:SetPos(
+        self.sizes.widthMainArea - self.sizes.widthButton,
+        self.sizes.padding + 1 * self.sizes.scale
+    )
     buttonClose.DoClick = function(btn)
         self:HidePanel()
     end

--- a/gamemodes/terrortown/gamemode/client/cl_search.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_search.lua
@@ -75,16 +75,17 @@ SEARCHSCREEN.infoBoxes = {}
 -- Calculates and caches the dimensions of the bodysearch UI.
 -- @realm client
 function SEARCHSCREEN:CalculateSizes()
-    self.sizes.width = 600
-    self.sizes.height = 500
-    self.sizes.padding = 10
+    local scale = appearance.GetGlobalScale()
+    self.sizes.width = 600 * scale
+    self.sizes.height = 500 * scale
+    self.sizes.padding = 10 * scale
 
-    self.sizes.heightButton = 45
-    self.sizes.widthButton = 160
-    self.sizes.widthButtonCredits = 220
-    self.sizes.widthButtonTakeCredits = 180
-    self.sizes.widthButtonClose = 100
-    self.sizes.heightBottomButtonPanel = self.sizes.heightButton + self.sizes.padding + 1
+    self.sizes.heightButton = 45 * scale
+    self.sizes.widthButton = 160 * scale
+    self.sizes.widthButtonCredits = 220 * scale
+    self.sizes.widthButtonTakeCredits = 180 * scale
+    self.sizes.widthButtonClose = 100 * scale
+    self.sizes.heightBottomButtonPanel = self.sizes.heightButton + self.sizes.padding + 1 * scale
 
     self.sizes.widthMainArea = self.sizes.width - 2 * self.sizes.padding
     self.sizes.heightMainArea = self.sizes.height
@@ -93,14 +94,15 @@ function SEARCHSCREEN:CalculateSizes()
         - vskin.GetHeaderHeight()
         - vskin.GetBorderSize()
 
-    self.sizes.widthProfileArea = 200
+    self.sizes.widthProfileArea = 200 * scale
 
     self.sizes.widthContentArea = self.sizes.width
         - self.sizes.widthProfileArea
         - 3 * self.sizes.padding
-    self.sizes.widthContentBox = self.sizes.widthContentArea - 2 * self.sizes.padding - 100
+    self.sizes.widthContentBox = self.sizes.widthContentArea - 2 * self.sizes.padding - 100 * scale
 
-    self.sizes.heightInfoItem = 78
+    self.sizes.heightInfoItem = 78 * scale
+    self.sizes.scale = scale
 end
 
 ---
@@ -330,11 +332,11 @@ function SEARCHSCREEN:Show(data)
     local buttonReport = vgui.Create("DButtonTTT2", buttonArea)
     buttonReport:SetText("search_call")
     buttonReport:SetSize(self.sizes.widthButton, self.sizes.heightButton)
-    buttonReport:SetPos(0, self.sizes.padding + 1)
+    buttonReport:SetPos(0, self.sizes.padding + 1 * self.sizes.scale)
     buttonReport.DoClick = function(btn)
         bodysearch.ClientReportsCorpse(data.rag)
     end
-    buttonReport:SetIcon(roles.DETECTIVE.iconMaterial, true, 16)
+    buttonReport:SetIcon(roles.DETECTIVE.iconMaterial, true, 16 * self.sizes.scale)
 
     if not bodysearch.CanReportBody(data.ragOwner) then
         buttonReport:SetEnabled(false)
@@ -355,7 +357,7 @@ function SEARCHSCREEN:Show(data)
         buttonConfirm:SetSize(self.sizes.widthButton, self.sizes.heightButton)
         buttonConfirm:SetPos(
             self.sizes.widthMainArea - self.sizes.widthButton,
-            self.sizes.padding + 1
+            self.sizes.padding + 1 * self.sizes.scale
         )
     elseif bodysearch.IsConfirmed(data.ragOwner) then
         buttonConfirm:SetText("search_confirmed")
@@ -363,7 +365,7 @@ function SEARCHSCREEN:Show(data)
         buttonConfirm:SetSize(self.sizes.widthButton, self.sizes.heightButton)
         buttonConfirm:SetPos(
             self.sizes.widthMainArea - self.sizes.widthButton,
-            self.sizes.padding + 1
+            self.sizes.padding + 1 * self.sizes.scale
         )
     elseif not bodysearch.CanConfirmBody() then
         if playerCanTakeCredits then
@@ -373,7 +375,7 @@ function SEARCHSCREEN:Show(data)
             buttonConfirm:SetSize(self.sizes.widthButtonTakeCredits, self.sizes.heightButton)
             buttonConfirm:SetPos(
                 self.sizes.widthMainArea - self.sizes.widthButtonTakeCredits,
-                self.sizes.padding + 1
+                self.sizes.padding + 1 * self.sizes.scale
             )
         else
             buttonConfirm:SetText("search_confirm_forbidden")
@@ -381,7 +383,7 @@ function SEARCHSCREEN:Show(data)
             buttonConfirm:SetSize(self.sizes.widthButton, self.sizes.heightButton)
             buttonConfirm:SetPos(
                 self.sizes.widthMainArea - self.sizes.widthButton,
-                self.sizes.padding + 1
+                self.sizes.padding + 1 * self.sizes.scale
             )
         end
     elseif playerCanTakeCredits then
@@ -390,7 +392,7 @@ function SEARCHSCREEN:Show(data)
         buttonConfirm:SetSize(self.sizes.widthButtonCredits, self.sizes.heightButton)
         buttonConfirm:SetPos(
             self.sizes.widthMainArea - self.sizes.widthButtonCredits,
-            self.sizes.padding + 1
+            self.sizes.padding + 1 * self.sizes.scale
         )
         buttonConfirm:SetIcon(materialCredits)
     else
@@ -398,7 +400,7 @@ function SEARCHSCREEN:Show(data)
         buttonConfirm:SetSize(self.sizes.widthButton, self.sizes.heightButton)
         buttonConfirm:SetPos(
             self.sizes.widthMainArea - self.sizes.widthButton,
-            self.sizes.padding + 1
+            self.sizes.padding + 1 * self.sizes.scale
         )
     end
     buttonConfirm.DoClick = function(btn)

--- a/gamemodes/terrortown/gamemode/client/cl_tradio.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_tradio.lua
@@ -24,10 +24,11 @@ local sounds = {
 -- Calculates and caches the dimensions of the Radio UI.
 -- @realm client
 function TRADIO:CalculateSizes()
-    self.sizes.padding = 10
+    local scale = appearance.GetGlobalScale()
+    self.sizes.padding = 10 * scale
 
-    self.sizes.heightButton = 45
-    self.sizes.widthButton = 160
+    self.sizes.heightButton = 45 * scale
+    self.sizes.widthButton = 160 * scale
 
     self.sizes.numWidthButtons = 3
     self.sizes.numHeightButtons = math.ceil(table.Count(sounds) / 3)
@@ -42,6 +43,7 @@ function TRADIO:CalculateSizes()
         + vskin.GetHeaderHeight()
         + vskin.GetBorderSize()
         + 2 * self.sizes.padding
+    self.sizes.scale = scale
 end
 
 ---

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/default_skin.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/default_skin.lua
@@ -52,10 +52,13 @@ local drawFilteredShadowedTexture = draw.FilteredShadowedTexture
 local drawOutlinedBox = draw.OutlinedBox
 local drawFilteredTexture = draw.FilteredTexture
 local drawSimpleText = draw.SimpleText
+local drawAdvancedText = draw.AdvancedText
 local drawLine = draw.Line
 local drawGetWrappedText = draw.GetWrappedText
 local drawGetTextSize = draw.GetTextSize
 local drawGetLimitedLengthText = draw.GetLimitedLengthText
+
+local GetGlobalScale = appearance.GetGlobalScale
 
 local alphaDisabled = 100
 
@@ -203,7 +206,7 @@ function SKIN:PaintFrameTTT2(panel, w, h)
         text = TryT(title)
     end
 
-    drawShadowedText(
+    drawAdvancedText(
         text,
         panel:GetTitleFont(),
         0.5 * w,
@@ -211,7 +214,8 @@ function SKIN:PaintFrameTTT2(panel, w, h)
         colors.titleText,
         TEXT_ALIGN_CENTER,
         TEXT_ALIGN_CENTER,
-        1
+        true,
+        GetGlobalScale()
     )
 end
 
@@ -239,7 +243,7 @@ end
 -- @param number h
 -- @realm client
 function SKIN:PaintButtonPanelTTT2(panel, w, h)
-    drawBox(0, 0, w, 1, ColorAlpha(colors.default, 200))
+    drawBox(0, 0, w, 1 * GetGlobalScale(), ColorAlpha(colors.default, 200))
 end
 
 ---
@@ -260,14 +264,14 @@ function SKIN:PaintWindowCloseButton(panel, w, h)
     local colorBackground = colors.accent
     local colorText = ColorAlpha(colors.accentText, 150)
     local shift = 0
-    local padding = 15
+    local padding = 15 * GetGlobalScale()
 
     if not panel:IsEnabled() then
         colorText = ColorAlpha(colors.accentText, 70)
     elseif panel.Depressed or panel:IsSelected() then
         colorBackground = colors.accentActive
         colorText = ColorAlpha(colors.accentText, 200)
-        shift = 1
+        shift = 1 * GetGlobalScale()
     elseif panel.Hovered then
         colorBackground = colors.accentHover
         colorText = colors.accentText
@@ -294,15 +298,15 @@ function SKIN:PaintWindowBackButton(panel, w, h)
     local colorBackground = colors.accent
     local colorText = ColorAlpha(colors.accentText, 150)
     local shift = 0
-    local padding_w = 10
-    local padding_h = 15
+    local padding_w = 10 * GetGlobalScale()
+    local padding_h = 15 * GetGlobalScale()
 
     if not panel:IsEnabled() then
         colorText = ColorAlpha(colors.accentText, 70)
     elseif panel.Depressed or panel:IsSelected() then
         colorBackground = colors.accentActive
         colorText = ColorAlpha(colors.accentText, 200)
-        shift = 1
+        shift = 1 * GetGlobalScale()
     elseif panel.Hovered then
         colorBackground = colors.accentHover
         colorText = colors.accentText
@@ -337,8 +341,8 @@ end
 -- @realm client
 function SKIN:PaintScrollBarGrip(panel, w, h)
     local colorScrollbar = colors.scrollBar
-    local posX = 4
-    local sizeX = w - 8
+    local posX = 4 * GetGlobalScale()
+    local sizeX = w - 8 * GetGlobalScale()
 
     if panel.Depressed then
         colorScrollbar = colors.scrollBarActive
@@ -362,20 +366,22 @@ function SKIN:PaintMenuButtonTTT2(panel, w, h)
         return
     end
 
+    local scale = GetGlobalScale()
+
     local colorOutline = utilGetChangedColor(colors.default, 170)
     local colorDescription = utilGetChangedColor(colors.default, 145)
     local colorText = utilGetChangedColor(colors.default, 65)
     local colorIcon = utilGetChangedColor(colors.default, 170)
     local shift = 0
-    local paddingText = 10
-    local paddingIcon = 25
+    local paddingText = 10 * scale
+    local paddingIcon = 25 * scale
 
     if panel.Depressed or panel:IsSelected() or panel:GetToggle() then
         colorOutline = utilGetChangedColor(colors.default, 135)
         colorDescription = utilGetChangedColor(colors.default, 135)
         colorIcon = utilGetChangedColor(colors.default, 160)
         colorText = utilGetChangedColor(colors.default, 50)
-        shift = 1
+        shift = 1 * scale
     elseif panel.Hovered then
         colorOutline = utilGetChangedColor(colors.default, 135)
         colorDescription = utilGetChangedColor(colors.default, 135)
@@ -383,7 +389,7 @@ function SKIN:PaintMenuButtonTTT2(panel, w, h)
         colorText = utilGetChangedColor(colors.default, 50)
     end
 
-    drawOutlinedBox(0, 0, w, h, 1, colorOutline)
+    drawOutlinedBox(0, 0, w, h, 1 * scale, colorOutline)
     drawFilteredTexture(
         paddingIcon,
         paddingIcon + shift,
@@ -393,35 +399,41 @@ function SKIN:PaintMenuButtonTTT2(panel, w, h)
         colorIcon.a,
         colorIcon
     )
-    drawSimpleText(
+    drawAdvancedText(
         TryT(panel:GetTitle()),
         panel:GetTitleFont(),
         h,
         paddingText + shift,
         colorText,
         TEXT_ALIGN_LEFT,
-        TEXT_ALIGN_TOP
+        TEXT_ALIGN_TOP,
+        false,
+        scale
     )
 
+    local font, fscale, fcmod = fonts.ScaledFont(panel:GetDescriptionFont(), scale)
     local desc_wrapped = drawGetWrappedText(
         TryT(panel:GetDescription()),
-        w - h - 2 * paddingText,
-        panel:GetDescriptionFont()
+        (w - h - 2 * paddingText) / fcmod,
+        font
     )
-    local line_pos = 35
+    local _, lineHeight = draw.GetTextSize("", font, fscale)
+    local line_pos = 35 * scale
 
     for i = 1, #desc_wrapped do
-        drawSimpleText(
+        drawAdvancedText(
             desc_wrapped[i],
             panel:GetDescriptionFont(),
             h,
             line_pos + paddingText + shift,
             colorDescription,
             TEXT_ALIGN_LEFT,
-            TEXT_ALIGN_TOP
+            TEXT_ALIGN_TOP,
+            false,
+            scale
         )
 
-        line_pos = line_pos + 20
+        line_pos = line_pos + lineHeight
     end
 end
 
@@ -454,7 +466,7 @@ function SKIN:PaintSubMenuButtonTTT2(panel, w, h)
         colorBar = colors.accentActive
         colorText = utilGetActiveColor(utilGetChangedColor(colors.default, 25))
         colorIcon = utilGetActiveColor(utilGetChangedColor(COLOR_WHITE, 32))
-        shift = 1
+        shift = 1 * GetGlobalScale()
     elseif panel.Hovered then
         colorBackground = utilGetHoverColor(ColorAlpha(colors.accent, 50))
         colorBar = colors.accentHover
@@ -493,14 +505,16 @@ function SKIN:PaintSubMenuButtonTTT2(panel, w, h)
         end
     end
 
-    drawSimpleText(
+    drawAdvancedText(
         TryT(panel:GetTitle()),
         panel:GetTitleFont(),
         sizes.border + pad + (hasIcon and (sizeIcon + pad) or pad),
         0.5 * h + shift,
         colorText,
         TEXT_ALIGN_LEFT,
-        TEXT_ALIGN_CENTER
+        TEXT_ALIGN_CENTER,
+        false,
+        GetGlobalScale()
     )
 end
 
@@ -542,8 +556,8 @@ function SKIN:PaintCheckBox(panel, w, h)
         end
     end
 
-    drawRoundedBox(4, 0, 0, w, h, colorBox)
-    drawRoundedBox(4, offset + 3, 3, h - 6, h - 6, colorCenter)
+    drawRoundedBox(4 * GetGlobalScale(), 0, 0, w, h, colorBox)
+    drawRoundedBox(4 * GetGlobalScale(), offset + 3 * GetGlobalScale(), 3 * GetGlobalScale(), h - 6 * GetGlobalScale(), h - 6 * GetGlobalScale(), colorCenter)
 end
 
 ---
@@ -564,14 +578,16 @@ function SKIN:PaintCheckBoxLabel(panel, w, h)
 
     local params = panel:GetTextParams()
 
-    drawSimpleText(
+    drawAdvancedText(
         params and ParT(panel:GetText(), params) or TryT(panel:GetText()),
         panel:GetFont(),
         panel:GetTextPosition(),
         0.5 * h,
         colorText,
         TEXT_ALIGN_LEFT,
-        TEXT_ALIGN_CENTER
+        TEXT_ALIGN_CENTER,
+        false,
+        GetGlobalScale()
     )
 end
 
@@ -593,17 +609,18 @@ end
 function SKIN:PaintCategoryHeaderTTT2(panel, w, h)
     local colorLine = utilGetChangedColor(colors.background, 50)
     local colorText = utilGetChangedColor(colors.default, 50)
-    local paddingX = 10
-    local paddingY = 10
+    local scale = GetGlobalScale()
+    local paddingX = 10 * scale
+    local paddingY = 10 * scale
 
     drawBox(0, 0, w, h, colors.background)
 
     if panel:GetParent():GetExpanded() then
-        drawLine(0, h - 1, w, h - 1, colorLine)
+        drawLine(0, h - 1 * scale, w, h - 1 * scale, colorLine)
 
         drawFilteredShadowedTexture(
             paddingX,
-            paddingY + 1,
+            paddingY + 1 * scale,
             h - 2 * paddingY,
             h - 2 * paddingY,
             materialCollapseOpened,
@@ -622,14 +639,16 @@ function SKIN:PaintCategoryHeaderTTT2(panel, w, h)
         )
     end
 
-    drawSimpleText(
+    drawAdvancedText(
         string.upper(TryT(panel.text)),
         panel:GetFont(),
         h,
         0.5 * h,
         colorText,
         TEXT_ALIGN_LEFT,
-        TEXT_ALIGN_CENTER
+        TEXT_ALIGN_CENTER,
+        false,
+        scale
     )
 end
 
@@ -643,6 +662,7 @@ function SKIN:PaintButtonTTT2(panel, w, h)
     local colorBox = colors.accent
     local colorText = ColorAlpha(utilGetDefaultColor(colors.accent), 220)
     local shift = 0
+    local scale = GetGlobalScale()
 
     if not panel:IsEnabled() then
         local colorAccentDisabled = utilGetChangedColor(colors.default, 150)
@@ -654,7 +674,7 @@ function SKIN:PaintButtonTTT2(panel, w, h)
         colorLine = colors.accentDarkActive
         colorBox = colors.accentActive
         colorText = ColorAlpha(utilGetDefaultColor(colors.accent), 220)
-        shift = 1
+        shift = 1 * scale
     elseif panel.Hovered then
         colorLine = colors.accentDarkHover
         colorBox = colors.accentHover
@@ -671,12 +691,12 @@ function SKIN:PaintButtonTTT2(panel, w, h)
         translatedText = string.upper(TryT(panel:GetText()))
     end
 
-    local font = panel:GetFont()
+    local font, fscale = fonts.ScaledFont(panel:GetFont(), scale)
     local xText = 0.5 * w
 
     if panel:HasIcon() then
-        local widthText = drawGetTextSize(translatedText, font)
-        local padding = 5
+        local widthText = drawGetTextSize(translatedText, font, fscale)
+        local padding = 5 * scale
         local sizeIcon = panel:GetIconSize()
         local yIcon = 0.5 * (h - sizeIcon)
 
@@ -699,14 +719,16 @@ function SKIN:PaintButtonTTT2(panel, w, h)
         end
     end
 
-    drawShadowedText(
+    drawAdvancedText(
         translatedText,
-        font,
+        panel:GetFont(),
         xText,
         0.5 * (h - sizes.border) + shift,
         colorText,
         TEXT_ALIGN_CENTER,
-        TEXT_ALIGN_CENTER
+        TEXT_ALIGN_CENTER,
+        true,
+        scale
     )
 end
 
@@ -717,6 +739,7 @@ end
 -- @realm client
 function SKIN:PaintFormButtonIconTTT2(panel, w, h)
     local colorBox = colors.accent
+    local scale = GetGlobalScale()
 
     if panel.colorBackground then
         if IsColor(panel.colorBackground) then
@@ -729,7 +752,7 @@ function SKIN:PaintFormButtonIconTTT2(panel, w, h)
     local colorBoxBack = colors.settingsBox
     local colorText = ColorAlpha(utilGetDefaultColor(colors.accent), 150)
     local shift = 0
-    local pad = 6
+    local pad = 6 * scale
 
     if not panel:IsEnabled() then
         colorBoxBack = ColorAlpha(colorBoxBack, alphaDisabled)
@@ -741,7 +764,7 @@ function SKIN:PaintFormButtonIconTTT2(panel, w, h)
     elseif panel.Depressed or panel:IsSelected() or panel:GetToggle() then
         colorBox = utilGetActiveColor(colorBox)
         colorText = ColorAlpha(utilGetDefaultColor(colorBox), 150)
-        shift = 1
+        shift = 1 * scale
     elseif panel.Hovered then
         colorBox = utilGetHoverColor(colorBox)
         colorText = ColorAlpha(utilGetDefaultColor(colorBox), 150)
@@ -753,7 +776,7 @@ function SKIN:PaintFormButtonIconTTT2(panel, w, h)
         drawBox(0, 0, w, h, colorBoxBack)
     end
 
-    drawRoundedBox(sizes.cornerRadius, 1, 1, w - 2, h - 2, colorBox)
+    drawRoundedBox(sizes.cornerRadius, 1 * scale, 1 * scale, w - 2 * scale, h - 2 * scale, colorBox)
 
     local iconMaterial = panel.iconMaterial or panel.material
 
@@ -801,7 +824,7 @@ function SKIN:PaintFormButtonTTT2(panel, w, h)
     end
 
     drawRoundedBoxEx(sizes.cornerRadius, 0, 0, w, h, colorBoxBack, false, true, false, true)
-    drawRoundedBox(sizes.cornerRadius, 1, 1, w - 2, h - 2, colorBox)
+    drawRoundedBox(sizes.cornerRadius, 1 * GetGlobalScale(), 1 * GetGlobalScale(), w - 2 * GetGlobalScale(), h - 2 * GetGlobalScale(), colorBox)
 
     drawShadowedText(
         TryT(panel:GetText()),
@@ -824,6 +847,7 @@ function SKIN:PaintBinderButtonTTT2(panel, w, h)
     local colorBox = colors.accent
     local colorText = ColorAlpha(utilGetDefaultColor(colors.accent), 150)
     local shift = 0
+    local scale = GetGlobalScale()
 
     if not panel:IsEnabled() then
         colorBoxBack = ColorAlpha(colors.settingsBox, alphaDisabled)
@@ -835,7 +859,7 @@ function SKIN:PaintBinderButtonTTT2(panel, w, h)
         colorBoxBack = colors.settingsBox
         colorBox = colors.accentActive
         colorText = ColorAlpha(utilGetDefaultColor(colors.accent), 150)
-        shift = 1
+        shift = 1 * scale
     end
 
     if panel.Hovered then
@@ -845,16 +869,18 @@ function SKIN:PaintBinderButtonTTT2(panel, w, h)
     end
 
     drawRoundedBoxEx(sizes.cornerRadius, 0, 0, w, h, colorBoxBack, false, true, false, true)
-    drawRoundedBox(sizes.cornerRadius, 1, 1, w - 2, h - 2, colorBox)
+    drawRoundedBox(sizes.cornerRadius, 1 * scale, 1 * scale, w - 2 * scale, h - 2 * scale, colorBox)
 
-    drawShadowedText(
+    drawAdvancedText(
         string.upper(TryT(panel:GetText())),
         panel:GetFont(),
         0.5 * w,
         0.5 * h + shift,
         colorText,
         TEXT_ALIGN_CENTER,
-        TEXT_ALIGN_CENTER
+        TEXT_ALIGN_CENTER,
+        true,
+        scale
     )
 end
 
@@ -867,11 +893,11 @@ function SKIN:PaintLabelSpacerTTT2(panel, w, h)
     local text = TryT(panel:GetText())
     local font = panel:GetFont()
 
-    local padding = 10
-    local heightBar = 5
+    local padding = 10 * GetGlobalScale()
+    local heightBar = 5 * GetGlobalScale()
     local barX1 = 0
     local barY1 = 0.5 * (h - heightBar) + 1
-    local widthBar1 = 20
+    local widthBar1 = 20 * GetGlobalScale()
     local textX = barX1 + widthBar1 + padding
     local widthText = drawGetTextSize(text, font)
     local barX2 = textX + widthText + padding
@@ -899,14 +925,16 @@ end
 -- @param number h
 -- @realm client
 function SKIN:PaintLabelTTT2(panel, w, h)
-    drawSimpleText(
+    drawAdvancedText(
         TryT(panel:GetText()),
         panel:GetFont(),
         0,
         0.5 * h,
         utilGetChangedColor(colors.default, 40),
         TEXT_ALIGN_LEFT,
-        TEXT_ALIGN_CENTER
+        TEXT_ALIGN_CENTER,
+        false,
+        GetGlobalScale()
     )
 end
 
@@ -941,15 +969,18 @@ function SKIN:PaintFormLabelTTT2(panel, w, h)
         colorBox = ColorAlpha(colors.settingsBox, alphaDisabled)
     end
 
+    local scale = GetGlobalScale()
     drawRoundedBoxEx(sizes.cornerRadius, 0, 0, w, h, colorBox, true, false, true, false)
-    drawSimpleText(
+    drawAdvancedText(
         TryT(panel:GetText()),
         panel:GetFont(),
-        10,
+        10 * scale,
         0.5 * h,
         colorText,
         TEXT_ALIGN_LEFT,
-        TEXT_ALIGN_CENTER
+        TEXT_ALIGN_CENTER,
+        false,
+        scale
     )
 end
 
@@ -967,8 +998,9 @@ function SKIN:PaintFormBoxTTT2(panel, w, h)
         colorHandle = ColorAlpha(colors.handle, alphaDisabled)
     end
 
+    local scale = GetGlobalScale()
     drawRoundedBoxEx(sizes.cornerRadius, 0, 0, w, h, colorBox, false, true, false, true)
-    drawRoundedBox(sizes.cornerRadius, 1, 1, w - 2, h - 2, colorHandle)
+    drawRoundedBox(sizes.cornerRadius, 1 * scale, 1 * scale, w - 2 * scale, h - 2 * scale, colorHandle)
 end
 
 ---
@@ -977,14 +1009,16 @@ end
 -- @param number h
 -- @realm client
 function SKIN:PaintMenuLabelTTT2(panel, w, h)
-    drawSimpleText(
+    drawAdvancedText(
         TryT(panel:GetText()),
         panel:GetFont(),
         0,
         0.5 * h,
         colors.settingsText,
         TEXT_ALIGN_LEFT,
-        TEXT_ALIGN_CENTER
+        TEXT_ALIGN_CENTER,
+        false,
+        GetGlobalScale()
     )
 end
 
@@ -1004,24 +1038,28 @@ function SKIN:PaintHelpLabelTTT2(panel, w, h)
         colorText = ColorAlpha(colorText, 0.5 * alphaDisabled)
     end
 
+    local scale = GetGlobalScale()
     drawBox(0, 0, w, h, colorBox)
-    drawBox(0, 0, 4, h, colorBar)
+    drawBox(0, 0, 4 * scale, h, colorBar)
 
     local textTranslated = ParT(panel:GetText(), TryT(panel:GetTextParams()))
-    local textWrapped = drawGetWrappedText(textTranslated, w - 2 * panel.paddingX, panel:GetFont())
+    local font, fscale, fcmod = fonts.ScaledFont(panel:GetFont(), scale)
+    local textWrapped = drawGetWrappedText(textTranslated, (w - 2 * panel.paddingX) / fcmod, font)
 
-    local _, heightText = drawGetTextSize("", panel:GetFont())
+    local _, heightText = drawGetTextSize("", font, fscale)
     local posY = panel.paddingY
 
     for i = 1, #textWrapped do
-        drawSimpleText(
+        drawAdvancedText(
             textWrapped[i],
             panel:GetFont(),
             panel.paddingX,
             posY,
             colorText,
             TEXT_ALIGN_LEFT,
-            TEXT_ALIGN_TOP
+            TEXT_ALIGN_TOP,
+            false,
+            scale
         )
 
         posY = posY + heightText
@@ -1071,11 +1109,11 @@ function SKIN:PaintNumSliderTTT2(panel, w, h)
     end
 
     drawBox(0, 0, w, h, colorBox)
-    drawRoundedBox(sizes.cornerRadius, 1, 1, w - 2, h - 2, colorHandle)
+    drawRoundedBox(sizes.cornerRadius, 1 * GetGlobalScale(), 1 * GetGlobalScale(), w - 2 * GetGlobalScale(), h - 2 * GetGlobalScale(), colorHandle)
 
     -- draw selection line
-    drawBox(5, 0.5 * h - 1, w - 2 * pad, 2, colorLinePassive)
-    drawBox(5, 0.5 * h - 1, (w - pad) * panel:GetFraction() - pad, 2, colorLineActive)
+    drawBox(5 * GetGlobalScale(), 0.5 * h - 1 * GetGlobalScale(), w - 2 * pad, 2 * GetGlobalScale(), colorLinePassive)
+    drawBox(5 * GetGlobalScale(), 0.5 * h - 1 * GetGlobalScale(), (w - pad) * panel:GetFraction() - pad, 2 * GetGlobalScale(), colorLineActive)
 end
 
 ---
@@ -1152,16 +1190,19 @@ function SKIN:PaintComboBoxTTT2(panel, w, h)
         colorHandle = utilGetActiveColor(colors.handle)
     end
 
+    local scale = GetGlobalScale()
     drawBox(0, 0, w, h, colorBox)
-    drawRoundedBox(sizes.cornerRadius, 1, 1, w - 2, h - 2, colorHandle)
-    drawSimpleText(
+    drawRoundedBox(sizes.cornerRadius, 1 * scale, 1 * scale, w - 2 * scale, h - 2 * scale, colorHandle)
+    drawAdvancedText(
         TryT(panel:GetText()),
         panel:GetFont(),
-        10,
+        10 * scale,
         0.5 * h,
         colorText,
         TEXT_ALIGN_LEFT,
-        TEXT_ALIGN_CENTER
+        TEXT_ALIGN_CENTER,
+        false,
+        scale
     )
 end
 
@@ -1202,7 +1243,7 @@ function SKIN:PaintColoredTextBoxTTT2(panel, w, h)
         drawRoundedBox(sizes.cornerRadius, 0, 0, w, h, colorFlash)
     end
 
-    drawShadowedText(
+    drawAppearanceText(
         TryT(panel:GetTitle()),
         panel:GetTitleFont(),
         (align == TEXT_ALIGN_CENTER) and (0.5 * w)
@@ -1211,7 +1252,8 @@ function SKIN:PaintColoredTextBoxTTT2(panel, w, h)
         ColorAlpha(colorText, alpha),
         align,
         TEXT_ALIGN_CENTER,
-        1
+        true,
+        GetGlobalScale()
     )
 
     if hasIcon then
@@ -1242,7 +1284,7 @@ end
 -- @param number h
 -- @realm client
 function SKIN:PaintVerticalBorderedBoxTTT2(panel, w, h)
-    drawBox(w - 1, 0, 1, h, ColorAlpha(colors.default, 200))
+    drawBox(w - 1 * GetGlobalScale(), 0, 1 * GetGlobalScale(), h, ColorAlpha(colors.default, 200))
 end
 
 ---
@@ -1255,7 +1297,7 @@ function SKIN:PaintButtonRoundEndLeftTTT2(panel, w, h)
     local shift = 0
 
     if panel.Depressed or panel:IsSelected() or panel:GetToggle() then
-        shift = 1
+        shift = 1 * GetGlobalScale()
     elseif panel.Hovered then
         colorForeground = colors.accentHover
     elseif not panel.isActive then
@@ -1265,7 +1307,7 @@ function SKIN:PaintButtonRoundEndLeftTTT2(panel, w, h)
     local colorText = ColorAlpha(utilGetDefaultColor(colorForeground), 220)
 
     drawRoundedBoxEx(sizes.cornerRadius, 0, 0, w, h, colors.content, true, false, true, false)
-    drawRoundedBox(sizes.cornerRadius, 2, 2, w - 3, h - 4, colorForeground)
+    drawRoundedBox(sizes.cornerRadius, 2 * GetGlobalScale(), 2 * GetGlobalScale(), w - 3 * GetGlobalScale(), h - 4 * GetGlobalScale(), colorForeground)
 
     drawSimpleText(
         TryT(panel:GetText()),
@@ -1288,7 +1330,7 @@ function SKIN:PaintButtonRoundEndRightTTT2(panel, w, h)
     local shift = 0
 
     if panel.Depressed or panel:IsSelected() or panel:GetToggle() then
-        shift = 1
+        shift = 1 * GetGlobalScale()
     elseif panel.Hovered then
         colorForeground = colors.accentHover
     elseif not panel.isActive then
@@ -1298,7 +1340,7 @@ function SKIN:PaintButtonRoundEndRightTTT2(panel, w, h)
     local colorText = ColorAlpha(utilGetDefaultColor(colorForeground), 220)
 
     drawRoundedBoxEx(sizes.cornerRadius, 0, 0, w, h, colors.content, false, true, false, true)
-    drawRoundedBox(sizes.cornerRadius, 1, 2, w - 3, h - 4, colorForeground)
+    drawRoundedBox(sizes.cornerRadius, 1 * GetGlobalScale(), 2 * GetGlobalScale(), w - 3 * GetGlobalScale(), h - 4 * GetGlobalScale(), colorForeground)
 
     drawSimpleText(
         TryT(panel:GetText()),
@@ -1333,10 +1375,11 @@ function SKIN:PaintTooltipTTT2(panel, w, h)
         colorLine
     )
 
-    drawBox(1, sizeArrow + 1, w - 2, h - sizeArrow - 2, colors.background)
+    local scale = GetGlobalScale()
+    drawBox(1, sizeArrow + 1 * scale, w - 2 * scale, h - sizeArrow - 2 * scale, colors.background)
     drawFilteredTexture(
         sizeArrow,
-        1,
+        1 * scale,
         sizeRhombus,
         sizeRhombus,
         materialRhombus,
@@ -1352,7 +1395,9 @@ function SKIN:PaintTooltipTTT2(panel, w, h)
             0.5 * (h + sizeArrow),
             utilGetDefaultColor(colors.background),
             TEXT_ALIGN_CENTER,
-            TEXT_ALIGN_CENTER
+            TEXT_ALIGN_CENTER,
+            false, -- shadow
+            scale
         )
     end
 end
@@ -1363,17 +1408,18 @@ end
 -- @param number h
 -- @realm client
 function SKIN:PaintEventBoxTTT2(panel, w, h)
+    local scale = GetGlobalScale()
     local event = panel:GetEvent()
 
     local colorLine = ColorAlpha(colors.default, 25)
     local colorText = ColorAlpha(colors.default, 200)
 
-    local sizeIcon = 30
-    local padding = 8
-    local widthLine = 4
+    local sizeIcon = 30 * scale
+    local padding = 8 * scale
+    local widthLine = 4 * scale
     local offsetXLine = 0.5 * sizeIcon + padding
     local offsetXIcon = offsetXLine - 0.5 * (sizeIcon - widthLine)
-    local offsetYIcon = 20 + padding
+    local offsetYIcon = 20 * scale + padding
     local offsetYLine = offsetYIcon + padding + sizeIcon
     local offsetXText = offsetXIcon + sizeIcon + padding
     local offsetYTitle = offsetYIcon + 0.5 * sizeIcon
@@ -1392,7 +1438,7 @@ function SKIN:PaintEventBoxTTT2(panel, w, h)
         colorText
     )
 
-    drawShadowedText(
+    drawAdvancedText(
         TryT(panel:GetTitle()),
         panel:GetTitleFont(),
         offsetXText,
@@ -1400,26 +1446,30 @@ function SKIN:PaintEventBoxTTT2(panel, w, h)
         colorText,
         TEXT_ALIGN_LEFT,
         TEXT_ALIGN_CENTER,
-        1
+        true,
+        scale
     )
 
     local time = event:GetTime()
     local minutes = math.floor(time / 60)
     local seconds = math.floor(time % 60)
 
-    drawSimpleText(
+    drawAdvancedText(
         string.format("[%02d:%02d]", minutes, seconds),
         panel:GetFont(),
-        w - 20,
+        w - 20 * scale,
         offsetYTitle,
         colorLine,
         TEXT_ALIGN_RIGHT,
-        TEXT_ALIGN_CENTER
+        TEXT_ALIGN_CENTER,
+        false,
+        scale
     )
 
     local posY = offsetYIcon + sizeIcon + padding
     local textTable = panel:GetText()
-    local _, heightText = drawGetTextSize("", panel:GetFont())
+    local font, fscale, fcmod = fonts.ScaledFont(panel:GetFont(), scale)
+    local _, heightText = drawGetTextSize("", font, fscale)
 
     for i = 1, #textTable do
         local text = textTable[i]
@@ -1435,23 +1485,25 @@ function SKIN:PaintEventBoxTTT2(panel, w, h)
 
         local textTranslated = ParT(text.string, params or {})
 
-        local textWrapped = drawGetWrappedText(textTranslated, w - offsetXText, panel:GetFont())
+        local textWrapped = drawGetWrappedText(textTranslated, (w - offsetXText) / fcmod, font)
 
         for k = 1, #textWrapped do
-            drawSimpleText(
+            drawAdvancedText(
                 textWrapped[k],
                 panel:GetFont(),
                 offsetXText,
                 posY,
                 colorText,
                 TEXT_ALIGN_LEFT,
-                TEXT_ALIGN_TOP
+                TEXT_ALIGN_TOP,
+                false,
+                scale
             )
 
             posY = posY + heightText
         end
 
-        posY = posY + 15
+        posY = posY + 15 * scale
     end
 
     if not event:HasScore() then
@@ -1480,41 +1532,47 @@ function SKIN:PaintEventBoxTTT2(panel, w, h)
 
         drawRoundedBox(sizes.cornerRadius, offsetXText, posY, widthScoreBox, height, colorBox)
 
-        drawSimpleText(
+        drawAdvancedext(
             ParT("title_player_score", { player = event:GetNameFrom64(ply64) }),
             panel:GetFont(),
             offsetXText + padding,
             posY + padding,
             colorText,
             TEXT_ALIGN_LEFT,
-            TEXT_ALIGN_TOP
+            TEXT_ALIGN_TOP,
+            false,
+            scale
         )
 
         for k = 1, scoreRows do
             local rawScoreText = rawScoreTexts[k]
 
-            drawSimpleText(
+            drawAdvancedText(
                 TryT(rawScoreText.name),
                 panel:GetFont(),
                 offsetXText + 2 * padding,
                 posY + padding + k * heightText,
                 colorText,
                 TEXT_ALIGN_LEFT,
-                TEXT_ALIGN_TOP
+                TEXT_ALIGN_TOP,
+                false,
+                scale
             )
 
-            drawSimpleText(
+            drawAdvancedText(
                 rawScoreText.score,
                 panel:GetFont(),
-                offsetXText + 2 * padding + 175,
+                offsetXText + 2 * padding + 175 * scale,
                 posY + padding + k * heightText,
                 colorText,
                 TEXT_ALIGN_LEFT,
-                TEXT_ALIGN_TOP
+                TEXT_ALIGN_TOP,
+                false,
+                scale
             )
         end
 
-        posY = posY + height + 15
+        posY = posY + height + 15 * scale
     end
 end
 
@@ -1528,13 +1586,14 @@ local MODE_INHERIT_REMOVED = ShopEditor.MODE_INHERIT_REMOVED
 -- @param number h
 -- @realm client
 function SKIN:PaintShopCardTTT2(panel, w, h)
-    local widthBorder = 2
+    local scale = GetGlobalScale()
+    local widthBorder = 2 * scale
     local widthBorder2 = widthBorder * 2
-    local sizeIcon = 64
-    local padding = 5
+    local sizeIcon = 64 * scale
+    local padding = 5 * scale
     local posIcon = widthBorder + padding
     local posText = posIcon + sizeIcon + 2 * padding
-    local heightMode = 35
+    local heightMode = 35 * scale
     local widthMode = w - sizeIcon - 3 * padding
     local posIconModeX = w - widthMode + 2 * padding
     local posIconModeY = h - heightMode + 2 * padding
@@ -1580,14 +1639,16 @@ function SKIN:PaintShopCardTTT2(panel, w, h)
 
     drawFilteredTexture(posIcon, posIcon, sizeIcon, sizeIcon, panel:GetIcon())
 
-    drawSimpleText(
+    drawAdvancedText(
         TryT(panel:GetText()),
         panel:GetFont(),
         posText,
         posIcon + padding,
         colorText,
         TEXT_ALIGN_LEFT,
-        TEXT_ALIGN_TOP
+        TEXT_ALIGN_TOP,
+        false,
+        scale
     )
 
     drawRoundedBoxEx(
@@ -1620,7 +1681,9 @@ function SKIN:PaintShopCardTTT2(panel, w, h)
         posTextModeY,
         colorTextMode,
         TEXT_ALIGN_LEFT,
-        TEXT_ALIGN_CENTER
+        TEXT_ALIGN_CENTER,
+        false,
+        scale
     )
 end
 
@@ -1630,7 +1693,7 @@ end
 -- @param number h
 -- @realm client
 function SKIN:PaintComboCardTTT2(panel, w, h)
-    local widthBorder = 2
+    local widthBorder = 2 * GetGlobalScale()
     local widthBorder2 = widthBorder * 2
     local widthBorder4 = widthBorder2 * 2
     local shift = 0
@@ -1650,7 +1713,7 @@ function SKIN:PaintComboCardTTT2(panel, w, h)
 
     if panel.Depressed then
         opacity = 240
-        shift = 1
+        shift = 1 * GetGlobalScale()
     end
 
     local colorText = utilGetDefaultColor(colorBox)
@@ -1684,15 +1747,15 @@ function SKIN:PaintComboCardTTT2(panel, w, h)
         local width = drawGetTextSize(tagText, panel:GetFont())
         local colorTag = panel:GetTagColor() or COLOR_WARMGRAY
 
-        width = width + 20
+        width = width + 20 * GetGlobalScale()
 
-        drawRoundedBox(sizes.cornerRadius, widthBorder4, widthBorder4, width, 20, colorTag)
+        drawRoundedBox(sizes.cornerRadius, widthBorder4, widthBorder4, width, 20 * GetGlobalScale(), colorTag)
 
         drawSimpleText(
             TryT(tagText),
             panel:GetFont(),
             widthBorder4 + 0.5 * width,
-            widthBorder4 + 10,
+            widthBorder4 + 10 * GetGlobalScale(),
             utilGetDefaultColor(colorTag),
             TEXT_ALIGN_CENTER,
             TEXT_ALIGN_CENTER
@@ -1739,14 +1802,17 @@ function SKIN:PaintRoleLayeringSenderTTT2(panel, w, h)
 
     drawRoundedBox(sizes.cornerRadius, 0, 0, w, h, colorBox)
 
-    drawSimpleText(
+    local scale = GetGlobalScale()
+    drawAdvancedText(
         TryT("layering_not_layered"),
         "DermaTTT2Text",
-        10,
+        10 * scale,
         0.5 * h,
         colorText,
         TEXT_ALIGN_LEFT,
-        TEXT_ALIGN_CENTER
+        TEXT_ALIGN_CENTER,
+        false,
+        scale
     )
 end
 
@@ -1759,19 +1825,23 @@ function SKIN:PaintRoleLayeringReceiverTTT2(panel, w, h)
     local colorBox = utilGetChangedColor(colors.background, 20)
     local colorText = utilGetDefaultColor(colorBox)
 
+    local scale = GetGlobalScale()
+
     for i = 1, #panel.layerBoxes do
         local layerBox = panel.layerBoxes[i]
 
         drawRoundedBox(sizes.cornerRadius, 0, layerBox.y, w, layerBox.h, colorBox)
 
-        drawSimpleText(
+        drawAdvancedText(
             ParT("layering_layer", { layer = i }),
             "DermaTTT2Text",
-            10,
+            10 * scale,
             layerBox.label,
             colorText,
             TEXT_ALIGN_LEFT,
-            TEXT_ALIGN_CENTER
+            TEXT_ALIGN_CENTER,
+            false,
+            scale
         )
     end
 end
@@ -1814,14 +1884,16 @@ function SKIN:PaintSearchbar(panel, w, h)
         return
     end
 
-    drawSimpleText(
+    drawAdvancedText(
         TryT(panel:GetCurrentPlaceholderText()),
         panel:GetFont(),
         leftPad + w * 0.02,
         0.5 * h,
         colorText,
         TEXT_ALIGN_LEFT,
-        TEXT_ALIGN_CENTER
+        TEXT_ALIGN_CENTER,
+        false,
+        GetGlobalScale()
     )
 end
 
@@ -1840,7 +1912,7 @@ function SKIN:PaintTextEntryTTT2(panel, w, h)
     end
 
     drawBox(0, 0, w, h, colorBox)
-    drawRoundedBox(sizes.cornerRadius, 1, 1, w - 2, h - 2, colorHandle)
+    drawRoundedBox(sizes.cornerRadius, 1 * GetGlobalScale(), 1 * GetGlobalScale(), w - 2 * GetGlobalScale(), h - 2 * GetGlobalScale(), colorHandle)
 end
 
 ---
@@ -1849,22 +1921,23 @@ end
 -- @param number h
 -- @realm client
 function SKIN:PaintImageCheckBoxTTT2(panel, w, h)
-    local widthBorder = 2
+    local scale = GetGlobalScale()
+    local widthBorder = 2 * scale
     local widthBorder2 = widthBorder * 2
-    local padding = 5
-    local heightMode = 35
-    local widthMode = 175
+    local padding = 5 * scale
+    local heightMode = 35 * scale
+    local widthMode = 175 * scale
     local posIconModeX = w - widthMode + 2 * padding
     local posIconModeY = h - heightMode + 2 * padding
     local sizeIconMode = heightMode - 4 * padding
     local posTextModeX = posIconModeX + sizeIconMode + 2 * padding
     local posTextModeY = posIconModeY + 0.5 * sizeIconMode - 1
-    local posStatusIconBoxX = 8
-    local sizeStatusIconBox = 32
+    local posStatusIconBoxX = 8 * scale
+    local sizeStatusIconBox = 32 * scale
     local sizeStatusIcon = sizeStatusIconBox - 2 * padding
     local posStatusIconX = posStatusIconBoxX + padding
 
-    local posHeadIconBoxY = 8
+    local posHeadIconBoxY = 8 * scale
     local posHeadIconY = posHeadIconBoxY + padding
     local posHattableIconBoxY = posHeadIconBoxY + sizeStatusIconBox + padding
     local posHattableIconY = posHattableIconBoxY + padding
@@ -1934,14 +2007,16 @@ function SKIN:PaintImageCheckBoxTTT2(panel, w, h)
         colorTextMode
     )
 
-    drawSimpleText(
+    drawAdvancedText(
         TryT(panel:GetText()),
         "DermaTTT2Text",
         posTextModeX,
         posTextModeY,
         colorTextMode,
         TEXT_ALIGN_LEFT,
-        TEXT_ALIGN_CENTER
+        TEXT_ALIGN_CENTER,
+        false,
+        scale
     )
 
     drawRoundedBox(
@@ -1987,14 +2062,15 @@ end
 -- @param number h
 -- @realm client
 function SKIN:PaintProfilePanelTTT2(panel, w, h)
-    local padding = 5
+    local scale = GetGlobalScale()
+    local padding = 5 * scale
 
-    local heightBottom = 100
+    local heightBottom = 100 * scale
 
     local widthRender = w - 2 * padding
     local heightRender = h - padding - heightBottom
 
-    local sizePlayerIcon = 64
+    local sizePlayerIcon = 64 * scale
     local xRoleIcon = 0.5 * (widthRender - sizePlayerIcon) + padding
     local yRoleIcon = heightRender + padding - 0.5 * sizePlayerIcon
 
@@ -2002,11 +2078,11 @@ function SKIN:PaintProfilePanelTTT2(panel, w, h)
     local xPlayerIconBox = xRoleIcon - padding
     local yPlayerIconBox = yRoleIcon - padding
 
-    local sizeRoleIcon = 32
+    local sizeRoleIcon = 32 * scale
     local posRoleIcon = 2 * padding
 
-    local yTextTeam = h - 26
-    local yTextRole = yTextTeam - 22
+    local yTextTeam = h - 26 * scale
+    local yTextRole = yTextTeam - 22 * scale
     local xText = 0.5 * w
 
     -- cache colors
@@ -2047,24 +2123,28 @@ function SKIN:PaintProfilePanelTTT2(panel, w, h)
         colorRoleIcon
     )
 
-    drawShadowedText(
+    drawAdvancedText(
         TryT(panel:GetPlayerRoleString()),
         "DermaTTT2TextLargest",
         xText,
         yTextRole,
         colorRoleText,
         TEXT_ALIGN_CENTER,
-        TEXT_ALIGN_CENTER
+        TEXT_ALIGN_CENTER,
+        true,
+        scale
     )
 
-    drawShadowedText(
+    drawAdvancedText(
         TryT(panel:GetPlayerTeamString()),
         "DermaTTT2TextLarger",
         xText,
         yTextTeam,
         colorRoleText,
         TEXT_ALIGN_CENTER,
-        TEXT_ALIGN_CENTER
+        TEXT_ALIGN_CENTER,
+        true,
+        scale
     )
 end
 
@@ -2076,16 +2156,16 @@ end
 function SKIN:PaintInfoItemTTT2(panel, w, h)
     local hasIcon = panel:HasIcon()
 
-    local padding = 5
+    local scale = GetGlobalScale()
+    local padding = 5 * scale
 
-    local widthBorder = 2
+    local widthBorder = 2 * scale
     local widthBorder2 = 2 * widthBorder
 
-    local sizeIcon = 64
+    local sizeIcon = 64 * scale
     local posIcon = widthBorder + padding
 
     local posText = hasIcon and (posIcon + sizeIcon + 2 * padding) or (posIcon + padding)
-    local heightText = 15
 
     local colorBackground = panel:GetColor() or colors.settingsBox
     local colorBorderDefault = utilGetChangedColor(colors.background, 75)
@@ -2111,28 +2191,30 @@ function SKIN:PaintInfoItemTTT2(panel, w, h)
         local widthIconText = drawGetTextSize(textString, "DermaTTT2SmallBold")
         local xIconText = posIcon + 0.5 * sizeIcon
         local yIconText = posIcon + 0.75 * sizeIcon
-        local widthIconTextBox = widthIconText + 8
-        local heightIconTextBox = 16
+        local widthIconTextBox = widthIconText + 8 * scale
+        local heightIconTextBox = 16 * scale
 
         local colorLiveTimeBackground = colors.settingsBox
 
         drawRoundedBox(
             sizes.cornerRadius,
             xIconText - 0.5 * widthIconTextBox,
-            yIconText - 7,
+            yIconText - 7 * scale,
             widthIconTextBox,
             heightIconTextBox,
             colorLiveTimeBackground
         )
 
-        drawShadowedText(
+        drawAdvancedText(
             textString,
             "DermaTTT2SmallBold",
             xIconText,
             yIconText,
             COLOR_ORANGE,
             TEXT_ALIGN_CENTER,
-            TEXT_ALIGN_CENTER
+            TEXT_ALIGN_CENTER,
+            true,
+            scale
         )
     end
 
@@ -2147,14 +2229,16 @@ function SKIN:PaintInfoItemTTT2(panel, w, h)
         end
     end
 
-    drawSimpleText(
+    drawAdvancedText(
         text_title,
         "DermaTTT2TitleSmall",
         posText,
         posIcon,
         colorText,
         TEXT_ALIGN_LEFT,
-        TEXT_ALIGN_TOP
+        TEXT_ALIGN_TOP,
+        false,
+        scale
     )
 
     local text = panel:GetText()
@@ -2177,19 +2261,23 @@ function SKIN:PaintInfoItemTTT2(panel, w, h)
         end
     end
 
-    local text_wrapped = drawGetWrappedText(text_translated, w - posText - padding, "DermaDefault")
+    local font, fscale, fcmod = fonts.ScaledFont("DermaDefault", scale)
+    local text_wrapped = drawGetWrappedText(text_translated, (w - posText - padding) / fcmod, font)
+    local _, heightText = drawGetTextSize("", font, fscale)
 
-    local posY = posIcon + heightText + 4
+    local posY = posIcon + heightText + 4 * scale
 
     for k = 1, #text_wrapped do
-        drawSimpleText(
+        drawAdvancedText(
             text_wrapped[k],
             "DermaDefault",
             posText,
             posY,
             colorText,
             TEXT_ALIGN_LEFT,
-            TEXT_ALIGN_TOP
+            TEXT_ALIGN_TOP,
+            false,
+            scale
         )
 
         posY = posY + heightText

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/default_skin.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/default_skin.lua
@@ -833,14 +833,7 @@ function SKIN:PaintFormButtonTTT2(panel, w, h)
     end
 
     drawRoundedBoxEx(sizes.cornerRadius, 0, 0, w, h, colorBoxBack, false, true, false, true)
-    drawRoundedBox(
-        sizes.cornerRadius,
-        1 * scale,
-        1 * scale,
-        w - 2 * scale,
-        h - 2 * scale,
-        colorBox
-    )
+    drawRoundedBox(sizes.cornerRadius, 1 * scale, 1 * scale, w - 2 * scale, h - 2 * scale, colorBox)
 
     drawAdvancedText(
         TryT(panel:GetText()),
@@ -1150,13 +1143,7 @@ function SKIN:PaintNumSliderTTT2(panel, w, h)
     )
 
     -- draw selection line
-    drawBox(
-        5 * scale,
-        0.5 * h - 1 * scale,
-        w - 2 * pad,
-        2 * scale,
-        colorLinePassive
-    )
+    drawBox(5 * scale, 0.5 * h - 1 * scale, w - 2 * pad, 2 * scale, colorLinePassive)
     drawBox(
         5 * scale,
         0.5 * h - 1 * scale,
@@ -1859,14 +1846,7 @@ function SKIN:PaintComboCardTTT2(panel, w, h)
 
         width = width + 20 * scale
 
-        drawRoundedBox(
-            sizes.cornerRadius,
-            widthBorder4,
-            widthBorder4,
-            width,
-            20 * scale,
-            colorTag
-        )
+        drawRoundedBox(sizes.cornerRadius, widthBorder4, widthBorder4, width, 20 * scale, colorTag)
 
         drawAdvancedText(
             TryT(tagText),
@@ -1883,12 +1863,7 @@ function SKIN:PaintComboCardTTT2(panel, w, h)
 
     local fnt, fscale = fonts.ScaledFont(panel:GetFont(), scale)
     drawAdvancedText(
-        drawGetLimitedLengthText(
-            TryT(panel:GetText()),
-            (w - 2 * widthBorder4) / fscale,
-            fnt,
-            "..."
-        ),
+        drawGetLimitedLengthText(TryT(panel:GetText()), (w - 2 * widthBorder4) / fscale, fnt, "..."),
         panel:GetFont(),
         widthBorder4,
         w + shift,
@@ -2391,7 +2366,8 @@ function SKIN:PaintInfoItemTTT2(panel, w, h)
         end
     end
 
-    local sfnt = "DermaTTT2Text"
+    --local sfnt = "DermaTTT2Text"
+    local sfnt = "DermaDefault"
     local font, fscale = fonts.ScaledFont(sfnt, scale)
     local text_wrapped = drawGetWrappedText(text_translated, (w - posText - padding) / fscale, font)
     local _, heightText = drawGetTextSize("", font, fscale)

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/default_skin.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/default_skin.lua
@@ -2391,7 +2391,8 @@ function SKIN:PaintInfoItemTTT2(panel, w, h)
         end
     end
 
-    local font, fscale = fonts.ScaledFont("DermaDefault", scale)
+    local sfnt = "DermaTTT2Text"
+    local font, fscale = fonts.ScaledFont(sfnt, scale)
     local text_wrapped = drawGetWrappedText(text_translated, (w - posText - padding) / fscale, font)
     local _, heightText = drawGetTextSize("", font, fscale)
 
@@ -2402,7 +2403,7 @@ function SKIN:PaintInfoItemTTT2(panel, w, h)
     for k = 1, #text_wrapped do
         drawAdvancedText(
             text_wrapped[k],
-            "DermaDefault",
+            sfnt,
             posText,
             posY,
             colorText,

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/default_skin.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/default_skin.lua
@@ -295,18 +295,19 @@ end
 -- @param number h
 -- @realm client
 function SKIN:PaintWindowBackButton(panel, w, h)
+    local scale = GetGlobalScale()
     local colorBackground = colors.accent
     local colorText = ColorAlpha(colors.accentText, 150)
     local shift = 0
-    local padding_w = 10 * GetGlobalScale()
-    local padding_h = 15 * GetGlobalScale()
+    local padding_w = 10 * scale
+    local padding_h = 15 * scale
 
     if not panel:IsEnabled() then
         colorText = ColorAlpha(colors.accentText, 70)
     elseif panel.Depressed or panel:IsSelected() then
         colorBackground = colors.accentActive
         colorText = ColorAlpha(colors.accentText, 200)
-        shift = 1 * GetGlobalScale()
+        shift = 1 * scale
     elseif panel.Hovered then
         colorBackground = colors.accentHover
         colorText = colors.accentText
@@ -322,7 +323,7 @@ function SKIN:PaintWindowBackButton(panel, w, h)
         colorText.a,
         colorText
     )
-    drawShadowedText(
+    drawAdvancedText(
         TryT("button_menu_back"),
         "DermaTTT2TitleSmall",
         h - padding_w,
@@ -330,7 +331,8 @@ function SKIN:PaintWindowBackButton(panel, w, h)
         colorText,
         TEXT_ALIGN_LEFT,
         TEXT_ALIGN_CENTER,
-        1
+        true,
+        scale
     )
 end
 
@@ -411,12 +413,9 @@ function SKIN:PaintMenuButtonTTT2(panel, w, h)
         scale
     )
 
-    local font, fscale, fcmod = fonts.ScaledFont(panel:GetDescriptionFont(), scale)
-    local desc_wrapped = drawGetWrappedText(
-        TryT(panel:GetDescription()),
-        (w - h - 2 * paddingText) / fcmod,
-        font
-    )
+    local font, fscale = fonts.ScaledFont(panel:GetDescriptionFont(), scale)
+    local desc_wrapped =
+        drawGetWrappedText(TryT(panel:GetDescription()), (w - h - 2 * paddingText) / fscale, font)
     local _, lineHeight = draw.GetTextSize("", font, fscale)
     local line_pos = 35 * scale
 
@@ -557,7 +556,14 @@ function SKIN:PaintCheckBox(panel, w, h)
     end
 
     drawRoundedBox(4 * GetGlobalScale(), 0, 0, w, h, colorBox)
-    drawRoundedBox(4 * GetGlobalScale(), offset + 3 * GetGlobalScale(), 3 * GetGlobalScale(), h - 6 * GetGlobalScale(), h - 6 * GetGlobalScale(), colorCenter)
+    drawRoundedBox(
+        4 * GetGlobalScale(),
+        offset + 3 * GetGlobalScale(),
+        3 * GetGlobalScale(),
+        h - 6 * GetGlobalScale(),
+        h - 6 * GetGlobalScale(),
+        colorCenter
+    )
 end
 
 ---
@@ -824,7 +830,14 @@ function SKIN:PaintFormButtonTTT2(panel, w, h)
     end
 
     drawRoundedBoxEx(sizes.cornerRadius, 0, 0, w, h, colorBoxBack, false, true, false, true)
-    drawRoundedBox(sizes.cornerRadius, 1 * GetGlobalScale(), 1 * GetGlobalScale(), w - 2 * GetGlobalScale(), h - 2 * GetGlobalScale(), colorBox)
+    drawRoundedBox(
+        sizes.cornerRadius,
+        1 * GetGlobalScale(),
+        1 * GetGlobalScale(),
+        w - 2 * GetGlobalScale(),
+        h - 2 * GetGlobalScale(),
+        colorBox
+    )
 
     drawShadowedText(
         TryT(panel:GetText()),
@@ -1000,7 +1013,14 @@ function SKIN:PaintFormBoxTTT2(panel, w, h)
 
     local scale = GetGlobalScale()
     drawRoundedBoxEx(sizes.cornerRadius, 0, 0, w, h, colorBox, false, true, false, true)
-    drawRoundedBox(sizes.cornerRadius, 1 * scale, 1 * scale, w - 2 * scale, h - 2 * scale, colorHandle)
+    drawRoundedBox(
+        sizes.cornerRadius,
+        1 * scale,
+        1 * scale,
+        w - 2 * scale,
+        h - 2 * scale,
+        colorHandle
+    )
 end
 
 ---
@@ -1043,8 +1063,8 @@ function SKIN:PaintHelpLabelTTT2(panel, w, h)
     drawBox(0, 0, 4 * scale, h, colorBar)
 
     local textTranslated = ParT(panel:GetText(), TryT(panel:GetTextParams()))
-    local font, fscale, fcmod = fonts.ScaledFont(panel:GetFont(), scale)
-    local textWrapped = drawGetWrappedText(textTranslated, (w - 2 * panel.paddingX) / fcmod, font)
+    local font, fscale = fonts.ScaledFont(panel:GetFont(), scale)
+    local textWrapped = drawGetWrappedText(textTranslated, (w - 2 * panel.paddingX) / fscale, font)
 
     local _, heightText = drawGetTextSize("", font, fscale)
     local posY = panel.paddingY
@@ -1109,11 +1129,30 @@ function SKIN:PaintNumSliderTTT2(panel, w, h)
     end
 
     drawBox(0, 0, w, h, colorBox)
-    drawRoundedBox(sizes.cornerRadius, 1 * GetGlobalScale(), 1 * GetGlobalScale(), w - 2 * GetGlobalScale(), h - 2 * GetGlobalScale(), colorHandle)
+    drawRoundedBox(
+        sizes.cornerRadius,
+        1 * GetGlobalScale(),
+        1 * GetGlobalScale(),
+        w - 2 * GetGlobalScale(),
+        h - 2 * GetGlobalScale(),
+        colorHandle
+    )
 
     -- draw selection line
-    drawBox(5 * GetGlobalScale(), 0.5 * h - 1 * GetGlobalScale(), w - 2 * pad, 2 * GetGlobalScale(), colorLinePassive)
-    drawBox(5 * GetGlobalScale(), 0.5 * h - 1 * GetGlobalScale(), (w - pad) * panel:GetFraction() - pad, 2 * GetGlobalScale(), colorLineActive)
+    drawBox(
+        5 * GetGlobalScale(),
+        0.5 * h - 1 * GetGlobalScale(),
+        w - 2 * pad,
+        2 * GetGlobalScale(),
+        colorLinePassive
+    )
+    drawBox(
+        5 * GetGlobalScale(),
+        0.5 * h - 1 * GetGlobalScale(),
+        (w - pad) * panel:GetFraction() - pad,
+        2 * GetGlobalScale(),
+        colorLineActive
+    )
 end
 
 ---
@@ -1130,24 +1169,53 @@ function SKIN:PaintSliderTextAreaTTT2(panel, w, h)
         colorText = ColorAlpha(colors.settingsText, alphaDisabled)
     end
 
+    local scale = GetGlobalScale()
+
     -- Draw normal text if currently not in input mode, otherwise draw the TTT2 Text Entry
     if not panel:GetParent():GetTextBoxEnabled() then
         drawBox(0, 0, w, h, colorBox)
-        drawSimpleText(
+        drawAdvancedText(
             panel:GetText(),
             panel:GetFont(),
             0.5 * w,
             0.5 * h,
             colorText,
             TEXT_ALIGN_CENTER,
-            TEXT_ALIGN_CENTER
+            TEXT_ALIGN_CENTER,
+            false,
+            scale
         )
     else
         self:PaintTextEntryTTT2(panel, w, h)
         local vguiColor = utilGetActiveColor(
             utilGetChangedColor(utilGetDefaultColor(vskinGetBackgroundColor()), 25)
         )
+        -- panel:DrawTextEntryText isn't well-behaved wrt scaling, do some hacks to make it work
+
+        local origFont = panel:GetFont()
+        local font, fscale = fonts.ScaledFont(origFont, scale)
+        if fscale ~= 1.0 then
+            mat = Matrix()
+            mat:Translate(Vector(0, 0))
+            mat:Scale(isvector(fscale) and fscale or Vector(fscale, fscale, fscale))
+            mat:Translate(-Vector(ScrW() * 0.5, ScrH() * 0.5))
+
+            render.PushFilterMag(TEXFILTER.LINEAR)
+            render.PushFilterMin(TEXFILTER.LINEAR)
+
+            cam.PushModelMatrix(mat)
+        end
+
+        panel:SetFont(font)
         panel:DrawTextEntryText(vguiColor, vguiColor, vguiColor)
+        panel:SetFont(origFont)
+
+        if fscale ~= 1.0 then
+            cam.PopModelMatrix()
+
+            render.PopFilterMag()
+            render.PopFilterMin()
+        end
     end
 end
 
@@ -1192,7 +1260,14 @@ function SKIN:PaintComboBoxTTT2(panel, w, h)
 
     local scale = GetGlobalScale()
     drawBox(0, 0, w, h, colorBox)
-    drawRoundedBox(sizes.cornerRadius, 1 * scale, 1 * scale, w - 2 * scale, h - 2 * scale, colorHandle)
+    drawRoundedBox(
+        sizes.cornerRadius,
+        1 * scale,
+        1 * scale,
+        w - 2 * scale,
+        h - 2 * scale,
+        colorHandle
+    )
     drawAdvancedText(
         TryT(panel:GetText()),
         panel:GetFont(),
@@ -1307,7 +1382,14 @@ function SKIN:PaintButtonRoundEndLeftTTT2(panel, w, h)
     local colorText = ColorAlpha(utilGetDefaultColor(colorForeground), 220)
 
     drawRoundedBoxEx(sizes.cornerRadius, 0, 0, w, h, colors.content, true, false, true, false)
-    drawRoundedBox(sizes.cornerRadius, 2 * GetGlobalScale(), 2 * GetGlobalScale(), w - 3 * GetGlobalScale(), h - 4 * GetGlobalScale(), colorForeground)
+    drawRoundedBox(
+        sizes.cornerRadius,
+        2 * GetGlobalScale(),
+        2 * GetGlobalScale(),
+        w - 3 * GetGlobalScale(),
+        h - 4 * GetGlobalScale(),
+        colorForeground
+    )
 
     drawSimpleText(
         TryT(panel:GetText()),
@@ -1340,7 +1422,14 @@ function SKIN:PaintButtonRoundEndRightTTT2(panel, w, h)
     local colorText = ColorAlpha(utilGetDefaultColor(colorForeground), 220)
 
     drawRoundedBoxEx(sizes.cornerRadius, 0, 0, w, h, colors.content, false, true, false, true)
-    drawRoundedBox(sizes.cornerRadius, 1 * GetGlobalScale(), 2 * GetGlobalScale(), w - 3 * GetGlobalScale(), h - 4 * GetGlobalScale(), colorForeground)
+    drawRoundedBox(
+        sizes.cornerRadius,
+        1 * GetGlobalScale(),
+        2 * GetGlobalScale(),
+        w - 3 * GetGlobalScale(),
+        h - 4 * GetGlobalScale(),
+        colorForeground
+    )
 
     drawSimpleText(
         TryT(panel:GetText()),
@@ -1468,7 +1557,7 @@ function SKIN:PaintEventBoxTTT2(panel, w, h)
 
     local posY = offsetYIcon + sizeIcon + padding
     local textTable = panel:GetText()
-    local font, fscale, fcmod = fonts.ScaledFont(panel:GetFont(), scale)
+    local font, fscale = fonts.ScaledFont(panel:GetFont(), scale)
     local _, heightText = drawGetTextSize("", font, fscale)
 
     for i = 1, #textTable do
@@ -1485,7 +1574,7 @@ function SKIN:PaintEventBoxTTT2(panel, w, h)
 
         local textTranslated = ParT(text.string, params or {})
 
-        local textWrapped = drawGetWrappedText(textTranslated, (w - offsetXText) / fcmod, font)
+        local textWrapped = drawGetWrappedText(textTranslated, (w - offsetXText) / fscale, font)
 
         for k = 1, #textWrapped do
             drawAdvancedText(
@@ -1749,7 +1838,14 @@ function SKIN:PaintComboCardTTT2(panel, w, h)
 
         width = width + 20 * GetGlobalScale()
 
-        drawRoundedBox(sizes.cornerRadius, widthBorder4, widthBorder4, width, 20 * GetGlobalScale(), colorTag)
+        drawRoundedBox(
+            sizes.cornerRadius,
+            widthBorder4,
+            widthBorder4,
+            width,
+            20 * GetGlobalScale(),
+            colorTag
+        )
 
         drawSimpleText(
             TryT(tagText),
@@ -1912,7 +2008,14 @@ function SKIN:PaintTextEntryTTT2(panel, w, h)
     end
 
     drawBox(0, 0, w, h, colorBox)
-    drawRoundedBox(sizes.cornerRadius, 1 * GetGlobalScale(), 1 * GetGlobalScale(), w - 2 * GetGlobalScale(), h - 2 * GetGlobalScale(), colorHandle)
+    drawRoundedBox(
+        sizes.cornerRadius,
+        1 * GetGlobalScale(),
+        1 * GetGlobalScale(),
+        w - 2 * GetGlobalScale(),
+        h - 2 * GetGlobalScale(),
+        colorHandle
+    )
 end
 
 ---
@@ -2261,8 +2364,8 @@ function SKIN:PaintInfoItemTTT2(panel, w, h)
         end
     end
 
-    local font, fscale, fcmod = fonts.ScaledFont("DermaDefault", scale)
-    local text_wrapped = drawGetWrappedText(text_translated, (w - posText - padding) / fcmod, font)
+    local font, fscale = fonts.ScaledFont("DermaDefault", scale)
+    local text_wrapped = drawGetWrappedText(text_translated, (w - posText - padding) / fscale, font)
     local _, heightText = drawGetTextSize("", font, fscale)
 
     local posY = posIcon + heightText + 4 * scale

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/default_skin.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/default_skin.lua
@@ -1641,7 +1641,7 @@ function SKIN:PaintEventBoxTTT2(panel, w, h)
 
         drawRoundedBox(sizes.cornerRadius, offsetXText, posY, widthScoreBox, height, colorBox)
 
-        drawAdvancedext(
+        drawAdvancedText(
             ParT("title_player_score", { player = event:GetNameFrom64(ply64) }),
             panel:GetFont(),
             offsetXText + padding,
@@ -2397,6 +2397,8 @@ function SKIN:PaintInfoItemTTT2(panel, w, h)
 
     local posY = posIcon + heightText + 4 * scale
 
+    print(font, fscale, heightText, posIcon, posY)
+    PrintTable(text_wrapped)
     for k = 1, #text_wrapped do
         drawAdvancedText(
             text_wrapped[k],

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/default_skin.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/default_skin.lua
@@ -47,11 +47,9 @@ local vskinGetCornerRadius = vskin.GetCornerRadius
 local drawRoundedBox = draw.RoundedBox
 local drawRoundedBoxEx = draw.RoundedBoxEx
 local drawBox = draw.Box
-local drawShadowedText = draw.ShadowedText
 local drawFilteredShadowedTexture = draw.FilteredShadowedTexture
 local drawOutlinedBox = draw.OutlinedBox
 local drawFilteredTexture = draw.FilteredTexture
-local drawSimpleText = draw.SimpleText
 local drawAdvancedText = draw.AdvancedText
 local drawLine = draw.Line
 local drawGetWrappedText = draw.GetWrappedText
@@ -264,14 +262,15 @@ function SKIN:PaintWindowCloseButton(panel, w, h)
     local colorBackground = colors.accent
     local colorText = ColorAlpha(colors.accentText, 150)
     local shift = 0
-    local padding = 15 * GetGlobalScale()
+    local scale = GetGlobalScale()
+    local padding = 15 * scale
 
     if not panel:IsEnabled() then
         colorText = ColorAlpha(colors.accentText, 70)
     elseif panel.Depressed or panel:IsSelected() then
         colorBackground = colors.accentActive
         colorText = ColorAlpha(colors.accentText, 200)
-        shift = 1 * GetGlobalScale()
+        shift = 1 * scale
     elseif panel.Hovered then
         colorBackground = colors.accentHover
         colorText = colors.accentText
@@ -343,8 +342,9 @@ end
 -- @realm client
 function SKIN:PaintScrollBarGrip(panel, w, h)
     local colorScrollbar = colors.scrollBar
-    local posX = 4 * GetGlobalScale()
-    local sizeX = w - 8 * GetGlobalScale()
+    local scale = GetGlobalScale()
+    local posX = 4 * scale
+    local sizeX = w - 8 * scale
 
     if panel.Depressed then
         colorScrollbar = colors.scrollBarActive
@@ -459,13 +459,14 @@ function SKIN:PaintSubMenuButtonTTT2(panel, w, h)
     local iconBadgeSize = panel:GetIconBadgeSize()
     local iconAlpha = isIconFullSize and 255 or colorText.a
     local sizeIcon = h - 2 * padIcon
+    local scale = GetGlobalScale()
 
     if panel.Depressed or panel:IsSelected() or panel:GetToggle() then
         colorBackground = utilGetActiveColor(ColorAlpha(colors.accent, 50))
         colorBar = colors.accentActive
         colorText = utilGetActiveColor(utilGetChangedColor(colors.default, 25))
         colorIcon = utilGetActiveColor(utilGetChangedColor(COLOR_WHITE, 32))
-        shift = 1 * GetGlobalScale()
+        shift = 1 * scale
     elseif panel.Hovered then
         colorBackground = utilGetHoverColor(ColorAlpha(colors.accent, 50))
         colorBar = colors.accentHover
@@ -513,7 +514,7 @@ function SKIN:PaintSubMenuButtonTTT2(panel, w, h)
         TEXT_ALIGN_LEFT,
         TEXT_ALIGN_CENTER,
         false,
-        GetGlobalScale()
+        scale
     )
 end
 
@@ -555,13 +556,14 @@ function SKIN:PaintCheckBox(panel, w, h)
         end
     end
 
-    drawRoundedBox(4 * GetGlobalScale(), 0, 0, w, h, colorBox)
+    local scale = GetGlobalScale()
+    drawRoundedBox(4 * scale, 0, 0, w, h, colorBox)
     drawRoundedBox(
-        4 * GetGlobalScale(),
-        offset + 3 * GetGlobalScale(),
-        3 * GetGlobalScale(),
-        h - 6 * GetGlobalScale(),
-        h - 6 * GetGlobalScale(),
+        4 * scale,
+        offset + 3 * scale,
+        3 * scale,
+        h - 6 * scale,
+        h - 6 * scale,
         colorCenter
     )
 end
@@ -697,10 +699,10 @@ function SKIN:PaintButtonTTT2(panel, w, h)
         translatedText = string.upper(TryT(panel:GetText()))
     end
 
-    local font, fscale = fonts.ScaledFont(panel:GetFont(), scale)
     local xText = 0.5 * w
 
     if panel:HasIcon() then
+        local font, fscale = fonts.ScaledFont(panel:GetFont(), scale)
         local widthText = drawGetTextSize(translatedText, font, fscale)
         local padding = 5 * scale
         local sizeIcon = panel:GetIconSize()
@@ -815,6 +817,7 @@ function SKIN:PaintFormButtonTTT2(panel, w, h)
     local colorBox = colors.accent
     local colorText = ColorAlpha(utilGetDefaultColor(colors.accent), 150)
     local shift = 0
+    local scale = GetGlobalScale()
 
     if not panel:IsEnabled() then
         colorBoxBack = ColorAlpha(colors.settingsBox, alphaDisabled)
@@ -823,7 +826,7 @@ function SKIN:PaintFormButtonTTT2(panel, w, h)
     elseif panel.Depressed or panel:IsSelected() or panel:GetToggle() then
         colorBox = colors.accentActive
         colorText = ColorAlpha(utilGetDefaultColor(colors.accent), 150)
-        shift = 1
+        shift = 1 * scale
     elseif panel.Hovered then
         colorBox = colors.accentHover
         colorText = ColorAlpha(utilGetDefaultColor(colors.accent), 150)
@@ -832,21 +835,23 @@ function SKIN:PaintFormButtonTTT2(panel, w, h)
     drawRoundedBoxEx(sizes.cornerRadius, 0, 0, w, h, colorBoxBack, false, true, false, true)
     drawRoundedBox(
         sizes.cornerRadius,
-        1 * GetGlobalScale(),
-        1 * GetGlobalScale(),
-        w - 2 * GetGlobalScale(),
-        h - 2 * GetGlobalScale(),
+        1 * scale,
+        1 * scale,
+        w - 2 * scale,
+        h - 2 * scale,
         colorBox
     )
 
-    drawShadowedText(
+    drawAdvancedText(
         TryT(panel:GetText()),
         panel:GetFont(),
         0.5 * w,
         0.5 * h + shift,
         colorText,
         TEXT_ALIGN_CENTER,
-        TEXT_ALIGN_CENTER
+        TEXT_ALIGN_CENTER,
+        true,
+        scale
     )
 end
 
@@ -905,12 +910,13 @@ end
 function SKIN:PaintLabelSpacerTTT2(panel, w, h)
     local text = TryT(panel:GetText())
     local font = panel:GetFont()
+    local scale = GetGlobalScale()
 
-    local padding = 10 * GetGlobalScale()
-    local heightBar = 5 * GetGlobalScale()
+    local padding = 10 * scale
+    local heightBar = 5 * scale
     local barX1 = 0
     local barY1 = 0.5 * (h - heightBar) + 1
-    local widthBar1 = 20 * GetGlobalScale()
+    local widthBar1 = 20 * scale
     local textX = barX1 + widthBar1 + padding
     local widthText = drawGetTextSize(text, font)
     local barX2 = textX + widthText + padding
@@ -921,14 +927,16 @@ function SKIN:PaintLabelSpacerTTT2(panel, w, h)
     drawBox(barX1, barY1, widthBar1, heightBar, colorLine)
     drawBox(barX2, barY1, widthBar2, heightBar, colorLine)
 
-    drawSimpleText(
+    drawAdvancedText(
         text,
         font,
         textX,
         0.5 * h,
         utilGetChangedColor(colors.default, 40),
         TEXT_ALIGN_LEFT,
-        TEXT_ALIGN_CENTER
+        TEXT_ALIGN_CENTER,
+        false,
+        scale
     )
 end
 
@@ -957,14 +965,16 @@ end
 -- @param number h
 -- @realm client
 function SKIN:PaintLabelRightTTT2(panel, w, h)
-    drawSimpleText(
+    drawAdvancedText(
         TryT(panel:GetText()),
         panel:GetFont(),
         w,
         0.5 * h,
         utilGetChangedColor(colors.default, 40),
         TEXT_ALIGN_RIGHT,
-        TEXT_ALIGN_CENTER
+        TEXT_ALIGN_CENTER,
+        false,
+        GetGlobalScale()
     )
 end
 
@@ -1119,7 +1129,8 @@ function SKIN:PaintNumSliderTTT2(panel, w, h)
     local colorHandle = colors.handle
     local colorLineActive = colors.accent
     local colorLinePassive = colors.sliderInactive
-    local pad = 5
+    local scale = GetGlobalScale()
+    local pad = 5 * scale
 
     if not panel:IsEnabled() then
         colorBox = ColorAlpha(colors.settingsBox, alphaDisabled)
@@ -1131,26 +1142,26 @@ function SKIN:PaintNumSliderTTT2(panel, w, h)
     drawBox(0, 0, w, h, colorBox)
     drawRoundedBox(
         sizes.cornerRadius,
-        1 * GetGlobalScale(),
-        1 * GetGlobalScale(),
-        w - 2 * GetGlobalScale(),
-        h - 2 * GetGlobalScale(),
+        1 * scale,
+        1 * scale,
+        w - 2 * scale,
+        h - 2 * scale,
         colorHandle
     )
 
     -- draw selection line
     drawBox(
-        5 * GetGlobalScale(),
-        0.5 * h - 1 * GetGlobalScale(),
+        5 * scale,
+        0.5 * h - 1 * scale,
         w - 2 * pad,
-        2 * GetGlobalScale(),
+        2 * scale,
         colorLinePassive
     )
     drawBox(
-        5 * GetGlobalScale(),
-        0.5 * h - 1 * GetGlobalScale(),
+        5 * scale,
+        0.5 * h - 1 * scale,
         (w - pad) * panel:GetFraction() - pad,
-        2 * GetGlobalScale(),
+        2 * scale,
         colorLineActive
     )
 end
@@ -1206,6 +1217,8 @@ function SKIN:PaintSliderTextAreaTTT2(panel, w, h)
             cam.PushModelMatrix(mat)
         end
 
+        -- TODO: this still doesn't seem to work
+        print(cam.GetModelMatrix())
         panel:SetFont(font)
         panel:DrawTextEntryText(vguiColor, vguiColor, vguiColor)
         panel:SetFont(origFont)
@@ -1318,7 +1331,7 @@ function SKIN:PaintColoredTextBoxTTT2(panel, w, h)
         drawRoundedBox(sizes.cornerRadius, 0, 0, w, h, colorFlash)
     end
 
-    drawAppearanceText(
+    drawAdvancedText(
         TryT(panel:GetTitle()),
         panel:GetTitleFont(),
         (align == TEXT_ALIGN_CENTER) and (0.5 * w)
@@ -1359,7 +1372,8 @@ end
 -- @param number h
 -- @realm client
 function SKIN:PaintVerticalBorderedBoxTTT2(panel, w, h)
-    drawBox(w - 1 * GetGlobalScale(), 0, 1 * GetGlobalScale(), h, ColorAlpha(colors.default, 200))
+    local scale = GetGlobalScale()
+    drawBox(w - 1 * scale, 0, 1 * scale, h, ColorAlpha(colors.default, 200))
 end
 
 ---
@@ -1371,8 +1385,9 @@ function SKIN:PaintButtonRoundEndLeftTTT2(panel, w, h)
     local colorForeground = colors.accent
     local shift = 0
 
+    local scale = GetGlobalScale()
     if panel.Depressed or panel:IsSelected() or panel:GetToggle() then
-        shift = 1 * GetGlobalScale()
+        shift = 1 * scale
     elseif panel.Hovered then
         colorForeground = colors.accentHover
     elseif not panel.isActive then
@@ -1384,21 +1399,23 @@ function SKIN:PaintButtonRoundEndLeftTTT2(panel, w, h)
     drawRoundedBoxEx(sizes.cornerRadius, 0, 0, w, h, colors.content, true, false, true, false)
     drawRoundedBox(
         sizes.cornerRadius,
-        2 * GetGlobalScale(),
-        2 * GetGlobalScale(),
-        w - 3 * GetGlobalScale(),
-        h - 4 * GetGlobalScale(),
+        2 * scale,
+        2 * scale,
+        w - 3 * scale,
+        h - 4 * scale,
         colorForeground
     )
 
-    drawSimpleText(
+    drawAdvancedText(
         TryT(panel:GetText()),
         panel:GetFont(),
         0.5 * w,
         0.5 * h + shift,
         colorText,
         TEXT_ALIGN_CENTER,
-        TEXT_ALIGN_CENTER
+        TEXT_ALIGN_CENTER,
+        false,
+        scale
     )
 end
 
@@ -1410,9 +1427,10 @@ end
 function SKIN:PaintButtonRoundEndRightTTT2(panel, w, h)
     local colorForeground = colors.accent
     local shift = 0
+    local scale = GetGlobalScale()
 
     if panel.Depressed or panel:IsSelected() or panel:GetToggle() then
-        shift = 1 * GetGlobalScale()
+        shift = 1 * scale
     elseif panel.Hovered then
         colorForeground = colors.accentHover
     elseif not panel.isActive then
@@ -1424,21 +1442,23 @@ function SKIN:PaintButtonRoundEndRightTTT2(panel, w, h)
     drawRoundedBoxEx(sizes.cornerRadius, 0, 0, w, h, colors.content, false, true, false, true)
     drawRoundedBox(
         sizes.cornerRadius,
-        1 * GetGlobalScale(),
-        2 * GetGlobalScale(),
-        w - 3 * GetGlobalScale(),
-        h - 4 * GetGlobalScale(),
+        1 * scale,
+        2 * scale,
+        w - 3 * scale,
+        h - 4 * scale,
         colorForeground
     )
 
-    drawSimpleText(
+    drawAdvancedText(
         TryT(panel:GetText()),
         panel:GetFont(),
         0.5 * w,
         0.5 * h + shift,
         colorText,
         TEXT_ALIGN_CENTER,
-        TEXT_ALIGN_CENTER
+        TEXT_ALIGN_CENTER,
+        false,
+        scale
     )
 end
 
@@ -1477,7 +1497,7 @@ function SKIN:PaintTooltipTTT2(panel, w, h)
     )
 
     if panel:HasText() then
-        drawSimpleText(
+        drawAdvancedText(
             TryT(panel:GetText()),
             panel:GetFont(),
             0.5 * w,
@@ -1763,7 +1783,7 @@ function SKIN:PaintShopCardTTT2(panel, w, h)
         colorTextMode
     )
 
-    drawSimpleText(
+    drawAdvancedText(
         TryT(textMode),
         "DermaTTT2TextSmall",
         posTextModeX,
@@ -1782,7 +1802,8 @@ end
 -- @param number h
 -- @realm client
 function SKIN:PaintComboCardTTT2(panel, w, h)
-    local widthBorder = 2 * GetGlobalScale()
+    local scale = GetGlobalScale()
+    local widthBorder = 2 * scale
     local widthBorder2 = widthBorder * 2
     local widthBorder4 = widthBorder2 * 2
     local shift = 0
@@ -1802,7 +1823,7 @@ function SKIN:PaintComboCardTTT2(panel, w, h)
 
     if panel.Depressed then
         opacity = 240
-        shift = 1 * GetGlobalScale()
+        shift = 1 * scale
     end
 
     local colorText = utilGetDefaultColor(colorBox)
@@ -1836,33 +1857,36 @@ function SKIN:PaintComboCardTTT2(panel, w, h)
         local width = drawGetTextSize(tagText, panel:GetFont())
         local colorTag = panel:GetTagColor() or COLOR_WARMGRAY
 
-        width = width + 20 * GetGlobalScale()
+        width = width + 20 * scale
 
         drawRoundedBox(
             sizes.cornerRadius,
             widthBorder4,
             widthBorder4,
             width,
-            20 * GetGlobalScale(),
+            20 * scale,
             colorTag
         )
 
-        drawSimpleText(
+        drawAdvancedText(
             TryT(tagText),
             panel:GetFont(),
             widthBorder4 + 0.5 * width,
-            widthBorder4 + 10 * GetGlobalScale(),
+            widthBorder4 + 10 * scale,
             utilGetDefaultColor(colorTag),
             TEXT_ALIGN_CENTER,
-            TEXT_ALIGN_CENTER
+            TEXT_ALIGN_CENTER,
+            false,
+            scale
         )
     end
 
-    drawSimpleText(
+    local fnt, fscale = fonts.ScaledFont(panel:GetFont(), scale)
+    drawAdvancedText(
         drawGetLimitedLengthText(
             TryT(panel:GetText()),
-            w - 2 * widthBorder4,
-            panel:GetFont(),
+            (w - 2 * widthBorder4) / fscale,
+            fnt,
             "..."
         ),
         panel:GetFont(),
@@ -1870,7 +1894,9 @@ function SKIN:PaintComboCardTTT2(panel, w, h)
         w + shift,
         colorText,
         TEXT_ALIGN_LEFT,
-        TEXT_ALIGN_TOP
+        TEXT_ALIGN_TOP,
+        false,
+        scale
     )
 end
 
@@ -2007,13 +2033,14 @@ function SKIN:PaintTextEntryTTT2(panel, w, h)
         colorHandle = ColorAlpha(colors.handle, alphaDisabled)
     end
 
+    local scale = GetGlobalScale()
     drawBox(0, 0, w, h, colorBox)
     drawRoundedBox(
         sizes.cornerRadius,
-        1 * GetGlobalScale(),
-        1 * GetGlobalScale(),
-        w - 2 * GetGlobalScale(),
-        h - 2 * GetGlobalScale(),
+        1 * scale,
+        1 * scale,
+        w - 2 * scale,
+        h - 2 * scale,
         colorHandle
     )
 end

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dbinder_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dbinder_ttt2.lua
@@ -14,8 +14,9 @@ Derma_Install_Convar_Functions(PANEL)
 ---
 -- @ignore
 function PANEL:Init()
+    local scale = appearance.GetGlobalScale()
     self:SetSelectedNumber(0)
-    self:SetSize(60, 30)
+    self:SetSize(60 * scale, 30 * scale)
 end
 
 ---

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dbinderpanel_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dbinderpanel_ttt2.lua
@@ -26,7 +26,8 @@ end
 ---
 -- @ignore
 function PANEL:PerformLayout(w, h)
-    self.binder:SetSize(150, h)
+    local scale = appearance.GetGlobalScale()
+    self.binder:SetSize(150 * scale, h)
     self.binder:SetPos(0, 0)
 
     self.disable:SetSize(h, h)

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dbutton_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dbutton_ttt2.lua
@@ -14,9 +14,10 @@ AccessorFunc(PANEL, "m_bBorder", "DrawBorder", FORCE_BOOL)
 ---
 -- @ignore
 function PANEL:Init()
-    self:SetContentAlignment(5)
+    local scale = appearance.GetGlobalScale()
+    self:SetContentAlignment(5 * scale)
 
-    self:SetTall(22)
+    self:SetTall(22 * scale)
     self:SetMouseInputEnabled(true)
     self:SetKeyboardInputEnabled(true)
 
@@ -128,7 +129,7 @@ end
 function PANEL:SetIcon(icon, is_shadowed, size)
     self.data.icon = icon
     self.data.icon_shadow = is_shadowed or false
-    self.data.icon_size = size or 32
+    self.data.icon_size = size or 32 * appearance.GetGlobalScale()
 end
 
 ---
@@ -163,8 +164,9 @@ end
 -- @ignore
 function PANEL:SizeToContents()
     local w, h = self:GetContentSize()
+    local scale = appearance.GetGlobalScale()
 
-    self:SetSize(w + 8, h + 4)
+    self:SetSize(w + 8 * scale, h + 4 * scale)
 end
 
 derma.DefineControl("DButtonTTT2", "A standard Button", PANEL, "DLabelTTT2")

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcategorycollapse_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcategorycollapse_ttt2.lua
@@ -37,16 +37,17 @@ AccessorFunc(PANEL, "m_pList", "List", "Panel")
 ---
 -- @ignore
 function PANEL:Init()
+    local scale = appearance.GetGlobalScale()
     self.Header = vgui.Create("DCategoryHeaderTTT2", self)
     self.Header:Dock(TOP)
-    self.Header:SetSize(20, vskin.GetCollapsableHeight())
+    self.Header:SetSize(20 * scale, vskin.GetCollapsableHeight())
 
-    self:SetSize(16, 16)
+    self:SetSize(16 * scale, 16 * scale)
     self:SetExpanded(true)
     self:SetMouseInputEnabled(true)
 
     self:SetPaintBackground(true)
-    self:DockMargin(10, 10, 10, 5)
+    self:DockMargin(10 * scale, 10 * scale, 10 * scale, 5 * scale)
     self:DockPadding(0, 0, 0, 0)
 end
 
@@ -60,11 +61,13 @@ function PANEL:Add(strName)
         derma.SkinHook("Paint", "CategoryButtonTTT2", panel, w, h)
     end
 
-    button:SetHeight(17)
-    button:SetTextInset(4, 0)
+    local scale = appearance.GetGlobalScale()
 
-    button:SetContentAlignment(4)
-    button:DockMargin(1, 0, 1, 0)
+    button:SetHeight(17 * scale)
+    button:SetTextInset(4 * scale, 0)
+
+    button:SetContentAlignment(4 * scale)
+    button:DockMargin(1 * scale, 0, 1 * scale, 0)
     button.DoClickInternal = function()
         if self:GetList() then
             self:GetList():UnselectAll()
@@ -198,6 +201,7 @@ function PANEL:PerformLayout()
         end
     end
 
+    local scale = appearance.GetGlobalScale()
     if self:GetExpanded() then
         if IsValid(self.Contents) and #self.Contents:GetChildren() > 0 then
             self.Contents:SizeToChildren(false, true)
@@ -208,18 +212,18 @@ function PANEL:PerformLayout()
         -- hacky solution to make sure box is always big enough
         -- I don't know why I have to do this though
         local w, h = self:GetSize()
-        self:SetSize(w, h + 15)
+        self:SetSize(w, h + 15 * scale)
     else
         if IsValid(self.Contents) and not self.OldHeight then
             self.OldHeight = self.Contents:GetTall()
         end
 
-        self:SetTall(self.Header:GetTall() + vskin:GetBorderSize() + 2)
+        self:SetTall(self.Header:GetTall() + vskin:GetBorderSize() + 2 * scale)
     end
 
     -- Make sure the color of header text is set
     self.Header:ApplySchemeSettings()
-    self.Header:SetSize(20, vskin.GetCollapsableHeight())
+    self.Header:SetSize(20 * scale, vskin.GetCollapsableHeight())
 
     self:UpdateAltLines()
 end
@@ -238,11 +242,12 @@ end
 ---
 -- @ignore
 function PANEL:GenerateExample(ClassName, PropertySheet, Width, Height)
+    local scale = appearance.GetGlobalScale()
     local ctrl = vgui.Create(ClassName)
 
     ctrl:SetLabel("Category List Test Category")
-    ctrl:SetSize(300, 300)
-    ctrl:SetPadding(10)
+    ctrl:SetSize(300 * scale, 300 * scale)
+    ctrl:SetPadding(10 * scale)
 
     -- The contents can be any panel, even a DPanelList
     local Contents = vgui.Create("DButton")

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcategoryheader_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcategoryheader_ttt2.lua
@@ -7,8 +7,9 @@ local PANEL = {}
 ---
 -- @ignore
 function PANEL:Init()
-    self:SetContentAlignment(4)
-    self:SetTextInset(5, 0)
+    local scale = appearance.GetGlobalScale()
+    self:SetContentAlignment(4 * scale)
+    self:SetTextInset(5 * scale, 0)
     self:SetFont("DermaTTT2CatHeader")
 
     self.text = ""

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcheckboxlabel_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcheckboxlabel_ttt2.lua
@@ -273,10 +273,11 @@ end
 ---
 -- @ignore
 function PANEL:PerformLayout()
+    local scale = appearance.GetGlobalScale()
     local x = self.m_iIndent or 0
 
     local height = self:GetTall()
-    local paddingButton = 4
+    local paddingButton = 4 * scale
     local heightButton = height - 2 * paddingButton
     local widthButton = 1.5 * heightButton
 

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcombocard_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dcombocard_ttt2.lua
@@ -7,9 +7,10 @@ local PANEL = {}
 ---
 -- @ignore
 function PANEL:Init()
-    self:SetContentAlignment(5)
+    local scale = appearance.GetGlobalScale()
+    self:SetContentAlignment(5 * scale)
 
-    self:SetTall(22)
+    self:SetTall(22 * scale)
     self:SetMouseInputEnabled(true)
     self:SetKeyboardInputEnabled(true)
 

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/ddragbase_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/ddragbase_ttt2.lua
@@ -37,7 +37,7 @@ end
 -- @return number The child height
 -- @realm client
 function PANEL:GetChildSize()
-    return self.childW or 64, self.childH or 64
+    return self.childW or 64 * appearance.GetGlobalScale(), self.childH or 64 * appearance.GetGlobalScale()
 end
 
 ---

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/ddragbase_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/ddragbase_ttt2.lua
@@ -37,7 +37,8 @@ end
 -- @return number The child height
 -- @realm client
 function PANEL:GetChildSize()
-    return self.childW or 64 * appearance.GetGlobalScale(), self.childH or 64 * appearance.GetGlobalScale()
+    return self.childW or 64 * appearance.GetGlobalScale(),
+        self.childH or 64 * appearance.GetGlobalScale()
 end
 
 ---

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/deventbox_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/deventbox_ttt2.lua
@@ -91,10 +91,12 @@ end
 -- @return number The calculated height
 -- @realm client
 function PANEL:GetContentHeight(width)
-    local size = 50 -- title height
+    local scale = appearance.GetGlobalScale()
+    local size = 50 * scale -- title height
 
     local textTable = self:GetText()
-    local _, heightText = drawGetTextSize("", self:GetFont())
+    local font, fscale, fcmod = fonts.ScaledFont(self:GetFont(), scale)
+    local _, heightText = drawGetTextSize("", font, fscale)
 
     for i = 1, #textTable do
         local text = textTable[i]
@@ -110,9 +112,9 @@ function PANEL:GetContentHeight(width)
 
         local textTranslated = ParT(text.string, params or {})
 
-        local textWrapped = drawGetWrappedText(textTranslated, width - 50, self:GetFont())
+        local textWrapped = drawGetWrappedText(textTranslated, (width - 50) / fcmod, font)
 
-        size = size + #textWrapped * heightText + 15 -- 15: paragraph end
+        size = size + #textWrapped * heightText + 15 * scale -- 15: paragraph end
     end
 
     local event = self:GetEvent()
@@ -134,11 +136,11 @@ function PANEL:GetContentHeight(width)
                 continue
             end
 
-            size = size + (scoreRows + 1) * heightText + 35 -- 35 spacing + padding
+            size = size + (scoreRows + 1) * heightText + 35 * scale -- 35 spacing + padding
         end
     end
 
-    return mathmax(size, 75)
+    return mathmax(size, 75 * scale)
 end
 
 ---

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/deventbox_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/deventbox_ttt2.lua
@@ -95,7 +95,7 @@ function PANEL:GetContentHeight(width)
     local size = 50 * scale -- title height
 
     local textTable = self:GetText()
-    local font, fscale, fcmod = fonts.ScaledFont(self:GetFont(), scale)
+    local font, fscale = fonts.ScaledFont(self:GetFont(), scale)
     local _, heightText = drawGetTextSize("", font, fscale)
 
     for i = 1, #textTable do
@@ -112,7 +112,7 @@ function PANEL:GetContentHeight(width)
 
         local textTranslated = ParT(text.string, params or {})
 
-        local textWrapped = drawGetWrappedText(textTranslated, (width - 50) / fcmod, font)
+        local textWrapped = drawGetWrappedText(textTranslated, (width - 50) / fscale, font)
 
         size = size + #textWrapped * heightText + 15 * scale -- 15: paragraph end
     end

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dform_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dform_ttt2.lua
@@ -32,8 +32,9 @@ local materialDisable = Material("vgui/ttt/vskin/icon_disable")
 function PANEL:Init()
     self.items = {}
 
-    self:SetSpacing(4)
-    self:SetPadding(10)
+    local scale = appearance.GetGlobalScale()
+    self:SetSpacing(4 * scale)
+    self:SetPadding(10 * scale)
 
     self:SetPaintBackground(true)
 
@@ -74,11 +75,12 @@ end
 function PANEL:AddItem(left, right, buttonReset, buttonToggle, buttonRun)
     self:InvalidateLayout()
 
+    local scale = appearance.GetGlobalScale()
     local panel = vgui.Create("DSizeToContents", self)
 
     panel:SetSizeX(false)
     panel:Dock(TOP)
-    panel:DockPadding(10, 10, 10, 0)
+    panel:DockPadding(10 * scale, 10 * scale, 10 * scale, 0)
     panel:InvalidateLayout()
 
     if IsValid(buttonReset) then
@@ -100,10 +102,10 @@ function PANEL:AddItem(left, right, buttonReset, buttonToggle, buttonRun)
         left:SetParent(panel)
         left:Dock(LEFT)
         left:InvalidateLayout(true)
-        left:SetSize(350, 20)
+        left:SetSize(350 * scale, 20 * scale)
 
         right:SetParent(panel)
-        right:SetPos(350, 0)
+        right:SetPos(350 * scale, 0)
         right:InvalidateLayout(true)
     elseif IsValid(left) then
         left:SetParent(panel)
@@ -121,10 +123,11 @@ function PANEL:Rebuild() end
 -- FUNCTIONS TO POPULATE THE FORM
 
 local function MakeButton(parent)
+    local scale = appearance.GetGlobalScale()
     local button = vgui.Create("DButtonTTT2", parent)
 
     button:SetText("button_default")
-    button:SetSize(32, 32)
+    button:SetSize(32 * scale, 32 * scale)
 
     button.Paint = function(slf, w, h)
         derma.SkinHook("Paint", "FormButtonIconTTT2", slf, w, h)
@@ -189,6 +192,7 @@ end
 -- @return Panel The created textentry
 -- @realm client
 function PANEL:MakeTextEntry(data)
+    local scale = appearance.GetGlobalScale()
     local left = vgui.Create("DLabelTTT2", self)
 
     left:SetText(data.label)
@@ -241,7 +245,7 @@ function PANEL:MakeTextEntry(data)
         end
     end
 
-    right:SetTall(32)
+    right:SetTall(32 * scale)
     right:Dock(TOP)
 
     self:AddItem(left, right, reset, toggle, run)
@@ -271,6 +275,7 @@ end
 -- @return Panel The created checkbox
 -- @realm client
 function PANEL:MakeCheckBox(data)
+    local scale = appearance.GetGlobalScale()
     local left = vgui.Create("DCheckBoxLabelTTT2", self)
 
     local reset = MakeResetButton(self)
@@ -297,7 +302,7 @@ function PANEL:MakeCheckBox(data)
     left:SetServerConVar(data.serverConvar)
     left:SetDatabase(data.database)
 
-    left:SetTall(32)
+    left:SetTall(32 * scale)
 
     if not data.convar and not data.serverConvar and not data.database and data.initial then
         left:SetValue(data.initial)
@@ -340,6 +345,7 @@ end
 -- @return Panel The created slider
 -- @realm client
 function PANEL:MakeSlider(data)
+    local scale = appearance.GetGlobalScale()
     local left = vgui.Create("DLabelTTT2", self)
 
     left:SetText(data.label)
@@ -390,7 +396,7 @@ function PANEL:MakeSlider(data)
         end
     end
 
-    right:SetTall(32)
+    right:SetTall(32 * scale)
     right:Dock(TOP)
 
     self:AddItem(left, right, reset, toggle, run)
@@ -426,6 +432,7 @@ end
 -- @return Panel The created slider
 -- @realm client
 function PANEL:MakeButton(data)
+    local scale = appearance.GetGlobalScale()
     local left = vgui.Create("DLabelTTT2", self)
 
     left:SetText(data.label)
@@ -444,7 +451,7 @@ function PANEL:MakeButton(data)
         right.DoClick = data.OnClick
     end
 
-    right:SetTall(32)
+    right:SetTall(32 * scale)
     right:Dock(TOP)
 
     right.Paint = function(slf, w, h)
@@ -547,7 +554,8 @@ function PANEL:MakeComboBox(data)
         end
     end
 
-    right:SetTall(32)
+    local scale = appearance.GetGlobalScale()
+    right:SetTall(32 * scale)
     right:Dock(TOP)
 
     self:AddItem(left, right, reset, toggle, run)
@@ -612,7 +620,8 @@ function PANEL:MakeBinder(data)
 
     right.disable.material = materialDisable
 
-    right:SetTall(32)
+    local scale = appearance.GetGlobalScale()
+    right:SetTall(32 * scale)
     right:Dock(TOP)
 
     local reset = MakeResetButton(self)
@@ -669,15 +678,16 @@ end
 -- @return Panel The created helpbox
 -- @realm client
 function PANEL:MakeHelp(data)
+    local scale = appearance.GetGlobalScale()
     local left = vgui.Create("DLabelTTT2", self)
 
     left:SetText(data.label)
     left:SetTextParams(data.params)
-    left:SetContentAlignment(7)
+    left:SetContentAlignment(7 * scale)
     left:SetAutoStretchVertical(true)
 
-    left.paddingX = 10
-    left.paddingY = 5
+    left.paddingX = 10 * scale
+    left.paddingY = 5 * scale
 
     left.Paint = function(slf, w, h)
         derma.SkinHook("Paint", "HelpLabelTTT2", slf, w, h)
@@ -689,11 +699,11 @@ function PANEL:MakeHelp(data)
     left.PerformLayout = function(slf, w, h)
         local textTranslated =
             LANG.GetParamTranslation(slf:GetText(), LANG.TryTranslation(slf:GetTextParams()))
+        local font, scale2, fcmod = fonts.ScaledFont(slf:GetFont(), appearance.GetGlobalScale())
+        local textWrapped = draw.GetWrappedText(textTranslated, (w - 2 * slf.paddingX) / fcmod, font)
+        local _, heightText = draw.GetTextSize("", font)
 
-        local textWrapped = draw.GetWrappedText(textTranslated, w - 2 * slf.paddingX, slf:GetFont())
-        local _, heightText = draw.GetTextSize("", slf:GetFont())
-
-        slf:SetSize(w, heightText * #textWrapped + 2 * slf.paddingY)
+        slf:SetSize(w, heightText * scale2 * #textWrapped + 2 * slf.paddingY)
     end
 
     self:AddItem(left, nil)
@@ -717,14 +727,15 @@ end
 -- @return Panel The created label
 -- @realm client
 function PANEL:MakeColorMixer(data)
+    local scale = appearance.GetGlobalScale()
     local left = vgui.Create("DLabelTTT2", self)
     local right = vgui.Create("DPanel", self)
 
-    left:SetTall(data.height or 240)
-    right:SetTall(data.height or 240)
+    left:SetTall(data.height or 240 * scale)
+    right:SetTall(data.height or 240 * scale)
 
     right:Dock(TOP)
-    right:DockPadding(10, 10, 10, 10)
+    right:DockPadding(10 * scale, 10 * scale, 10 * scale, 10 * scale)
 
     left:SetText(data.label)
 
@@ -794,9 +805,10 @@ end
 -- @return Panel The created card
 -- @realm client
 function PANEL:MakeShopCard(data, base)
+    local scale = appearance.GetGlobalScale()
     local card = base:Add("DShopCardTTT2")
 
-    card:SetSize(238, 78)
+    card:SetSize(238 * scale, 78 * scale)
     card:SetIcon(data.icon)
     card:SetText(data.label)
     card:SetMode(data.initial)
@@ -818,10 +830,11 @@ end
 -- @return Panel The created card
 -- @realm client
 function PANEL:MakeComboCard(data, base)
+    local scale = appearance.GetGlobalScale()
     local card = base:Add("DComboCardTTT2")
 
     -- todo smaller, higher - square?
-    card:SetSize(175, 205)
+    card:SetSize(175 * scale, 205 * scale)
     card:SetIcon(data.icon)
     card:SetText(data.label)
     card:SetTagText(data.tag)
@@ -844,9 +857,10 @@ end
 -- @return Panel The created image check box
 -- @realm client
 function PANEL:MakeImageCheckBox(data, base)
+    local scale = appearance.GetGlobalScale()
     local box = base:Add("DImageCheckBoxTTT2")
 
-    box:SetSize(238, 175)
+    box:SetSize(238 * scale, 175 * scale)
     box:SetModel(data.model)
     box:SetHeadBox(data.headbox or false)
     box:SetText(data.label)
@@ -879,10 +893,11 @@ end
 -- @return Panel The created panel
 -- @realm client
 function PANEL:MakeIconLayout(spacing)
+    local scale = appearance.GetGlobalScale()
     local panel = vgui.Create("DIconLayout", self)
 
-    panel:SetSpaceY(spacing or 10)
-    panel:SetSpaceX(spacing or 10)
+    panel:SetSpaceY(spacing or 10 * scale)
+    panel:SetSpaceX(spacing or 10 * scale)
 
     self:AddItem(panel)
 

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dform_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dform_ttt2.lua
@@ -699,8 +699,9 @@ function PANEL:MakeHelp(data)
     left.PerformLayout = function(slf, w, h)
         local textTranslated =
             LANG.GetParamTranslation(slf:GetText(), LANG.TryTranslation(slf:GetTextParams()))
-        local font, scale2, fcmod = fonts.ScaledFont(slf:GetFont(), appearance.GetGlobalScale())
-        local textWrapped = draw.GetWrappedText(textTranslated, (w - 2 * slf.paddingX) / fcmod, font)
+        local font, scale2 = fonts.ScaledFont(slf:GetFont(), appearance.GetGlobalScale())
+        local textWrapped =
+            draw.GetWrappedText(textTranslated, (w - 2 * slf.paddingX) / scale2, font)
         local _, heightText = draw.GetTextSize("", font)
 
         slf:SetSize(w, heightText * scale2 * #textWrapped + 2 * slf.paddingY)

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dframe_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dframe_ttt2.lua
@@ -62,8 +62,10 @@ function PANEL:Init()
     self:SetScreenLock(false)
     self:SetDeleteOnClose(true)
 
-    self:SetMinWidth(50)
-    self:SetMinHeight(50)
+    local scale = appearance.GetGlobalScale()
+
+    self:SetMinWidth(50 * scale)
+    self:SetMinHeight(50 * scale)
 
     -- This turns off the engine drawing
     self:SetPaintBackgroundEnabled(false)
@@ -87,7 +89,7 @@ function PANEL:Init()
         font = "DermaTTT2Title",
     }
 
-    self:SetPadding(5, 5, 5, 5)
+    self:SetPadding(5 * scale, 5 * scale, 5 * scale, 5 * scale)
 
     self.panelData = {
         hidden = false,
@@ -378,6 +380,8 @@ function PANEL:Think()
     local mousex = math.Clamp(gui.MouseX(), 1, scrW - 1)
     local mousey = math.Clamp(gui.MouseY(), 1, scrH - 1)
 
+    local scale = appearance.GetGlobalScale()
+
     if self.dragging then
         local x = mousex - self.dragging[1]
         local y = mousey - self.dragging[2]
@@ -419,7 +423,7 @@ function PANEL:Think()
     if
         self.Hovered
         and self.m_bSizable
-        and mousex > (screenX + self:GetWide() - 20)
+        and mousex > (screenX + self:GetWide() - 20 * scale)
         and mousey > (screenY + self:GetTall() - vskin.GetHeaderHeight())
     then
         self:SetCursor("sizenwse")
@@ -457,10 +461,11 @@ end
 -- @realm client
 function PANEL:OnMousePressed()
     local screenX, screenY = self:LocalToScreen(0, 0)
+    local scale = appearance.GetGlobalScale()
 
     if
         self.m_bSizable
-        and gui.MouseX() > (screenX + self:GetWide() - 20)
+        and gui.MouseX() > (screenX + self:GetWide() - 20 * scale)
         and gui.MouseY() > (screenY + self:GetTall() - vskin.GetHeaderHeight())
     then
         self.sizing = {
@@ -496,12 +501,13 @@ end
 -- @ignore
 function PANEL:PerformLayout()
     local size = vskin.GetHeaderHeight()
+    local scale = appearance.GetGlobalScale()
 
     self.btnClose:SetPos(self:GetWide() - size, 0)
     self.btnClose:SetSize(size, size)
 
     self.btnBack:SetPos(0, 0)
-    self.btnBack:SetSize(100, size)
+    self.btnBack:SetSize(100 * scale, size)
 
     self:UpdatePadding()
 end

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dimagecheckbox_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dimagecheckbox_ttt2.lua
@@ -64,9 +64,10 @@ function PANEL:Init()
     self.directionalLight = {}
     self.farZ = 4096
 
-    self:SetContentAlignment(5)
+    local scale = appearance.GetGlobalScale()
+    self:SetContentAlignment(5 * scale)
 
-    self:SetTall(22)
+    self:SetTall(22 * scale)
     self:SetMouseInputEnabled(true)
     self:SetKeyboardInputEnabled(true)
 

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dinfoitem_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dinfoitem_ttt2.lua
@@ -7,9 +7,10 @@ local PANEL = {}
 ---
 -- @ignore
 function PANEL:Init()
-    self:SetContentAlignment(5)
+    local scale = appearance.GetGlobalScale()
+    self:SetContentAlignment(5 * scale)
 
-    self:SetTall(22)
+    self:SetTall(22 * scale)
     self:SetMouseInputEnabled(true)
     self:SetKeyboardInputEnabled(true)
 

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dlabel_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dlabel_ttt2.lua
@@ -74,8 +74,10 @@ function PANEL:Init()
     self:SetKeyboardInputEnabled(false)
     self:SetDoubleClickingEnabled(true)
 
+    local scale = appearance.GetGlobalScale()
+
     -- Nicer default height
-    self:SetTall(20)
+    self:SetTall(20 * scale)
 
     -- This turns off the engine drawing
     self:SetPaintBackgroundEnabled(false)
@@ -111,7 +113,8 @@ function PANEL:GetIndentationMargin()
         return 0
     end
 
-    return 10 + self.master:GetIndentationMargin()
+    local scale = appearance.GetGlobalScale()
+    return 10 * scale + self.master:GetIndentationMargin()
 end
 
 ---

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dmenubutton_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dmenubutton_ttt2.lua
@@ -12,12 +12,13 @@ AccessorFunc(PANEL, "m_bBorder", "DrawBorder", FORCE_BOOL)
 ---
 -- @ignore
 function PANEL:Init()
+    local scale = appearance.GetGlobalScale()
     self:SetContentAlignment(5)
 
     self:SetDrawBorder(true)
     self:SetPaintBackground(true)
 
-    self:SetTall(22)
+    self:SetTall(22 * scale)
     self:SetMouseInputEnabled(true)
     self:SetKeyboardInputEnabled(true)
 
@@ -139,7 +140,8 @@ end
 function PANEL:SizeToContents()
     local w, h = self:GetContentSize()
 
-    self:SetSize(w + 8, h + 4)
+    local scale = appearance.GetGlobalScale()
+    self:SetSize(w + 8 * scale, h + 4 * scale)
 end
 
 derma.DefineControl("DMenuButtonTTT2", "A standard Button", PANEL, "DButtonTTT2")

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dnumslider_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dnumslider_ttt2.lua
@@ -7,10 +7,11 @@ local PANEL = {}
 ---
 -- @ignore
 function PANEL:Init()
+    local scale = appearance.GetGlobalScale()
     self.TextArea = self:Add("DTextEntry")
     self.TextArea:Dock(RIGHT)
     self.TextArea:SetPaintBackground(false)
-    self.TextArea:SetWide(45)
+    self.TextArea:SetWide(45 * scale)
     self.TextArea:SetNumeric(true)
     self.TextArea:SetFont("DermaTTT2Text")
     self.TextArea:SetDrawLanguageID(false)
@@ -52,7 +53,7 @@ function PANEL:Init()
 
     self.Slider:SetTrapInside(true)
     self.Slider:Dock(FILL)
-    self.Slider:SetHeight(16)
+    self.Slider:SetHeight(16 * scale)
 
     self.Slider.Knob.OnMousePressed = function(panel, mcode)
         if mcode == MOUSE_MIDDLE then
@@ -75,12 +76,13 @@ function PANEL:Init()
     self.Slider.Knob.PerformLayout = function(slf)
         local _, pH = self:GetSize()
 
-        slf:SetSize(8, pH - 10)
+        local scale2 = appearance.GetGlobalScale()
+        slf:SetSize(8 * scale2, pH - 10 * scale2)
     end
 
     Derma_Hook(self.Slider, "Paint", "Paint", "NumSliderTTT2")
 
-    self:SetTall(32)
+    self:SetTall(32 * scale)
     self:SetMin(0)
     self:SetMax(1)
     self:SetDecimals(2)

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dpanel_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dpanel_ttt2.lua
@@ -53,13 +53,15 @@ function PANEL:Init()
     self:SetPaintBackgroundEnabled(false)
     self:SetPaintBorderEnabled(false)
 
+    local scale = appearance.GetGlobalScale()
+
     self.tooltip = {
         fixedPosition = nil,
         fixedSize = nil,
         delay = 0,
         text = "",
         font = "DermaTTT2Text",
-        sizeArrow = 8,
+        sizeArrow = 8 * scale,
     }
 
     local oldSetTooltipPanel = self.SetTooltipPanel
@@ -166,9 +168,10 @@ end
 -- @realm client
 function PANEL:SetTooltipFixedSize(w, h)
     -- +2 are the outline pixels
+    local scale = appearance.GetGlobalScale()
     self.tooltip.fixedSize = {
-        w = w + 2,
-        h = h + self.tooltip.sizeArrow + 2,
+        w = w + 2 * scale,
+        h = h + self.tooltip.sizeArrow + 2 * scale,
     }
 end
 
@@ -255,7 +258,8 @@ function PANEL:GetIndentationMargin()
         return 0
     end
 
-    return 10 + self.master:GetIndentationMargin()
+    local scale = appearance.GetGlobalScale()
+    return 10 * scale + self.master:GetIndentationMargin()
 end
 
 derma.DefineControl("DPanelTTT2", "", PANEL, "Panel")

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dprofilepanel_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dprofilepanel_ttt2.lua
@@ -61,9 +61,11 @@ function PANEL:Init()
     self.directionalLight = {}
     self.farZ = 4096
 
-    self:SetContentAlignment(5)
+    local scale = appearance.GetGlobalScale()
 
-    self:SetTall(22)
+    self:SetContentAlignment(5 * scale)
+
+    self:SetTall(22 * scale)
     self:SetMouseInputEnabled(true)
     self:SetKeyboardInputEnabled(true)
 

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/drolelayeringreceiver_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/drolelayeringreceiver_ttt2.lua
@@ -12,7 +12,7 @@ function PANEL:Init()
     self.layerList = {}
     self.layerBoxes = {}
 
-    self.m_iPadding = 5
+    self.m_iPadding = 5 * appearance.GetGlobalScale()
 end
 
 ---
@@ -220,6 +220,7 @@ function PANEL:InitRoles(layeredRoles)
     self:SetLayers(layeredRoles)
 
     local layerCount = #layeredRoles
+    local scale = appearance.GetGlobalScale()
 
     for layer = 1, layerCount do
         local currentLayerTable = layeredRoles[layer]
@@ -230,11 +231,11 @@ function PANEL:InitRoles(layeredRoles)
 
             -- create the role icon
             local ic = vgui.Create("DRoleImageTTT2", self)
-            ic:SetSize(64, 64)
+            ic:SetSize(64 * scale, 64 * scale)
             ic:SetMaterial(roleData.iconMaterial)
             ic:SetColor(roleData.color)
             ic:SetTooltip(roleData.name)
-            ic:SetTooltipFixedPosition(0, 64)
+            ic:SetTooltipFixedPosition(0, 64 * scale)
 
             ic.subrole = subrole
 

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dshopcard_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dshopcard_ttt2.lua
@@ -12,9 +12,11 @@ local MODE_INHERIT_REMOVED = ShopEditor.MODE_INHERIT_REMOVED
 ---
 -- @ignore
 function PANEL:Init()
-    self:SetContentAlignment(5)
+    local scale = appearance.GetGlobalScale()
 
-    self:SetTall(22)
+    self:SetContentAlignment(5 * scale)
+
+    self:SetTall(22 * scale)
     self:SetMouseInputEnabled(true)
     self:SetKeyboardInputEnabled(true)
 

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dsubmenubutton_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dsubmenubutton_ttt2.lua
@@ -12,7 +12,9 @@ AccessorFunc(PANEL, "m_bBorder", "DrawBorder", FORCE_BOOL)
 ---
 -- @ignore
 function PANEL:Init()
-    self:SetContentAlignment(5)
+    local scale = appearance.GetGlobalScale()
+
+    self:SetContentAlignment(5 * scale)
 
     self:SetDrawBorder(true)
     self:SetPaintBackground(true)
@@ -171,7 +173,8 @@ end
 function PANEL:SizeToContents()
     local w, h = self:GetContentSize()
 
-    self:SetSize(w + 8, h + 4)
+    local scale = appearance.GetGlobalScale()
+    self:SetSize(w + 8 * scale, h + 4 * scale)
 end
 
 derma.DefineControl("DSubmenuButtonTTT2", "A standard Button", PANEL, "DButtonTTT2")

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dsubmenulist_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dsubmenulist_ttt2.lua
@@ -62,10 +62,12 @@ function PANEL:EnableSearchBar(active)
         return
     end
 
+    local scale = appearance.GetGlobalScale()
+
     -- Add searchbar on top
     local searchBar = vgui.Create("DSearchBarTTT2", self)
     searchBar:SetUpdateOnType(true)
-    searchBar:SetPos(0, heightNavHeader)
+    searchBar:SetPos(0, heightNavHeader * scale)
     searchBar:SetHeightMult(1)
 
     searchBar.OnValueChange = function(slf, searchText)
@@ -98,7 +100,7 @@ function PANEL:AddSubmenuButton(submenuClass)
     settingsButton:SetTooltip(submenuClass.tooltip)
 
     settingsButton.PerformLayout = function(panel)
-        panel:SetSize(panel:GetParent():GetWide(), heightNavButton)
+        panel:SetSize(panel:GetParent():GetWide(), heightNavButton * appearance.GetGlobalScale())
     end
 
     settingsButton.DoClick = function(slf)
@@ -125,14 +127,16 @@ function PANEL:GenerateSubmenuList(submenuClasses)
     self.navAreaScrollGrid:Clear()
     self.contentArea:Clear()
 
+    local scale = appearance.GetGlobalScale()
+
     if #submenuClasses == 0 then
         local labelNoContent = vgui.Create("DLabelTTT2", self.contentArea)
         local widthContent = self.contentArea:GetSize()
 
         labelNoContent:SetText("label_menu_not_populated")
-        labelNoContent:SetSize(widthContent - 40, 50)
+        labelNoContent:SetSize(widthContent - 40 * scale, 50 * scale)
         labelNoContent:SetFont("DermaTTT2Title")
-        labelNoContent:SetPos(20, 0)
+        labelNoContent:SetPos(20 * scale, 0)
     else
         for i = 1, #submenuClasses do
             local submenuClass = submenuClasses[i]
@@ -186,11 +190,12 @@ end
 function PANEL:PerformLayout()
     -- First invalidate Parent to get current correct docking size
     self:InvalidateParent(true)
+    local scale = appearance.GetGlobalScale()
 
     local widthNavContent, heightNavContent = self:GetSize()
-    local heightShift = heightNavHeader + (self.searchBar and heightNavButton + self.padding or 0)
+    local heightShift = heightNavHeader * scale + (self.searchBar and heightNavButton * scale + self.padding or 0)
 
-    self:SetSearchBarSize(widthNavContent, heightNavButton)
+    self:SetSearchBarSize(widthNavContent, heightNavButton * scale)
     self.navAreaScroll:SetSize(widthNavContent, heightNavContent - heightShift)
 
     -- Last invalidate all buttons and then the scrolllist for correct size to contents

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dsubmenulist_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dsubmenulist_ttt2.lua
@@ -193,7 +193,8 @@ function PANEL:PerformLayout()
     local scale = appearance.GetGlobalScale()
 
     local widthNavContent, heightNavContent = self:GetSize()
-    local heightShift = heightNavHeader * scale + (self.searchBar and heightNavButton * scale + self.padding or 0)
+    local heightShift = heightNavHeader * scale
+        + (self.searchBar and heightNavButton * scale + self.padding or 0)
 
     self:SetSearchBarSize(widthNavContent, heightNavButton * scale)
     self.navAreaScroll:SetSize(widthNavContent, heightNavContent - heightShift)

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dtooltip_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dtooltip_ttt2.lua
@@ -43,19 +43,22 @@ function PANEL:PerformLayout()
         return
     end
 
+    local scale = appearance.GetGlobalScale()
+
     if self.targetPanel:HasTooltipFixedSize() then
         self:SetSize(self.targetPanel:GetTooltipFixedSize())
     elseif IsValid(self.contents) then
-        self:SetWide(self.contents:GetWide() + 8)
-        self:SetTall(self.contents:GetTall() + 8)
+        self:SetWide(self.contents:GetWide() + 8 * scale)
+        self:SetTall(self.contents:GetTall() + 8 * scale)
     else
-        local w, h = draw.GetTextSize(LANG.TryTranslation(self:GetText()), self:GetFont())
+        local font, fontScale = fonts.ScaledFont(self:GetFont(), scale)
+        local w, h = draw.GetTextSize(LANG.TryTranslation(self:GetText()), font)
 
-        self:SetSize(w + 20, h + 8 + self.targetPanel.tooltip.sizeArrow)
+        self:SetSize(w * fontScale + 20 * scale, h * fontScale + 8 * scale + self.targetPanel.tooltip.sizeArrow)
     end
 
     if IsValid(self.contents) then
-        self.contents:SetPos(1, self.targetPanel.tooltip.sizeArrow + 1)
+        self.contents:SetPos(1 * scale, self.targetPanel.tooltip.sizeArrow + 1 * scale)
         self.contents:SetVisible(true)
     end
 end
@@ -82,6 +85,7 @@ function PANEL:PositionTooltip()
 
     self:InvalidateLayout(true)
 
+    local scale = appearance.GetGlobalScale()
     local x, y
 
     if self.targetPanel:HasTooltipFixedPosition() then
@@ -93,8 +97,8 @@ function PANEL:PositionTooltip()
     else
         x, y = input.GetCursorPos()
 
-        x = x + 10
-        y = y + 20
+        x = x + 10 * scale
+        y = y + 20 * scale
     end
 
     self:SetPos(x, y)

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dtooltip_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dtooltip_ttt2.lua
@@ -54,7 +54,10 @@ function PANEL:PerformLayout()
         local font, fontScale = fonts.ScaledFont(self:GetFont(), scale)
         local w, h = draw.GetTextSize(LANG.TryTranslation(self:GetText()), font)
 
-        self:SetSize(w * fontScale + 20 * scale, h * fontScale + 8 * scale + self.targetPanel.tooltip.sizeArrow)
+        self:SetSize(
+            w * fontScale + 20 * scale,
+            h * fontScale + 8 * scale + self.targetPanel.tooltip.sizeArrow
+        )
     end
 
     if IsValid(self.contents) then

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dtooltip_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dtooltip_ttt2.lua
@@ -52,7 +52,7 @@ function PANEL:PerformLayout()
         self:SetTall(self.contents:GetTall() + 8 * scale)
     else
         local font, fontScale = fonts.ScaledFont(self:GetFont(), scale)
-        local w, h = draw.GetTextSize(LANG.TryTranslation(self:GetText()), font)
+        local w, h = draw.GetTextSize(LANG.TryTranslation(self:GetText()), font, fontScale)
 
         self:SetSize(
             w * fontScale + 20 * scale,

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dvscrollbar_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dvscrollbar_ttt2.lua
@@ -14,7 +14,8 @@ function PANEL:Init()
 
     self.btnGrip = vgui.Create("DScrollBarGrip", self)
 
-    self:SetSize(15, 15)
+    local scale = appearance.GetGlobalScale()
+    self:SetSize(15 * scale, 15 * scale)
 end
 
 ---
@@ -91,7 +92,8 @@ end
 function PANEL:AddScroll(dlta)
     local oldScroll = self:GetScroll()
 
-    dlta = dlta * 25
+    local scale = appearance.GetGlobalScale()
+    dlta = dlta * 25 * scale
 
     self:SetScroll(self:GetScroll() + dlta)
 
@@ -229,8 +231,9 @@ end
 function PANEL:PerformLayout()
     local wide = self:GetWide()
 
-    local barSize = math.max(self:BarScale() * self:GetTall(), 10)
-    local track = self:GetTall() - barSize + 1
+    local scale = appearance.GetGlobalScale()
+    local barSize = math.max(self:BarScale() * self:GetTall(), 10 * scale)
+    local track = self:GetTall() - barSize + 1 * scale
     local scroll = self:GetScroll() / self.canvasSize * track
 
     self.btnGrip:SetPos(0, scroll)

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dweaponpreview_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dweaponpreview_ttt2.lua
@@ -64,9 +64,11 @@ function PANEL:Init()
     self.directionalLight = {}
     self.farZ = 4096
 
-    self:SetContentAlignment(5)
+    local scale = appearance.GetGlobalScale()
 
-    self:SetTall(22)
+    self:SetContentAlignment(5 * scale)
+
+    self:SetTall(22 * scale)
 
     self:SetFont("DermaTTT2TextLarge")
 

--- a/lua/terrortown/menus/gamemode/administration/rolelayering.lua
+++ b/lua/terrortown/menus/gamemode/administration/rolelayering.lua
@@ -118,17 +118,18 @@ hook.Add("TTT2ReceivedRolelayerData", "received_layer_data", function(role, laye
 
     local basePanel = menuReference.forms[role]:MakeIconLayout()
 
+    local scale = appearance.GetGlobalScale()
     local dragSender = basePanel:Add("DRoleLayeringSenderTTT2")
-    dragSender:SetLeftMargin(108)
+    dragSender:SetLeftMargin(108 * scale)
     dragSender:Dock(TOP)
-    dragSender:SetPadding(5)
+    dragSender:SetPadding(5 * scale)
     dragSender:MakeDroppable("drop_group_" .. role)
 
     -- modify the dragReceiver
     local dragReceiver = basePanel:Add("DRoleLayeringReceiverTTT2")
-    dragReceiver:SetLeftMargin(108)
+    dragReceiver:SetLeftMargin(108 * scale)
     dragReceiver:Dock(TOP)
-    dragReceiver:SetPadding(5)
+    dragReceiver:SetPadding(5 * scale)
     dragReceiver:MakeDroppable("drop_group_" .. role)
     dragReceiver:InitRoles(layerTable)
     dragReceiver.OnLayerUpdated = function(slf)
@@ -142,11 +143,11 @@ hook.Add("TTT2ReceivedRolelayerData", "received_layer_data", function(role, laye
         local roleData = roles.GetByIndex(subrole)
 
         local ic = vgui.Create("DRoleImageTTT2", dragSender)
-        ic:SetSize(64, 64)
+        ic:SetSize(64 * scale, 64 * scale)
         ic:SetMaterial(roleData.iconMaterial)
         ic:SetColor(roleData.color)
         ic:SetTooltip(roleData.name)
-        ic:SetTooltipFixedPosition(0, 64)
+        ic:SetTooltipFixedPosition(0, 64 * scale)
 
         ic.subrole = subrole
 

--- a/lua/terrortown/menus/gamemode/changelog/base_changelog.lua
+++ b/lua/terrortown/menus/gamemode/changelog/base_changelog.lua
@@ -8,12 +8,13 @@ local htmlStart = [[
                 background-color: rgb(22, 42, 57);
                 color: white;
                 font-weight: 100;
+                --ui-scale: /*TTT2-UISCALE*/;
             }
             body * {
-                font-size: 13pt;
+                font-size: calc(13pt * var(--ui-scale));
             }
             h1 {
-                font-size: 16pt;
+                font-size: calc(16pt * var(--ui-scale));
                 text-decoration: underline;
             }
         </style>
@@ -38,7 +39,8 @@ function CLGAMEMODESUBMENU:Populate(parent)
     header = header .. "</h1>"
 
     local html = vgui.Create("DHTML", parent)
-    html:SetSize(500, 640)
+    local scale = appearance.GetGlobalScale()
+    html:SetSize(500 * scale, 640 * scale)
     html:Dock(FILL)
-    html:SetHTML(htmlStart .. header .. self.change.text .. htmlEnd)
+    html:SetHTML(string.Replace(htmlStart, "/*TTT2-UISCALE*/", tostring(scale)) .. header .. self.change.text .. htmlEnd)
 end

--- a/lua/terrortown/menus/gamemode/changelog/base_changelog.lua
+++ b/lua/terrortown/menus/gamemode/changelog/base_changelog.lua
@@ -42,5 +42,10 @@ function CLGAMEMODESUBMENU:Populate(parent)
     local scale = appearance.GetGlobalScale()
     html:SetSize(500 * scale, 640 * scale)
     html:Dock(FILL)
-    html:SetHTML(string.Replace(htmlStart, "/*TTT2-UISCALE*/", tostring(scale)) .. header .. self.change.text .. htmlEnd)
+    html:SetHTML(
+        string.Replace(htmlStart, "/*TTT2-UISCALE*/", tostring(scale))
+            .. header
+            .. self.change.text
+            .. htmlEnd
+    )
 end

--- a/lua/terrortown/menus/score/info.lua
+++ b/lua/terrortown/menus/score/info.lua
@@ -4,14 +4,15 @@ local TryT = LANG.TryTranslation
 local ParT = LANG.GetParamTranslation
 local IsKarmaEnabled = KARMA.IsEnabled
 
-local function GetPanelTextSize(pnl)
-    surface.SetFont(pnl:GetTitleFont())
-    return surface.GetTextSize(TryT(pnl:GetTitle()))
+local function GetPanelTextSize(pnl, scale)
+    scale = scale or 1.0
+    local font, fscale = fonts.ScaledFont(pnl:GetTitleFont(), scale)
+    return draw.GetTextSize(TryT(pnl:GetTitle()), font, fscale)
 end
 
-local function MakePlayerGenericTooltip(parent, ply, items, title)
-    local initTitleHeight = 25
-    local lineHeight = 20
+local function MakePlayerGenericTooltip(parent, ply, items, title, sizes)
+    local initTitleHeight = 25 * sizes.scale
+    local lineHeight = 20 * sizes.scale
     local iconOffset = (
         (lineHeight - 2 * math.Round(0.1 * lineHeight)) + 4 * math.Round(0.1 * lineHeight)
     )
@@ -24,7 +25,7 @@ local function MakePlayerGenericTooltip(parent, ply, items, title)
     titleBox:SetTitle(title)
     titleBox:SetTitleAlign(TEXT_ALIGN_LEFT)
 
-    local lengthLongestLine, titleHeight = GetPanelTextSize(titleBox)
+    local lengthLongestLine, titleHeight = GetPanelTextSize(titleBox, sizes.scale)
     local height = math.max(initTitleHeight, titleHeight)
     titleBox:SetHeight(height)
 
@@ -37,7 +38,7 @@ local function MakePlayerGenericTooltip(parent, ply, items, title)
             plyRow:SetTitle(thing.title)
         end
 
-        local rowWidth, rowHeight = GetPanelTextSize(plyRow)
+        local rowWidth, rowHeight = GetPanelTextSize(plyRow, sizes.scale)
 
         if thing.iconMaterial then
             plyRow:SetIcon(thing.iconMaterial)
@@ -200,11 +201,12 @@ local function PopulatePlayerView(parent, sizes, columnData, columnTeams, showDe
                     plyRolesTooltipPanel,
                     ply,
                     roleBucket,
-                    "tooltip_roles_time"
+                    "tooltip_roles_time",
+                    sizes
                 )
 
                 plyNameBox:SetTooltipPanel(plyRolesTooltipPanel)
-                plyNameBox:SetTooltipFixedPosition(0, sizes.heightRow + 1)
+                plyNameBox:SetTooltipFixedPosition(0, sizes.heightRow + 1 * sizes.scale)
                 plyNameBox:SetTooltipFixedSize(widthRolesTooltip, heightRolesTooltip)
                 plyRolesTooltipPanel:SetSize(widthRolesTooltip, heightRolesTooltip)
 
@@ -229,11 +231,12 @@ local function PopulatePlayerView(parent, sizes, columnData, columnTeams, showDe
                         plyKarmaTooltipPanel,
                         ply,
                         karmaBucket,
-                        "tooltip_karma_gained"
+                        "tooltip_karma_gained",
+                        sizes
                     )
 
                     plyKarmaBox:SetTooltipPanel(plyKarmaTooltipPanel)
-                    plyKarmaBox:SetTooltipFixedPosition(0, sizes.heightRow + 1)
+                    plyKarmaBox:SetTooltipFixedPosition(0, sizes.heightRow + 1 * sizes.scale)
                     plyKarmaBox:SetTooltipFixedSize(widthKarmaTooltip, heightKarmaTooltip)
                     plyKarmaTooltipPanel:SetSize(widthKarmaTooltip, heightKarmaTooltip)
                 end
@@ -289,11 +292,12 @@ local function PopulatePlayerView(parent, sizes, columnData, columnTeams, showDe
                     plyScoreTooltipPanel,
                     ply,
                     scoreBucket,
-                    "tooltip_score_gained"
+                    "tooltip_score_gained",
+                    sizes
                 )
 
                 plyPointsBox:SetTooltipPanel(plyScoreTooltipPanel)
-                plyPointsBox:SetTooltipFixedPosition(0, sizes.heightRow + 1)
+                plyPointsBox:SetTooltipFixedPosition(0, sizes.heightRow + 1 * sizes.scale)
                 plyPointsBox:SetTooltipFixedSize(widthScoreTooltip, heightScoreTooltip)
                 plyScoreTooltipPanel:SetSize(widthScoreTooltip, heightScoreTooltip)
             end

--- a/lua/ttt2/extensions/draw.lua
+++ b/lua/ttt2/extensions/draw.lua
@@ -49,7 +49,7 @@ end
 -- @2D
 -- @realm client
 function draw.OutlinedBox(x, y, w, h, t, color)
-    t = t or 1
+    t = t or 1 * appearance.GetGlobalScale()
 
     surface.SetDrawColor(color or COLOR_WHITE)
 
@@ -420,11 +420,10 @@ local drawShadowedText = draw.ShadowedText
 function draw.AdvancedText(text, font, x, y, color, xalign, yalign, shadow, scale, angle)
     local scaleModifier = 1.0
     local t_font = fonts.GetFont(font)
+    scale = scale or 1.0
 
     if t_font then
-        scaleModifier = fonts.GetScaleModifier(scale)
-        font = t_font[scaleModifier]
-        scale = scale / scaleModifier
+        font, scale, scaleModifier = fonts.ScaledFont(font, scale, t_font)
     end
 
     local scaled = isvector(scale) or scale ~= 1.0

--- a/lua/ttt2/libraries/fonts.lua
+++ b/lua/ttt2/libraries/fonts.lua
@@ -99,8 +99,10 @@ function fonts.ScaledFont(font, scale, t_font)
         scale = appearance.GetGlobalScale()
     end
     t_font = t_font or fonts.GetFont(font)
-    local scaleModifier = fonts.GetScaleModifier(scale)
-    font = t_font[scaleModifier]
-    scale = scale / scaleModifier
+    if t_font then
+        local scaleModifier = fonts.GetScaleModifier(scale)
+        font = t_font[scaleModifier]
+        scale = scale / scaleModifier
+    end
     return font, scale, scaleModifier
 end

--- a/lua/ttt2/libraries/fonts.lua
+++ b/lua/ttt2/libraries/fonts.lua
@@ -20,6 +20,24 @@ fonts = {}
 fonts.fonts = {}
 fonts.scales = { 1, 1.5, 2, 2.5 }
 
+-- If we already have the global scale cvar, make sure that it is in the fonst scales list
+local function AddScale(scale)
+    for i = 1, #fonts.scales do
+        if scale == fonts.scales[i] then
+            -- the scale already exists in the list, nothing to do
+            return
+        end
+        if scale < fonts.scales[i] then
+            table.insert(fonts.scales, i, scale)
+            return
+        end
+    end
+end
+local cv_scale = GetConVar("ttt2_resolution_scale")
+if cv_scale then
+    AddScale(cv_scale:GetFloat() or 1.0)
+end
+
 ---
 -- Gets the scale modifer based on a given scale. This function tries to find one of
 -- the given steps defined in `fonts.scales` that fits best to the given scale. If it

--- a/lua/ttt2/libraries/fonts.lua
+++ b/lua/ttt2/libraries/fonts.lua
@@ -85,3 +85,22 @@ end
 function fonts.GetScales()
     return fonts.scales
 end
+
+---
+-- Gets the scaled variant of a font.
+-- @param string name The font name
+-- @param number[default=appearance.GetGlobalScale()] scale The target scale
+-- @return string The name of the scaled font
+-- @return number The scale that the font needs to be rendered at to exactly match the target scale
+-- @return number The font scale modifier
+-- @realm client
+function fonts.ScaledFont(font, scale, t_font)
+    if not scale then
+        scale = appearance.GetGlobalScale()
+    end
+    t_font = t_font or fonts.GetFont(font)
+    local scaleModifier = fonts.GetScaleModifier(scale)
+    font = t_font[scaleModifier]
+    scale = scale / scaleModifier
+    return font, scale, scaleModifier
+end

--- a/lua/ttt2/libraries/vskin.lua
+++ b/lua/ttt2/libraries/vskin.lua
@@ -248,10 +248,10 @@ function vskin.GetShadowSize()
     local vskinObject = vskin.skins[vskin.GetVSkinName()]
 
     if not vskinObject then
-        return 5
+        return 5 * appearance.GetGlobalScale()
     end
 
-    return vskinObject.params.shadow_size
+    return vskinObject.params.shadow_size * appearance.GetGlobalScale()
 end
 
 ---
@@ -262,10 +262,10 @@ function vskin.GetHeaderHeight()
     local vskinObject = vskin.skins[vskin.GetVSkinName()]
 
     if not vskinObject then
-        return 45
+        return 45 * appearance.GetGlobalScale()
     end
 
-    return vskinObject.params.header_height
+    return vskinObject.params.header_height * appearance.GetGlobalScale()
 end
 
 ---
@@ -276,10 +276,10 @@ function vskin.GetCollapsableHeight()
     local vskinObject = vskin.skins[vskin.GetVSkinName()]
 
     if not vskinObject then
-        return 30
+        return 30 * appearance.GetGlobalScale()
     end
 
-    return vskinObject.params.collapsable_height
+    return vskinObject.params.collapsable_height * appearance.GetGlobalScale()
 end
 
 ---
@@ -290,10 +290,10 @@ function vskin.GetBorderSize()
     local vskinObject = vskin.skins[vskin.GetVSkinName()]
 
     if not vskinObject then
-        return 3
+        return 3 * appearance.GetGlobalScale()
     end
 
-    return vskinObject.params.border_size
+    return vskinObject.params.border_size * appearance.GetGlobalScale()
 end
 
 ---
@@ -304,10 +304,10 @@ function vskin.GetCornerRadius()
     local vskinObject = vskin.skins[vskin.GetVSkinName()]
 
     if not vskinObject then
-        return 6
+        return 6 * appearance.GetGlobalScale()
     end
 
-    return vskinObject.params.corner_radius
+    return vskinObject.params.corner_radius * appearance.GetGlobalScale()
 end
 
 ---


### PR DESCRIPTION
Currently, only the HUD is scaled. This is rather annoying for those with high DPI displays, as much of the text is too small to be readable. Instead, we want to present as much of our UI according to the user's specified UI scale as possible, which this PR does.

This unfortunately means threading `* scale` through a bunch of layout and skin code, and it also means that non-default skins will not work until updated (This is particularly onerous with the role debugger and embedded legacy VGUI menus). I tried, at first, implementing a fully-general system that would automatically attempt to scale things which are not hidpi-aware, but that NOT ONLY had terrible performance, but ALSO didn't work.

In the process of doing this, I also discovered that `draw.AdvancedText` was implemented fundamentally incorrectly, and have fixed it.

Some limitations:
- For some reason, I *cannot* convince `Panel:DrawTextEntryText()` to use a different font set dynamically or be scaled. Is `Panel:SetFont()` frame-delayed?
- Body search result items have their description currently hard-coded to `DermaDefault`, which doesn't have scaled variants and so looks bad (though it is scaled! I spent 3 whole days on this!)

Currently unchanged:
- Scoreboard
- Buy menu

I intend to continue this and apply scaling to the scoreboard as well, but I don't think the buy menu is reasonably possible without giving it a whole UI overhaul.

Before:
![Screenshot_20250118_024453](https://github.com/user-attachments/assets/f9548052-0a4f-40ba-abdb-9e41ed5ffb66)
![Screenshot_20250118_024459](https://github.com/user-attachments/assets/7a2d702c-2ddc-475f-98c2-5ab0febf0f23)
![Screenshot_20250118_024507](https://github.com/user-attachments/assets/0be16ea3-6fd5-4479-863b-12612b384bf8)
![Screenshot_20250118_024548](https://github.com/user-attachments/assets/a3b1ea99-0823-4204-b899-ecdb9f50bdbc)

After: (1.5x UI scale)
![Screenshot_20250118_025243](https://github.com/user-attachments/assets/5f515833-5d07-44ef-ac53-7128eb5f542e)
![Screenshot_20250118_025245](https://github.com/user-attachments/assets/739e01f4-7a7d-41dc-956e-61cefe1b423e)
![Screenshot_20250118_025250](https://github.com/user-attachments/assets/66c5c10d-2e40-4d32-872e-e060b99a05d4)
![Screenshot_20250118_025410](https://github.com/user-attachments/assets/3f78441f-c76e-4254-88c9-e94747352202)
