### PR TITLE
vgui: Reworked inheritance

### DIFF
--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dbutton_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dbutton_ttt2.lua
@@ -178,6 +178,10 @@ function PANEL:SetValue(val, ignoreCallbackEnabledVar)
     self:OnChange(self.value)
 end
 
+---
+-- @return boolean Returns the value of the button if there is one
+-- assigned. It can be assigned by attaching convars or database values.
+-- @realm client
 function PANEL:GetValue()
     return self.value or false
 end

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dbutton_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dbutton_ttt2.lua
@@ -12,6 +12,11 @@ local soundClick = Sound("common/talk.wav")
 AccessorFunc(PANEL, "m_bBorder", "DrawBorder", FORCE_BOOL)
 
 ---
+-- @accessor bool
+-- @realm client
+AccessorFunc(PANEL, "ignoreCallbackEnabledVar", "IgnoreCallbackEnabledVar", FORCE_BOOL)
+
+---
 -- @ignore
 function PANEL:Init()
     self:SetContentAlignment(5)
@@ -52,6 +57,193 @@ function PANEL:Init()
         end
     end)
 end
+
+---
+-- This is only used temporarily to keep old variables without breaking the style of "no enable to disable" checkboxes
+-- @param bool invert
+-- @realm client
+function PANEL:SetInverted(invert)
+    self.inverted = invert
+end
+
+---
+-- @param string cvar
+-- @realm client
+function PANEL:SetConVar(cvar)
+    if not ConVarExists(cvar or "") then
+        return
+    end
+
+    self:SetDefaultValue(tobool(GetConVar(cvar):GetDefault()))
+end
+
+local callbackEnabledVarTracker = 0
+---
+-- @param string cvar
+-- @realm client
+function PANEL:SetServerConVar(cvar)
+    if not cvar or cvar == "" then
+        return
+    end
+
+    self.serverConVar = cvar
+
+    -- Check if self is valid before calling SetValue.
+    cvars.ServerConVarGetValue(cvar, function(wasSuccess, value, default)
+        if wasSuccess and IsValid(self) then
+            self:SetValue(tobool(value), true)
+            self:SetDefaultValue(tobool(default))
+        end
+    end)
+
+    callbackEnabledVarTracker = callbackEnabledVarTracker + 1
+    local myIdentifierString = "TTT2CheckBoxConVarChangeCallback"
+        .. tostring(callbackEnabledVarTracker)
+
+    local callback = function(conVarName, oldValue, newValue)
+        if not IsValid(self) then
+            -- We need to remove the callback in a timer, because otherwise the ConVar change callback code
+            -- will throw an error while looping over the callbacks.
+            -- This happens, because the callback is removed from the same table that is iterated over.
+            -- Thus, the table size changes while iterating over it and leads to a nil callback as the last entry.
+            timer.Simple(0, function()
+                cvars.RemoveChangeCallback(conVarName, myIdentifierString)
+            end)
+
+            return
+        end
+
+        self:SetValue(tobool(newValue), true)
+    end
+
+    cvars.AddChangeCallback(cvar, callback, myIdentifierString)
+end
+
+---
+-- @param table databaseInfo containing {name, itemName, key}
+-- @realm client
+function PANEL:SetDatabase(databaseInfo)
+    if not istable(databaseInfo) then
+        return
+    end
+
+    local name = databaseInfo.name
+    local itemName = databaseInfo.itemName
+    local key = databaseInfo.key
+
+    if not name or not itemName or not key then
+        return
+    end
+
+    self.databaseInfo = databaseInfo
+
+    database.GetValue(name, itemName, key, function(databaseExists, value)
+        if databaseExists then
+            self:SetValue(value, true)
+        end
+    end)
+
+    self:SetDefaultValue(database.GetDefaultValue(name, itemName, key))
+
+    callbackEnabledVarTracker = callbackEnabledVarTracker + 1
+    local myIdentifierString = "TTT2CheckBoxDatabaseChangeCallback"
+        .. tostring(callbackEnabledVarTracker)
+
+    local function OnDatabaseChangeCallback(_name, _itemName, _key, oldValue, newValue)
+        if not IsValid(self) then
+            database.RemoveChangeCallback(name, itemName, key, myIdentifierString)
+
+            return
+        end
+
+        self:SetValue(newValue, true)
+    end
+
+    database.AddChangeCallback(name, itemName, key, OnDatabaseChangeCallback, myIdentifierString)
+end
+
+---
+-- @param any val
+-- @param boolean ignoreCallbackEnabledVar To avoid endless loops, separated setting of convars and UI values
+-- @realm client
+function PANEL:SetValue(val, ignoreCallbackEnabledVar)
+    self:SetIgnoreCallbackEnabledVar(ignoreCallbackEnabledVar)
+
+    if self.inverted then
+        val = not val
+    end
+
+    self.value = val
+
+    self:OnChange(self.value)
+end
+
+function PANEL:GetValue()
+    return self.value or false
+end
+
+---
+-- @param boolean value
+-- @realm client
+function PANEL:SetDefaultValue(value)
+    if isbool(value) then
+        -- note: even when it is inverted, the default is not inverted here
+        -- as it is inverted when the default button is pressed
+
+        self.default = value
+
+        noDefault = false
+    else
+        self.default = nil
+    end
+end
+
+---
+-- @return boolean defaultValue, if unset returns false
+-- @realm client
+function PANEL:GetDefaultValue()
+    return tobool(self.default)
+end
+
+---
+-- @param any val
+-- @realm client
+function PANEL:ValueChanged(val)
+    if self.inverted then
+        val = not val
+    end
+
+    if self.serverConVar and not self:GetIgnoreCallbackEnabledVar() then
+        cvars.ChangeServerConVar(self.serverConVar, val and "1" or "0")
+    elseif self.databaseInfo and not self:GetIgnoreCallbackEnabledVar() then
+        database.SetValue(
+            self.databaseInfo.name,
+            self.databaseInfo.itemName,
+            self.databaseInfo.key,
+            val
+        )
+    else
+        self:SetIgnoreCallbackEnabledVar(false)
+    end
+
+    self:OnValueChanged(val)
+end
+
+---
+-- overwrites the base function with an empty function
+-- @param any val
+-- @realm client
+function PANEL:OnValueChanged(val) end
+
+---
+-- @param any val
+-- @realm client
+function PANEL:OnChange(val) end
+
+---
+-- @param any val
+-- @realm client
+function PANEL:OnDefaultChange(val) end
 
 ---
 -- @return string

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dlabel_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dlabel_ttt2.lua
@@ -77,6 +77,23 @@ function PANEL:Init()
     -- Nicer default height
     self:SetTall(20)
 
+    self.tooltip = {
+        fixedPosition = nil,
+        fixedSize = nil,
+        delay = 0,
+        text = "",
+        font = "DermaTTT2Text",
+        sizeArrow = 8,
+    }
+
+    local oldSetTooltipPanel = self.SetTooltipPanel
+
+    self.SetTooltipPanel = function(slf, panel)
+        slf:SetTooltipPanelOverride("DTooltipTTT2")
+
+        oldSetTooltipPanel(slf, panel)
+    end
+
     -- This turns off the engine drawing
     self:SetPaintBackgroundEnabled(false)
     self:SetPaintBorderEnabled(false)
@@ -343,5 +360,106 @@ function PANEL:DoDoubleClick() end
 -- overwrites the base function with an empty function
 -- @realm client
 function PANEL:DoDoubleClickInternal() end
+
+---
+-- @param number x
+-- @param number y
+-- @realm client
+function PANEL:SetTooltipFixedPosition(x, y)
+    self.tooltip.fixedPosition = {
+        x = x,
+        y = y,
+    }
+end
+
+---
+-- @return number, number
+-- @realm client
+function PANEL:GetTooltipFixedPosition()
+    return self.tooltip.fixedPosition.x, self.tooltip.fixedPosition.y
+end
+
+---
+-- @return boolean
+-- @realm client
+function PANEL:HasTooltipFixedPosition()
+    return self.tooltip.fixedPosition ~= nil
+end
+
+---
+-- @param number w
+-- @param number h
+-- @realm client
+function PANEL:SetTooltipFixedSize(w, h)
+    -- +2 are the outline pixels
+    self.tooltip.fixedSize = {
+        w = w + 2,
+        h = h + self.tooltip.sizeArrow + 2,
+    }
+end
+
+---
+-- @return number, number
+-- @realm client
+function PANEL:GetTooltipFixedSize()
+    return self.tooltip.fixedSize.w, self.tooltip.fixedSize.h
+end
+
+---
+-- @realm client
+function PANEL:HasTooltipFixedSize()
+    return self.tooltip.fixedSize ~= nil
+end
+
+---
+-- @param number delay
+-- @realm client
+function PANEL:SetTooltipOpeningDelay(delay)
+    self.tooltip.delay = delay
+end
+
+---
+-- @return number
+-- @realm client
+function PANEL:GetTooltipOpeningDelay()
+    return self.tooltip.delay
+end
+
+---
+-- @param string text
+-- @realm client
+function PANEL:SetTooltip(text)
+    self:SetTooltipPanelOverride("DTooltipTTT2")
+
+    self.tooltip.text = text
+end
+
+---
+-- @return string
+-- @realm client
+function PANEL:GetTooltipText()
+    return self.tooltip.text
+end
+
+---
+-- @return boolean
+-- @realm client
+function PANEL:HasTooltipText()
+    return self.tooltip.text ~= nil and self.tooltip.text ~= ""
+end
+
+---
+-- @param string font
+-- @realm client
+function PANEL:SetTooltipFont(font)
+    self.tooltip.font = font
+end
+
+---
+-- @return string
+-- @realm client
+function PANEL:GetTooltipFont()
+    return self.tooltip.font
+end
 
 derma.DefineControl("DLabelTTT2", "A Label", PANEL, "DLabel")

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/droleimage_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/droleimage_ttt2.lua
@@ -40,6 +40,8 @@ function PANEL:GetMaterial()
     return self.data.material
 end
 
+---
+-- @realm client
 function PANEL:DoRightClick()
     local newValue = not self:GetValue()
 

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/droleimage_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/droleimage_ttt2.lua
@@ -40,6 +40,13 @@ function PANEL:GetMaterial()
     return self.data.material
 end
 
+function PANEL:DoRightClick()
+    local newValue = not self:GetValue()
+
+    self:SetValue(newValue)
+    self:ValueChanged(newValue)
+end
+
 ---
 -- @ignore
 function PANEL:Paint(w, h)
@@ -48,4 +55,4 @@ function PANEL:Paint(w, h)
     return true
 end
 
-derma.DefineControl("DRoleImageTTT2", "A simple role image", PANEL, "DPanelTTT2")
+derma.DefineControl("DRoleImageTTT2", "A simple role image", PANEL, "DButtonTTT2")

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/droleimage_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/droleimage_ttt2.lua
@@ -41,15 +41,6 @@ function PANEL:GetMaterial()
 end
 
 ---
--- @realm client
-function PANEL:DoRightClick()
-    local newValue = not self:GetValue()
-
-    self:SetValue(newValue)
-    self:ValueChanged(newValue)
-end
-
----
 -- @ignore
 function PANEL:Paint(w, h)
     derma.SkinHook("Paint", "RoleImageTTT2", self, w, h)

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dsubmenulist_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dsubmenulist_ttt2.lua
@@ -126,7 +126,10 @@ function PANEL:AddSubmenuButton(submenuClass)
     settingsButton:SetIcon(submenuClass.icon, submenuClass.iconFullSize)
     settingsButton:SetIconBadge(submenuClass.iconBadge)
     settingsButton:SetIconBadgeSize(submenuClass.iconBadgeSize)
-    settingsButton:SetTooltip(submenuClass.tooltip)
+
+    if submenuClass.tooltip then
+        settingsButton:SetTooltip(submenuClass.tooltip)
+    end
 
     settingsButton.PerformLayout = function(panel)
         panel:SetSize(panel:GetParent():GetWide(), heightNavButton)


### PR DESCRIPTION
This PR adds no new code or new functionality, it only moves code around in files so that everything that inherits from buttons can use (server) convars. Therefore the code from the ttt2 checkboxlabel was moved to button. This caused this change to track the underlying button in those labels:

![image](https://github.com/user-attachments/assets/afeef60e-1d7d-4b66-b44f-15f4ec827ce8)

Moreover I added our tooltip code from the panel to the label as well, as both of these are a starting point for the inheritance that can't be merged.

I'd appreaciate a quick merge so that #1715 can be finished.

Also note, that there are MANY things that could be further improved by improving the inheritance. This only tackles a small part of that.