### PR TITLE
vgui: Toggleable Role Indicator

### DIFF
--- a/gamemodes/terrortown/gamemode/client/cl_vskin/default_skin.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/default_skin.lua
@@ -1777,6 +1777,10 @@ function SKIN:PaintRoleImageTTT2(panel, w, h)
         )
     end
 
+    if not panel:IndicatorEnabled() then
+        return
+    end
+
     drawRoundedBoxEx(
         sizes.cornerRadius,
         w - sizeMode,

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/droleimage_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/droleimage_ttt2.lua
@@ -9,6 +9,7 @@ function PANEL:Init()
     self.data = {
         color = COLOR_WHITE,
         icon = nil,
+        indicatorState = false,
     }
 end
 
@@ -47,6 +48,20 @@ function PANEL:DoRightClick()
 
     self:SetValue(newValue)
     self:ValueChanged(newValue)
+end
+
+---
+-- param boolean state
+-- @realm client
+function PANEL:EnableIndicator(state)
+    self.data.indicatorState = state
+end
+
+---
+-- @return boolean
+-- @realm client
+function PANEL:IndicatorEnabled()
+    return self.data.indicatorState or false
 end
 
 ---

--- a/lua/terrortown/menus/gamemode/roles/rolelayering.lua
+++ b/lua/terrortown/menus/gamemode/roles/rolelayering.lua
@@ -153,6 +153,7 @@ hook.Add("TTT2ReceivedRolelayerData", "received_layer_data", function(role, laye
         ic:SetTooltip(roleData.name)
         ic:SetTooltipFixedPosition(0, 64)
         ic:SetServerConVar("ttt_" .. roleData.name .. "_enabled")
+        ic:EnableIndicator(true)
 
         ic.subrole = subrole
 


### PR DESCRIPTION
Added option to show and hide these indicators for `DRoleImageTTT2`.

![image](https://github.com/user-attachments/assets/87a6d233-2cf3-411b-a730-a1d4e923ef60)
