### PR TITLE
vGui: Fixed Clientside ConVars & Small Misc Fixes

### DIFF
--- a/gamemodes/terrortown/gamemode/client/cl_vskin/default_skin.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/default_skin.lua
@@ -1768,8 +1768,8 @@ function SKIN:PaintRoleImageTTT2(panel, w, h)
         drawFilteredShadowedTexture(
             widthBorder,
             widthBorder,
-            sizeIconRole - widthBorder2,
-            sizeIconRole - widthBorder2,
+            sizeIconRole,
+            sizeIconRole,
             panel:GetMaterial(),
             colorIcon.a,
             colorIcon
@@ -1778,8 +1778,8 @@ function SKIN:PaintRoleImageTTT2(panel, w, h)
         drawFilteredTexture(
             widthBorder,
             widthBorder,
-            sizeIconRole - widthBorder2,
-            sizeIconRole - widthBorder2,
+            sizeIconRole,
+            sizeIconRole,
             panel:GetMaterial(),
             colorIcon.a * 0.5,
             colorIcon

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dbutton_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dbutton_ttt2.lua
@@ -74,7 +74,10 @@ function PANEL:SetConVar(cvar)
         return
     end
 
-    self:SetDefaultValue(tobool(GetConVar(cvar):GetDefault()))
+    self.convar = GetConVar(cvar)
+
+    self:SetDefaultValue(tobool(self.convar:GetDefault()))
+    self:SetValue(self.convar:GetBool())
 end
 
 local callbackEnabledVarTracker = 0
@@ -217,7 +220,9 @@ function PANEL:ValueChanged(val)
         val = not val
     end
 
-    if self.serverConVar and not self:GetIgnoreCallbackEnabledVar() then
+    if self.convar then
+        self.convar:SetBool(val)
+    elseif self.serverConVar and not self:GetIgnoreCallbackEnabledVar() then
         cvars.ChangeServerConVar(self.serverConVar, val and "1" or "0")
     elseif self.databaseInfo and not self:GetIgnoreCallbackEnabledVar() then
         database.SetValue(

--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/drolelayeringreceiver_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/drolelayeringreceiver_ttt2.lua
@@ -236,7 +236,7 @@ function PANEL:InitRoles(layeredRoles)
             ic:SetTooltip(roleData.name)
             ic:SetTooltipFixedPosition(0, 64)
             ic:SetServerConVar("ttt_" .. roleData.name .. "_enabled")
-            ic:EnableIndicator(true)
+            ic:SetIsActiveIndicator(true)
 
             ic.subrole = subrole
 


### PR DESCRIPTION
fixes #1735

This issue was created since the cvar is now tracked in the "main button" not the checkbox button anymore. This worked fine for serverside settings with custom handling, as well as client settings that use function wrappers to set the convar (like vskin for example).

This change now correctly sets the stored convar. It feels a bit hacky to me to be honest, but only a full rewrite would resolve this. So it is probably fine.

I also noticed that [this requested change](https://github.com/TTT-2/TTT2/pull/1724#discussion_r1921642625) was not applied to all function calls, so I renamed the one remaining.

Last but not least, I noticed that the border radius was substracted twice.