### PR TITLE
Fixed Win-Score Breaking Roundend Screen

### DIFF
--- a/lua/terrortown/events/finish.lua
+++ b/lua/terrortown/events/finish.lua
@@ -122,7 +122,7 @@ function EVENT:CalculateScore()
             score_timelimit = wintype == WIN_TIMELIMIT and math.ceil(
                 otherAlivePlayers * roleData.score.timelimitMultiplier
             ) or 0,
-            score_win = wintype == team and roleData.score.winMultiplier,
+            score_win = wintype == team and roleData.score.winMultiplier or 0,
         })
     end
 end


### PR DESCRIPTION
In #1733 I said in a review comment that the fallback can be removed here: https://github.com/TTT-2/TTT2/pull/1733#discussion_r1923652492

However, this was not true. I misread the context of the code. This caused the issue reported in #1744.