### PR TITLE
VGui: Rework

### DIFF
--- a/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dlabel_ttt2.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dlabel_ttt2.lua
@@ -1,48 +1,38 @@
 ---
 -- @class PANEL
--- @section DLabelTTT2
+-- @section TTT2:DLabel
 
 local PANEL = {}
 
 ---
--- @accessor Color
--- @realm client
-AccessorFunc(PANEL, "m_colText", "TextColor")
-
----
--- @accessor Color
--- @realm client
-AccessorFunc(PANEL, "m_colTextStyle", "TextStyleColor")
-
----
 -- @accessor string
 -- @realm client
-AccessorFunc(PANEL, "m_FontName", "Font")
+AccessorFunc(PANEL, "m_FontName", "Font", true)
 
 ---
 -- @accessor boolean
 -- @realm client
-AccessorFunc(PANEL, "m_bDoubleClicking", "DoubleClickingEnabled", FORCE_BOOL)
+AccessorFunc(PANEL, "m_bDoubleClicking", "DoubleClickingEnabled", FORCE_BOOL, true)
 
 ---
 -- @accessor boolean
 -- @realm client
-AccessorFunc(PANEL, "m_bAutoStretchVertical", "AutoStretchVertical", FORCE_BOOL)
+AccessorFunc(PANEL, "m_bAutoStretchVertical", "AutoStretchVertical", FORCE_BOOL, true)
 
 ---
 -- @accessor boolean
 -- @realm client
-AccessorFunc(PANEL, "m_bIsMenuComponent", "IsMenu", FORCE_BOOL)
+AccessorFunc(PANEL, "m_bIsMenuComponent", "IsMenu", FORCE_BOOL) -- ??? needed in TTT2:DComboBox?
 
 ---
 -- @accessor boolean
 -- @realm client
-AccessorFunc(PANEL, "m_bBackground", "PaintBackground", FORCE_BOOL)
+AccessorFunc(PANEL, "m_bBackground", "PaintBackground", FORCE_BOOL) -- ??? needed in TTT2:DButton?
 
 ---
 -- @accessor boolean
 -- @realm client
-AccessorFunc(PANEL, "m_bIsToggle", "IsToggle", FORCE_BOOL)
+AccessorFunc(PANEL, "m_bIsToggle", "IsToggle", FORCE_BOOL, true)
 
 ---
 -- @accessor boolean
@@ -52,110 +42,273 @@ AccessorFunc(PANEL, "m_bToggle", "Toggle", FORCE_BOOL)
 ---
 -- @accessor boolean
 -- @realm client
-AccessorFunc(PANEL, "m_bBright", "Bright", FORCE_BOOL)
+AccessorFunc(PANEL, "m_bDepressed", "Depressed", FORCE_BOOL)
 
 ---
--- @accessor boolean
+-- @accessor string
 -- @realm client
-AccessorFunc(PANEL, "m_bDark", "Dark", FORCE_BOOL)
+AccessorFunc(PANEL, "m_PaintHookName", "PaintHookName", FORCE_STRING, true)
 
 ---
--- @accessor boolean
+-- @accessor table
 -- @realm client
-AccessorFunc(PANEL, "m_bHighlight", "Highlight", FORCE_BOOL)
+AccessorFunc(PANEL, "m_TextParams", "TextParams", nil, true)
+
+-- data attached to the panel is put in its own scope
+PANEL._eventListeners = {}
+PANEL._attached = {}
+PANEL._tooltip = {}
 
 ---
 -- @ignore
 function PANEL:Init()
+    -- enable the panel
+    self:SetEnabled(true)
+
+    -- disable toggling and set state to false
     self:SetIsToggle(false)
     self:SetToggle(false)
-    self:SetEnabled(true)
+
+    -- disable keyboard and mouse input
     self:SetMouseInputEnabled(false)
     self:SetKeyboardInputEnabled(false)
     self:SetDoubleClickingEnabled(true)
 
-    -- Nicer default height
-    self:SetTall(20)
-
-    self.tooltip = {
-        fixedPosition = nil,
-        fixedSize = nil,
-        delay = 0,
-        text = "",
-        font = "DermaTTT2Text",
-        sizeArrow = 8,
-    }
-
-    local oldSetTooltipPanel = self.SetTooltipPanel
-
-    self.SetTooltipPanel = function(slf, panel)
-        slf:SetTooltipPanelOverride("DTooltipTTT2")
-
-        oldSetTooltipPanel(slf, panel)
-    end
-
-    -- This turns off the engine drawing
+    -- turn off the engine drawing
     self:SetPaintBackgroundEnabled(false)
     self:SetPaintBorderEnabled(false)
 
+    -- set the default name for the paint hook
+    self:SetPaintHookName("LabelTTT2")
+
+    -- set visual defaults
+    self:SetTall(20)
     self:SetFont("DermaTTT2Text")
+
+    -- set the defaults for the tooltip
+    self:SetTooltipFixedPosition(nil)
+    self:SetTooltipFixedSize(nil)
+    self:SetTooltipOpeningDelay(0)
+    self:SetTooltipFont("DermaTTT2Text")
+    self:SetTooltipArrowSize(8)
+
+    -- some basic engine defined functions of panels have to be extended to
+    -- support method chaining
+    local _SetSize = self.SetSize
+    self.SetSize = function(slf, ...)
+        _SetSize(slf, ...)
+
+        return slf
+    end
+
+    local _SetPos = self.SetPos
+    self.SetPos = function(slf, ...)
+        _SetPos(slf, ...)
+
+        return slf
+    end
+
+    local _DockPadding = self.DockPadding
+    self.DockPadding = function(slf, ...)
+        _DockPadding(slf, ...)
+
+        return slf
+    end
+
+    local _DockMargin = self.DockMargin
+    self.DockMargin = function(slf, ...)
+        _DockMargin(slf, ...)
+
+        return slf
+    end
+
+    local _Dock = self.Dock
+    self.Dock = function(slf, ...)
+        _Dock(slf, ...)
+
+        return slf
+    end
+end
+
+-- SPECIAL FUNCTIONS TO HANDLE HOOKS AND EXTENDED FEATURES --
+
+---
+-- Used to register an event on the panel. This can be stuff such as "Click" etc.
+-- @param string eventName The name of the event
+-- @param function callback The callback function that is called in this event
+-- @return Panel Returns the panel itself
+-- @realm client
+function PANEL:On(eventName, callback)
+    self._eventListeners[eventName] = self._eventListeners[eventName] or {}
+
+    self._eventListeners[eventName][#self._eventListeners[eventName] + 1] = callback
+
+    return self
+end
+
+---
+-- Calls the functions on the hook table that are registered to this hook.
+-- @param string eventName The name of the event
+-- @return any Returns whatever the specific hook may return
+-- @internal
+-- @realm client
+function PANEL:TriggerOn(eventName, ...)
+    local eventTable = self._eventListeners[eventName]
+
+    if not eventTable then
+        return
+    end
+
+    for i = 1, #eventTable do
+        local returnValue = eventTable[i](...)
+
+        if returnValue ~= nil then
+            return returnValue
+        end
+    end
+end
+
+function PANEL:TriggerOnWith(eventName, ...)
+    self:TriggerOn(eventName, ...)
+
+    if isfunction(self["On" .. eventName]) then
+        return self["On" .. eventName](...)
+    end
+end
+
+function PANEL:TriggerDeprecatedEvent(eventName, ...)
+    if isfunction(self[eventName]) then
+        self[eventName](...)
+
+        ErrorNoHaltWithStack(
+            "[DEPRECATION WARNING]: Overwriting hooks for panels is no longer recommended, use PANEL:On() instead. Hook: "
+                .. eventName
+        )
+    end
+end
+
+---
+-- Used to register an action that happens after a set time afer initialization.
+-- @param number delay The delay in seconds when this should trigger
+-- @param function callback The callback function that is called after this time
+-- @return Panel Returns the panel itself
+-- @realm client
+function PANEL:After(delay, callback)
+    timer.Simple(delay, function()
+        if not IsValid(self) or not isfunction(callback) then
+            return
+        end
+
+        callback(self)
+    end)
+
+    return self
+end
+
+---
+-- Used to attach any data on the panel, this is mostly useful to pass it to
+-- the draw hook without defininig loads of setters and getters.
+-- @param string identifier A unique identifer to later access the data
+-- @param any data The data that should be attached
+-- @return Panel Returns the panel itself
+-- @realm client
+function PANEL:Attach(identifier, data)
+    self._attached[identifier] = data
+
+    return self
+end
+
+---
+-- Returns previously attached data if set.
+-- @param string identifier A unique identifer to access the data
+-- @return any The data that was attached to this identifier
+-- @realm client
+function PANEL:GetAttached(identifier)
+    return self._attached[identifier]
 end
 
 ---
 -- @ignore
 function PANEL:Paint(w, h)
-    derma.SkinHook("Paint", "LabelTTT2", self, w, h)
+    derma.SkinHook("Paint", self:GetPaintHookName(), self, w, h)
 
     return true
 end
 
+-- SET THE PRIMARY TO THE DEPENDENT --
+
 ---
--- @param Panel master
+-- Sets the primary of this panel which is then able to control this dependent.
+-- @param Panel primary The primary panel
+-- @return Panel Returns the panel itself
 -- @realm client
-function PANEL:SetMaster(master)
-    if not IsValid(master) then
-        return
+function PANEL:SetPrimary(primary)
+    if IsValid(primary) then
+        self.primary = primary
     end
 
-    self.master = master
+    return self
 end
 
 ---
--- @return number
+-- Returns the indentation margin based on the amount of primary levels above this deoendent.
+-- @return number The identation amount
 -- @realm client
 function PANEL:GetIndentationMargin()
-    if not IsValid(self.master) then
+    if not IsValid(self.primary) then
         return 0
     end
 
-    return 10 + self.master:GetIndentationMargin()
+    return 10 + self.primary:GetIndentationMargin()
 end
 
+-- SETTERS/GETTERS THAT SET BASIC PARAMETERS --
+
 ---
--- @param string strFont
+-- Sets the font of the label.
+-- @param string fontName The name of the font
+-- @return Panel Returns the panel itself
 -- @realm client
-function PANEL:SetFont(strFont)
-    self.m_FontName = strFont
+function PANEL:SetFont(fontName)
+    self.m_FontName = fontName
 
     self:SetFontInternal(self.m_FontName)
     self:ApplySchemeSettings()
+
+    return self
 end
 
 ---
--- Sets the param table used for the param translation.
--- @param table params
+-- Sets the enabled state of a disable-able panel object, such as a DButton or DTextEntry.
+-- @param boolean state Whether to enable or disable the panel object
+-- @return Panel Returns the panel itself
 -- @realm client
-function PANEL:SetTextParams(params)
-    self.params = params
+function PANEL:SetEnabled(state)
+    self.m_bEnabled = state
+
+    self:InvalidateLayout()
+
+    return self
 end
 
 ---
+-- Returns whether the the panel is enabled or disabled.
+-- @return boolean Whether the panel is enabled or disabled
 -- @realm client
-function PANEL:GetTextParams()
-    return self.params or {}
+function PANEL:IsEnabled()
+    return self.m_bEnabled
 end
 
 ---
+-- Returns whether the mouse button is pressed down on this panel.
+-- @return boolean Whether the mouse button is depressed
+-- @realm client
+function PANEL:IsDepressed()
+    return self.m_bDepressed
+end
+
+---
+-- Toggles the state of the panel.
 -- @realm client
 function PANEL:Toggle()
     if not self:GetIsToggle() then
@@ -163,74 +316,83 @@ function PANEL:Toggle()
     end
 
     self:SetToggle(not self:GetToggle())
-    self:OnToggled(self:GetToggle())
+
+    self:TriggerOnWithBase("Toggle", self:GetToggle())
 end
 
----
--- @param boolean bEnabled
--- @realm client
-function PANEL:SetEnabled(bEnabled)
-    self.m_bEnabled = bEnabled
-
-    self:InvalidateLayout()
-end
+-- HOOKS DEFINED IN THE ENGINE --
 
 ---
--- @return boolean
--- @realm client
-function PANEL:IsEnabled()
-    return self.m_bEnabled
-end
-
----
--- @return boolean
--- @realm client
-function PANEL:GetDisabled()
-    return not self:IsEnabled()
-end
-
----
+-- Called whenever the panel should apply its scheme (colors, fonts, style). It is called
+-- a few frames after panel's creation once.
+-- @ref https://wiki.facepunch.com/gmod/PANEL:ApplySchemeSettings
+-- @hook
 -- @realm client
 function PANEL:ApplySchemeSettings() end
 
 ---
--- @ignore
+-- Called every frame while Panel:IsVisible is true.
+-- @ref https://wiki.facepunch.com/gmod/PANEL:Think
+-- @hook
+-- @realm client
 function PANEL:Think()
+    self:TriggerOn("Think")
+
     if self:GetAutoStretchVertical() then
         self:SizeToContentsY()
     end
 end
 
 ---
--- @ignore
+-- Called whenever the panels' layout needs to be performed again. This means all child panels must
+-- be re-positioned to fit the possibly new size of this panel.
+-- @ref https://wiki.facepunch.com/gmod/PANEL:PerformLayout
+-- @hook
+-- @realm client
 function PANEL:PerformLayout()
     self:ApplySchemeSettings()
 end
 
 ---
+-- Called whenever the cursor entered the panels bounds.
+-- @ref https://wiki.facepunch.com/gmod/PANEL:OnCursorEntered
+-- @hook
 -- @realm client
 function PANEL:OnCursorEntered()
+    self:TriggerOn("CursorEntered")
+
     self:InvalidateLayout(true)
 end
 
 ---
+-- Called whenever the cursor left the panels bounds.
+-- @ref https://wiki.facepunch.com/gmod/PANEL:OnCursorExited
+-- @hook
 -- @realm client
 function PANEL:OnCursorExited()
+    self:TriggerOn("CursorExited")
+
     self:InvalidateLayout(true)
 end
 
 ---
--- @param number mcode
+-- Called whenever a mouse key was pressed while the panel is focused.
+-- @ref https://wiki.facepunch.com/gmod/PANEL:OnMousePressed
+-- @param number mouseCode The key code of the mouse button pressed
+-- @hook
 -- @realm client
-function PANEL:OnMousePressed(mcode)
-    if self:GetDisabled() then
+function PANEL:OnMousePressed(mouseCode)
+    if not self:IsEnabled() then
         return
     end
 
-    if mcode == MOUSE_LEFT and not dragndrop.IsDragging() and self.m_bDoubleClicking then
+    if mouseCode == MOUSE_LEFT and not dragndrop.IsDragging() and self.m_bDoubleClicking then
         if self.LastClickTime and SysTime() - self.LastClickTime < 0.2 then
-            self:DoDoubleClickInternal()
-            self:DoDoubleClick()
+            self:TriggerDeprecatedEvent("DoDoubleClickInternal")
+            self:TriggerDeprecatedEvent("DoDoubleClick")
+
+            self:TriggerOnWithBase("DoubleClickInternal")
+            self:TriggerOnWithBase("DoubleClick")
 
             return
         end
@@ -240,47 +402,52 @@ function PANEL:OnMousePressed(mcode)
 
     -- If we're selectable and have shift held down then go up
     -- the parent until we find a selection canvas and start box selection
-    if self:IsSelectable() and mcode == MOUSE_LEFT and input.IsShiftDown() then
+    if self:IsSelectable() and mouseCode == MOUSE_LEFT and input.IsShiftDown() then
         return self:StartBoxSelection()
     end
 
     self:MouseCapture(true)
-    self.Depressed = true
-    self:OnDepressed()
+    self:SetDepressed(true)
+
+    self:TriggerOnWithBase("Depressed", mouseCode)
+
     self:InvalidateLayout(true)
 
-    --
-    -- Tell DragNDrop that we're down, and might start getting dragged!
-    --
-    self:DragMousePress(mcode)
+    -- tell DragNDrop that we're down, and might start getting dragged!
+    self:DragMousePress(mouseCode)
 end
 
 ---
--- @param number mcode
+--Called whenever a mouse key was released while the panel is focused.
+-- @ref https://wiki.facepunch.com/gmod/PANEL:OnMouseReleased
+-- @param number mouseCode The key code of the mouse button released
+-- @hook
 -- @realm client
-function PANEL:OnMouseReleased(mcode)
+function PANEL:OnMouseReleased(mouseCode)
     self:MouseCapture(false)
 
     if self:GetDisabled() then
         return
     end
 
-    if not self.Depressed and dragndrop.m_DraggingMain ~= self then
+    if not self:IsDepressed() and dragndrop.m_DraggingMain ~= self then
         return
     end
 
-    if self.Depressed then
-        self.Depressed = nil
-        self:OnReleased()
+    if self:IsDepressed() then
+        self:SetDepressed(false)
+
+        self:TriggerOnWithBase("Released", mouseCode)
+
         self:InvalidateLayout(true)
     end
 
     -- If we were being dragged then don't do the default behaviour!
-    if self:DragMouseRelease(mcode) then
+    if self:DragMouseRelease(mouseCode) then
         return
     end
 
-    if self:IsSelectable() and mcode == MOUSE_LEFT then
+    if self:IsSelectable() and mouseCode == MOUSE_LEFT then
         local canvas = self:GetSelectionCanvas()
 
         if canvas then
@@ -288,178 +455,251 @@ function PANEL:OnMouseReleased(mcode)
         end
     end
 
-    if not self.Hovered then
+    if not self:IsHovered() then
         return
     end
 
-    --
-    -- For the purposes of these callbacks we want to
-    -- keep depressed true. This helps us out in controls
-    -- like the checkbox in the properties dialog. Because
-    -- the properties dialog will only manually change the value
-    -- if IsEditing() is true - and the only way to work out if
-    -- a label/button based control is editing is when it's depressed.
-    --
-    self.Depressed = true
+    -- For the purposes of these callbacks we want to keep depressed true. This helps
+    -- us out in controls like the checkbox in the properties dialog. Because the
+    -- properties dialog will only manually change the value if IsEditing() is true -
+    -- and the only way to work out if a label/button based control is editing is when
+    -- it's depressed.
+    self:SetDepressed(true)
 
-    if mcode == MOUSE_RIGHT then
-        self:DoRightClick()
-    elseif mcode == MOUSE_LEFT then
-        self:DoClickInternal()
-        self:DoClick()
-    elseif mcode == MOUSE_MIDDLE then
-        self:DoMiddleClick()
+    if mouseCode == MOUSE_RIGHT then
+        self:TriggerDeprecatedEvent("DoRightClick")
+
+        self:TriggerOnWithBase("RightClick")
+    elseif mouseCode == MOUSE_LEFT then
+        self:TriggerDeprecatedEvent("DoClickInternal")
+        self:TriggerDeprecatedEvent("DoClick")
+
+        self:TriggerOnWithBase("LeftClickInternal")
+        self:TriggerOnWithBase("LeftClick")
+    elseif mouseCode == MOUSE_MIDDLE then
+        self:TriggerDeprecatedEvent("DoMiddleClick")
+
+        self:TriggerOnWithBase("MiddleClick")
     end
 
-    self.Depressed = nil
+    self:SetDepressed(false)
 end
 
----
--- overwrites the base function with an empty function
--- @realm client
-function PANEL:OnReleased() end
+-- HOOKS DEFINED FROM HERE ON ARE LUA BASED HOOKS AND NOT PROVIDED BY THE ENGINE --
 
 ---
--- overwrites the base function with an empty function
+-- Called when the player releases any mouse button on the label.
+-- @param number mouseCode The mouse code defines the button that was released.
+-- @hook
 -- @realm client
-function PANEL:OnDepressed() end
+function PANEL:OnDepressed(mouseCode) end
 
 ---
--- overwrites the base function with an empty function
--- @param boolean bool
+-- Called when the player presses the label with any mouse button.
+-- @param number mouseCode The mouse code defines the button that was released.
+-- @hook
 -- @realm client
-function PANEL:OnToggled(bool) end
+function PANEL:OnReleased(mouseCode) end
 
 ---
+-- Called when the toggle state of the label is changed by Label.
+-- @note In order to use toggle functionality, you must first call `DLabel:SetIsToggle()` with
+-- `true`, as it is disabled by default.
+-- @param boolean state The current toggle state
+-- @hook
 -- @realm client
-function PANEL:DoClick()
+function PANEL:OnToggled(state) end
+
+---
+-- Called after the left mouse mouse was released on a button, performing a click.
+-- @note Calls the internal toggle functionality if enabled.
+-- @hook
+-- @realm client
+function PANEL:OnLeftClick()
     self:Toggle()
 end
 
 ---
--- overwrites the base function with an empty function
+-- Called after the left mouse mouse was released on a button, performing a left click. This
+-- function is called immidiately before OnLeftClick.
+-- @hook
 -- @realm client
-function PANEL:DoRightClick() end
+function PANEL:OnLeftClickInternal() end
 
 ---
--- overwrites the base function with an empty function
+-- Called after the right mouse mouse was released on a button, performing a right click.
+-- @hook
 -- @realm client
-function PANEL:DoMiddleClick() end
+function PANEL:OnRightClick() end
 
 ---
--- overwrites the base function with an empty function
+-- Called after the middle mouse mouse was released on a button, performing a middle click.
+-- @hook
 -- @realm client
-function PANEL:DoClickInternal() end
+function PANEL:OnMiddleClick() end
 
 ---
--- overwrites the base function with an empty function
+-- Called after the left mouse mouse was released on a button, performing a double click.
+-- @note Calls the internal toggle functionality if enabled.
+-- @hook
 -- @realm client
-function PANEL:DoDoubleClick() end
+function PANEL:OnDoubleClick() end
 
 ---
--- overwrites the base function with an empty function
+-- Called after the left mouse mouse was released on a button, performing a double click. This
+-- function is called immidiately before OnDoubleClick.
+-- @hook
 -- @realm client
-function PANEL:DoDoubleClickInternal() end
+function PANEL:OnDoubleClickInternal() end
+
+-- TOOLTIP RELATED FUNCTIONS --
+
+---
+-- @param string text
+-- @return Panel Returns the panel itself
+-- @realm client
+function PANEL:SetTooltip(text)
+    self:SetTooltipPanelOverride("TTT2:DTooltip")
+
+    self._tooltip.text = text
+
+    return self
+end
+
+-- TODO review this - do we actually need this? what of this code is needed? looks strange.
+-- @return Panel Returns the panel itself
+function PANEL:SetTooltipPanel(panel)
+    self:SetTooltipPanelOverride("TTT2:DTooltip")
+
+    -- original code before the overwrite
+    self.pnlTooltipPanel = panel
+
+    if IsValid(panel) then
+        panel:SetVisible(false)
+    end
+
+    return self
+end
 
 ---
 -- @param number x
 -- @param number y
+-- @return Panel Returns the panel itself
 -- @realm client
 function PANEL:SetTooltipFixedPosition(x, y)
-    self.tooltip.fixedPosition = {
+    self._tooltip.fixedPosition = {
         x = x,
         y = y,
     }
+
+    return self
 end
 
 ---
 -- @return number, number
 -- @realm client
 function PANEL:GetTooltipFixedPosition()
-    return self.tooltip.fixedPosition.x, self.tooltip.fixedPosition.y
+    return self._tooltip.fixedPosition.x, self._tooltip.fixedPosition.y
 end
 
 ---
 -- @return boolean
 -- @realm client
 function PANEL:HasTooltipFixedPosition()
-    return self.tooltip.fixedPosition ~= nil
+    return self._tooltip.fixedPosition ~= nil
 end
 
 ---
 -- @param number w
 -- @param number h
+-- @return Panel Returns the panel itself
 -- @realm client
 function PANEL:SetTooltipFixedSize(w, h)
     -- +2 are the outline pixels
-    self.tooltip.fixedSize = {
+    self._tooltip.fixedSize = {
         w = w + 2,
-        h = h + self.tooltip.sizeArrow + 2,
+        h = h + (self._tooltip.sizeArrow or 0) + 2,
     }
+
+    return self
 end
 
 ---
 -- @return number, number
 -- @realm client
 function PANEL:GetTooltipFixedSize()
-    return self.tooltip.fixedSize.w, self.tooltip.fixedSize.h
+    return self._tooltip.fixedSize.w, self._tooltip.fixedSize.h
 end
 
 ---
 -- @realm client
 function PANEL:HasTooltipFixedSize()
-    return self.tooltip.fixedSize ~= nil
+    return self._tooltip.fixedSize ~= nil
 end
 
 ---
 -- @param number delay
+-- @return Panel Returns the panel itself
 -- @realm client
 function PANEL:SetTooltipOpeningDelay(delay)
-    self.tooltip.delay = delay
+    self._tooltip.delay = delay
+
+    return self
 end
 
 ---
 -- @return number
 -- @realm client
 function PANEL:GetTooltipOpeningDelay()
-    return self.tooltip.delay
+    return self._tooltip.delay
 end
 
 ---
--- @param string text
+-- @param number size
+-- @return Panel Returns the panel itself
 -- @realm client
-function PANEL:SetTooltip(text)
-    self:SetTooltipPanelOverride("DTooltipTTT2")
+function PANEL:SetTooltipArrowSize(size)
+    self._tooltip.delay = sizeArrow
 
-    self.tooltip.text = text
+    return self
+end
+
+---
+-- @return number
+-- @realm client
+function PANEL:GetTooltipArrowSize()
+    return self._tooltip.sizeArrow
 end
 
 ---
 -- @return string
 -- @realm client
 function PANEL:GetTooltipText()
-    return self.tooltip.text
+    return self._tooltip.text
 end
 
 ---
 -- @return boolean
 -- @realm client
 function PANEL:HasTooltipText()
-    return self.tooltip.text ~= nil and self.tooltip.text ~= ""
+    return self._tooltip.text ~= nil and self._tooltip.text ~= ""
 end
 
 ---
 -- @param string font
+-- @return Panel Returns the panel itself
 -- @realm client
 function PANEL:SetTooltipFont(font)
-    self.tooltip.font = font
+    self._tooltip.font = font
+
+    return self
 end
 
 ---
 -- @return string
 -- @realm client
 function PANEL:GetTooltipFont()
-    return self.tooltip.font
+    return self._tooltip.font
 end
 
-derma.DefineControl("DLabelTTT2", "A Label", PANEL, "DLabel")
+derma.DefineControl("TTT2:DLabel", "The basic Label everything in TTT2 is based on", PANEL, "Label")

--- a/lua/ttt2/libraries/none.lua
+++ b/lua/ttt2/libraries/none.lua
@@ -27,21 +27,128 @@ end
 -- The create @{function} names are based on the var name and the prefix "Get" and "Set"
 -- @note Instead of using this function simply replace `ENT:DTVar()` calls with `ENT:NetworkVar()`.
 -- @param table tbl the @{table} that should receive the Getter and Setter @{function}
--- @param string varname the name the tbl @{table} should have as key value
+-- @param string varName the name the tbl @{table} should have as key value
 -- @param string name the name that should be concatenated to the prefix "Get" and "Set"
 -- @deprecated
 -- @realm shared
-function AccessorFuncDT(tbl, varname, name)
+function AccessorFuncDT(tbl, varName, name)
     ErrorNoHaltWithStack(
         "[DEPRECATION WARNING] Using `AccessorFuncDT` is deprecated and will be removed in a future version."
     )
     tbl["Get" .. name] = function(s)
-        return s.dt and s.dt[varname]
+        return s.dt and s.dt[varName]
     end
 
     tbl["Set" .. name] = function(s, v)
         if s.dt then
-            s.dt[varname] = v
+            s.dt[varName] = v
+        end
+    end
+end
+
+---
+-- Adds simple Get/Set accessor functions on the specified table. Can also force the value to be set to a number, bool or string.
+-- @ref https://wiki.facepunch.com/gmod/Global.AccessorFunc
+-- @param table tableScope The table to add the accessor functions to
+-- @param string varName The key of the table to be get/set
+-- @param string name The name of the functions (will be prefixed with Get and Set)
+-- @param[opt] number forceType The type the setter should force to (uses FORCE enum)
+-- @param[default=false] returnSelf Makes Setters return a reference to itself
+-- @realm shared
+function AccessorFunc(tableScope, varName, name, forceType, returnSelf)
+    if not tableScope then
+        debug.Trace()
+    end
+
+    tableScope["Get" .. name] = function(slf)
+        return self[varName]
+    end
+
+    if forceType == FORCE_STRING then
+        tableScope["Set" .. name] = function(slf, v)
+            slf[varName] = tostring(v)
+
+            if returnSelf then
+                return slf
+            end
+        end
+
+        return
+    end
+
+    if forceType == FORCE_NUMBER then
+        tableScope["Set" .. name] = function(slf, v)
+            slf[varName] = tonumber(v)
+
+            if returnSelf then
+                return slf
+            end
+        end
+
+        return
+    end
+
+    if forceType == FORCE_BOOL then
+        tableScope["Set" .. name] = function(slf, v)
+            slf[varName] = tobool(v)
+
+            if returnSelf then
+                return slf
+            end
+        end
+
+        return
+    end
+
+    if forceType == FORCE_ANGLE then
+        tableScope["Set" .. name] = function(slf, v)
+            slf[varName] = Angle(v)
+
+            if returnSelf then
+                return slf
+            end
+        end
+
+        return
+    end
+
+    if forceType == FORCE_COLOR then
+        tableScope["Set" .. name] = function(slf, v)
+            if type(v) == "Vector" then
+                slf[varName] = v:ToColor()
+            else
+                slf[varName] = string.ToColor(tostring(v))
+            end
+
+            if returnSelf then
+                return slf
+            end
+        end
+
+        return
+    end
+
+    if forceType == FORCE_VECTOR then
+        tableScope["Set" .. name] = function(slf, v)
+            if IsColor(v) then
+                slf[varName] = v:ToVector()
+            else
+                slf[varName] = Vector(v)
+            end
+
+            if returnSelf then
+                return slf
+            end
+        end
+
+        return
+    end
+
+    tableScope["Set" .. name] = function(slf, v)
+        slf[varName] = v
+
+        if returnSelf then
+            return slf
         end
     end
 end


### PR DESCRIPTION
This PR has _many_ things yet to do, but I wanted to open a draft so it is open to discussion. There are a few things I want to tackle in this PR. It will probably be rather large, but without any meaningful new features. It is mostly renamed, reordered and cleaned up.

### 1. Broken Inheritance

The first issue I want to address in this PR is the broken vgui inheritance in TTT2. There are quite a few places in the codebase with code duplications and also many unnecessary vgui elements.

After some investigation I learned that both `PANEL` and `LABEL` are defined in the GMod codebase, while every other element with a D prefix is defined in lua. We could use those elements already existing, but there are so many modifications by now, that is is useful to stick to our copied and modied files.
However, in our code base `TTT2:DLabel` and `TTT2:DPanel` have many duplications because they both inherit from their respective engine defined base. In the engine `LABEL` inherits from `PANEL`. We can make `TTT2:DPanel` inherit from TTT2:DLabel`. This drastically cleans up our code and has only a single side effect: the two elements are mostly similar (with some changed default values).

### 2. Repetitive Code

The issue that triggered this rework is the following scenario. This is how it looks if you want to create a button:

```lua
local buttonReport = vgui.Create("DButtonTTT2", buttonArea)
buttonReport:SetText("search_call")
buttonReport:SetSize(self.sizes.widthButton, self.sizes.heightButton)
buttonReport:SetPos(0, self.sizes.padding + 1)
buttonReport:SetIcon(roles.DETECTIVE.iconMaterial, true, 16)
buttonReport.DoClick = function(btn)
    bodysearch.ClientReportsCorpse(data.rag)
end
```

When using _method chaining_ this can be cleaned up a lot:

```lua
local buttonReport = vgui.Create("DButtonTTT2", buttonArea)
    :SetText("search_call")
    :SetSize(self.sizes.widthButton, self.sizes.heightButton)
    :SetPos(0, self.sizes.padding + 1)
    :SetIcon(roles.DETECTIVE.iconMaterial, true, 16)
    :On("Click", function(btn)
        bodysearch.ClientReportsCorpse(data.rag)
    end)
```

This makes it way more clean and less cluttered.

### 3. Events and Hook Overwrites

It is typical that our custom elements have something like this in their initialize function:

```lua
local oldClick = self.DoClick

self.DoClick = function(slf)
    sound.ConditionalPlay(soundClick, SOUND_TYPE_BUTTONS)

    oldClick(slf)
end
```

While this does work, it is rather tedious and prone to errors. This has to be done since there is no real inheritance in vgui elements that could use `BaseClasses`, at least not as far as I could tell. Additionally one might want to attach a function to an event after a element was already created. The developer here has to make sure that they don't overwrite an already existing hook.
[The way the sound was added to buttons](https://github.com/TTT-2/TTT2/blob/master/gamemodes/terrortown/gamemode/client/cl_vskin/vgui/dbutton_ttt2.lua#L38-L58) is a good example of the issue at hand.

The solution is to introduce a simple system, that mimics hooks. Elements can be registered with `PANEL:On(name, function)`. That supports multiple events on a single event. So we can handle our button sounds internally in a clean way, while also exposing the event to the developer.

Similarly `PANEL:After(delay, function)` was introduced to provide a clean wrapper for timers.

Adding sound to a button would look like this:

```lua
local buttonReport = vgui.Create("DButtonTTT2", buttonArea)
    :On("Click", function(slf)
        sound.ConditionalPlay(soundClick, SOUND_TYPE_BUTTONS)
    end)
```

### 4. Other Ideas

While researching this, I also found this library which seems quite nice: https://github.com/Threebow/better-derma-grid