### PR TITLE
M16 Ironsights Allignment and Zoom Tweak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed `markerVision`'s registry table being able to contain duplicate obsolete entries, thus fixing potential syncing issues with markers (by @TW1STaL1CKY)
 - Fixed issue in new Ammo dropping that could cause an error when dropping for modified weapon bases. (by @MrXonte)
 - Fixed C4 not showing the correct inflictor when the player is killed (by @TimGoll)
+- Fixed M16 Ironsight misalignment (by @SvveetMavis) 
 
 ### Changed
 
@@ -63,6 +64,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Improved description of role layering (by @nike4613)
 - Improved the role layering menu by showing which role is enabled and which is disabled (by @TimGoll)
 - Reworked C4 damage calculation with new gameEffect ExplosiveSphereDamage (by @MrXonte)
+- Changed the amount the M16 zooms in (by @SvveetMavis)
 
 ## [v0.14.0b](https://github.com/TTT-2/TTT2/tree/v0.14.0b) (2024-09-20)
 

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_m16.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_m16.lua
@@ -44,8 +44,8 @@ SWEP.ViewModel = "models/weapons/cstrike/c_rif_m4a1.mdl"
 SWEP.WorldModel = "models/weapons/w_rif_m4a1.mdl"
 SWEP.idleResetFix = true
 
-SWEP.IronSightsPos = Vector(-7.58, -9.2, 0.55)
-SWEP.IronSightsAng = Vector(2.599, -1.3, -3.6)
+SWEP.IronSightsPos = Vector(-7.639, -9.2, 0.55)
+SWEP.IronSightsAng = Vector(2.9, -1.3, -3.6)
 
 ---
 -- @ignore
@@ -57,7 +57,7 @@ function SWEP:SetZoom(state)
     end
 
     if state then
-        owner:SetFOV(42, 0.5)
+        owner:SetFOV(62, 0.5)
     else
         owner:SetFOV(0, 0.2)
     end

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_m16.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_m16.lua
@@ -44,8 +44,8 @@ SWEP.ViewModel = "models/weapons/cstrike/c_rif_m4a1.mdl"
 SWEP.WorldModel = "models/weapons/w_rif_m4a1.mdl"
 SWEP.idleResetFix = true
 
-SWEP.IronSightsPos = Vector(-7.639, -9.2, 0.55)
-SWEP.IronSightsAng = Vector(2.9, -1.3, -3.6)
+SWEP.IronSightsPos = Vector(-7.677, -9.2, 0.55)
+SWEP.IronSightsAng = Vector(2.95, -1.4, -3.7)
 
 ---
 -- @ignore


### PR DESCRIPTION
This aligns the iron sights position of the m16 to fit better and lessens the zoom on the iron sights to look at a lot better, the little default zoom I feel is a little much.

Before 
![Desktop Screenshot 2025 01 30 - 05 30 32 86](https://github.com/user-attachments/assets/98f6488e-5dc2-4e2e-9d22-c7757ac2f75a)


After 
![Desktop Screenshot 2025 01 30 - 05 31 08 57](https://github.com/user-attachments/assets/fb19b814-ef86-474e-8872-3acef032b20d)
