### PR TITLE
Fix OUTLINE_MODE_BOTH and OUTLINE_MODE_VISIBLE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ## Unreleased
 
+### Fixed
+
+- Fixed new outlines' `OUTLINE_MODE_VISIBLE` and `OUTLINE_MODE_BOTH`
+
 ## [v0.14.1b](https://github.com/TTT-2/TTT2/tree/v0.14.1b) (2025-02-01)
 
 ### Added

--- a/lua/ttt2/libraries/outline.lua
+++ b/lua/ttt2/libraries/outline.lua
@@ -294,7 +294,7 @@ local function Render()
                 mode == OUTLINE_MODE_BOTH and STENCIL_REPLACE or STENCIL_KEEP
             )
             render.SetStencilFailOperation(STENCIL_KEEP)
-            render.SetStencilPassOperation(STENCIL_KEEP)
+            render.SetStencilPassOperation(STENCIL_REPLACE)
 
             RenderModels(render_ents)
         elseif mode == OUTLINE_MODE_NOTVISIBLE then


### PR DESCRIPTION
Current behavior:

![Image](https://github.com/user-attachments/assets/54f232e9-fd74-4b69-b4ff-e981e4fec00f)

![Image](https://github.com/user-attachments/assets/f1592ecc-efd0-4bd1-bdec-36fb8cc1b44e)

This is simply due to not updating the stencil when the Z-test passes