### PR TITLE
Added incompatible addon to the addonchecker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ### Changed
 - Updated Russian and English localization files (by @Satton2)
+- Updated the list of troublesome addons used by the addonchecker
 
 ## [v0.14.2b](https://github.com/TTT-2/TTT2/tree/v0.14.2b) (2025-02-02)
 

--- a/gamemodes/terrortown/gamemode/server/sv_addonchecker.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_addonchecker.lua
@@ -207,6 +207,10 @@ addonChecker.curatedList = {
         reason = "This addon doesn't use the TTT base correctly and also causes sound and broken playermodel issues.",
         type = ADDON_INCOMPATIBLE,
     },
+    ["2795122660"] = { -- TTT Weapon Rework by wget
+        reason = "This addon messes with some core TTT(2) functions, creating issues like corpses being recognized as 'fake' even though they are not.",
+        type = ADDON_INCOMPATIBLE,
+    },
     ["456247192"] = { -- TTT Coffee-Cup Hunt by Niandra!
         alternative = "2150924507",
         reason = "Addon is broken and doesn't do anything.",


### PR DESCRIPTION
The addon (https://steamcommunity.com/sharedfiles/filedetails/?id=2795122660) is no longer supported too and seems to cause some issues with TTT2. For example: How corpses are created is overwritten and causes them to act like they are fake.