### PR TITLE
LastWords: Fixed convar not being respected and added a new hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ### Added
 
 - Added option to select preferred unit of length for distance displays (by @wgetJane)
+- Added a new hook `TTT2AvoidLastWords` to allow blocking last word messages on a per-message basis (by @vertiKarl)
 
 ### Changed
+
 - Updated Russian and English localization files (by @Satton2)
 - Updated the list of troublesome addons used by the addonchecker
 
@@ -17,6 +19,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ### Fixed
 
 - Fixed new outlines' `OUTLINE_MODE_VISIBLE` and `OUTLINE_MODE_BOTH`
+- Fixed ConVar `ttt_lastwords_chatprint` not being respected if player dies by fall damage (by @vertiKarl)
 
 ## [v0.14.1b](https://github.com/TTT-2/TTT2/tree/v0.14.1b) (2025-02-01)
 
@@ -58,7 +61,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed `markerVision`'s registry table being able to contain duplicate obsolete entries, thus fixing potential syncing issues with markers (by @TW1STaL1CKY)
 - Fixed issue in new Ammo dropping that could cause an error when dropping for modified weapon bases. (by @MrXonte)
 - Fixed C4 not showing the correct inflictor when the player is killed (by @TimGoll)
-- Fixed M16 Ironsight misalignment (by @SvveetMavis) 
+- Fixed M16 Ironsight misalignment (by @SvveetMavis)
 - Fixed outline interactions with certain weapon scopes (by @WardenPotato)
 - Fixed outlines not rendering uniformly (by @WardenPotato)
 

--- a/gamemodes/terrortown/gamemode/server/sv_gamemsg.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_gamemsg.lua
@@ -481,7 +481,7 @@ local function deathrec(ply, cmd, args)
         return
     end
 
-    if ttt_lastwords:GetBool() or ply.death_type == KILL_FALL then
+    if ttt_lastwords:GetBool() and hook.Run("TTT2AvoidLastWords", ply, words) ~= false then
         LastWordsMsg(ply, words)
     end
 
@@ -582,3 +582,12 @@ function GM:TTT2AvoidTeamChat(sender, team, msg) end
 -- @hook
 -- @realm server
 function GM:TTT2AvoidGeneralChat(sender, msg) end
+
+---
+-- Cancelable hook to block a the last words chat message.
+-- @param Player sender The player that sends the message.
+-- @param string words The message that is about to be sent
+-- @return nil|boolean Return false to block message
+-- @hook
+-- @realm server
+function GM:TTT2AvoidLastWords(sender, words) end

--- a/gamemodes/terrortown/gamemode/server/sv_gamemsg.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_gamemsg.lua
@@ -481,6 +481,7 @@ local function deathrec(ply, cmd, args)
         return
     end
 
+    -- check ConVar and also test if anyone blocks the message
     if ttt_lastwords:GetBool() and hook.Run("TTT2AvoidLastWords", ply, words) ~= false then
         LastWordsMsg(ply, words)
     end
@@ -584,7 +585,7 @@ function GM:TTT2AvoidTeamChat(sender, team, msg) end
 function GM:TTT2AvoidGeneralChat(sender, msg) end
 
 ---
--- Cancelable hook to block a the last words chat message.
+-- Cancelable hook to block the last words chat message.
 -- @param Player sender The player that sends the message.
 -- @param string words The message that is about to be sent
 -- @return nil|boolean Return false to block message


### PR DESCRIPTION
- Added a new hook `TTT2AvoidLastWords` which is getting checked when the server tries to send out the last words message to other clients. The parameters are the player that is trying to send the message and the chat message they were trying to send. To block said message, just add this hook to your addon and return false based on conditions you define. 
- Fixed (#1776) not respecting ConVar if player dies by fall damage.

I have tested the following:
- Dying by fall damage when ConVar is disabled and having a chat message written but not sent. (works: is getting blocked)
- Adding the hook to the Shinigami and:
  - Dying as Shinigami when not reborn (works: sends message)
  - Dying as Shinigami when reborn (works: blocks message)

I will also make a PR for the Shinigami once this PR gets merged.