### PR TITLE
Fixed Hud error on pickup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ### Fixed
 
 - Fixed new outlines' `OUTLINE_MODE_VISIBLE` and `OUTLINE_MODE_BOTH`
+- Fixed Hud errors when picking up items or weapons with no viable icon (by @NickCloudAT)
 
 ## [v0.14.1b](https://github.com/TTT-2/TTT2/tree/v0.14.1b) (2025-02-01)
 

--- a/gamemodes/terrortown/gamemode/shared/hud_elements/tttpickup/pure_skin_pickup.lua
+++ b/gamemodes/terrortown/gamemode/shared/hud_elements/tttpickup/pure_skin_pickup.lua
@@ -85,6 +85,11 @@ if CLIENT then
             icon = self.icon_ammo
         end
 
+        -- Some items, like default HL2 items, have no icon. Fallback to the "icon_special"
+        if icon == nil then
+            icon = self.icon_item
+        end
+
         -- Draw the colour tip
         surface.SetDrawColor(tipColor.r, tipColor.g, tipColor.b, alpha)
         surface.DrawRect(x, y, self.tipsize, h)


### PR DESCRIPTION
This fixes Hud errors when picking up an item or weapon with no viable icon by falling back to the item_special icon

Fixes https://github.com/TTT-2/TTT2/issues/1728