### PR TITLE
Body armour adjustments

### DIFF
--- a/gamemodes/terrortown/gamemode/server/sv_armor.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_armor.lua
@@ -64,7 +64,7 @@ ARMOR.cv = {
     -- @realm server
     item_armor_block_headshots = CreateConVar(
         "ttt_item_armor_block_headshots",
-        0,
+        1,
         { FCVAR_NOTIFY, FCVAR_ARCHIVE }
     ),
 
@@ -72,6 +72,14 @@ ARMOR.cv = {
     -- @realm server
     item_armor_block_blastdmg = CreateConVar(
         "ttt_item_armor_block_blastdmg",
+        0,
+        { FCVAR_NOTIFY, FCVAR_ARCHIVE }
+    ),
+
+    ---
+    -- @realm server
+    item_armor_block_clubdmg = CreateConVar(
+        "ttt_item_armor_block_clubdmg",
         0,
         { FCVAR_NOTIFY, FCVAR_ARCHIVE }
     ),
@@ -160,10 +168,15 @@ function ARMOR:HandlePlayerTakeDamage(ply, infl, att, amount, dmginfo)
         return
     end
 
+    -- handle if crowbar damage should be ignored by the armor
+    if dmginfo:IsDamageType(DMG_CLUB) and not self.cv.item_armor_block_clubdmg:GetBool() then
+        return
+    end
+
     -- fallback for players who prefer the vanilla armor
     if not self.cv.armor_dynamic:GetBool() then
-        -- classic armor only shields from bullet/crowbar damage
-        if dmginfo:IsDamageType(DMG_BULLET) or dmginfo:IsDamageType(DMG_CLUB) then
+        -- classic armor only shields from bullet damage
+        if dmginfo:IsDamageType(DMG_BULLET) then
             dmginfo:ScaleDamage(0.7)
         end
 

--- a/lua/terrortown/lang/en.lua
+++ b/lua/terrortown/lang/en.lua
@@ -2818,3 +2818,6 @@ L.choice_distance_unit_0 = "Inches"
 L.choice_distance_unit_1 = "Meters"
 L.choice_distance_unit_2 = "Yards"
 L.choice_distance_unit_3 = "Feet"
+
+-- 2025-03-06
+L.label_armor_block_clubdmg = "Enable armor blocking crowbar damage"

--- a/lua/terrortown/menus/gamemode/administration/playersettings.lua
+++ b/lua/terrortown/menus/gamemode/administration/playersettings.lua
@@ -36,6 +36,11 @@ function CLGAMEMODESUBMENU:Populate(parent)
         label = "label_armor_block_blastdmg",
     })
 
+    form2:MakeCheckBox({
+        serverConvar = "ttt_item_armor_block_clubdmg",
+        label = "label_armor_block_clubdmg",
+    })
+
     form2:MakeHelp({
         label = "help_item_armor_classic",
     })


### PR DESCRIPTION
- adds a new cvar for blocking crowbar damage
- removed crowbar damage being reduced by "classic" armour: crowbar damage was never blocked by armour in ttt
- set headshot damage to be reduced by default: this was never an oversight or mistake in ttt, it is a deliberate balance change, body armour initially only protected against shots to the torso but bku updated it to also protect against headshots and limbshots

this is a draft because this is untested right now, will test later