### PR TITLE
Fixed a regression in TTT voice chat team colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed health station continuous use not working (by @wgetJane)
 - Fixed the shop search breaking when using certain special characters (by @NickCloudAT)
 - Fixed propspec not working (by @wgetJane)
+- Fixed a regression in TTT voice chat team colors (see <https://github.com/Facepunch/garrysmod/commit/38b7394ced29ffe318213e580efa4b1090828ac7>)
 
 ## [v0.14.3b](https://github.com/TTT-2/TTT2/tree/v0.14.3b) (2025-03-18)
 

--- a/gamemodes/terrortown/gamemode/client/cl_chat.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_chat.lua
@@ -64,7 +64,12 @@ net.Receive("TTT_RoleChat", TTT_RoleChat)
 -- @local
 function GM:GetTeamColor(ent)
     -- don't reveal that a player has died when they happen to chat or voicechat at the moment of death
-    if ent:IsPlayer() and ent:IsSpec() and ScoreGroup(ent) == GROUP_NOTFOUND then
+    if
+        not LocalPlayer():IsSpec()
+        and ent:IsPlayer()
+        and ent:IsSpec()
+        and ScoreGroup(ent) == GROUP_NOTFOUND
+    then
         --
         -- @realm client
         return hook.Run("GetTeamNumColor", TEAM_TERROR)


### PR DESCRIPTION
This PR adds a fix from here: https://github.com/Facepunch/garrysmod/commit/38b7394ced29ffe318213e580efa4b1090828ac7
The issue which is solved by the fix is described here: https://github.com/Facepunch/garrysmod-issues/issues/6246