### PR TITLE
Fixed ghost viewmodels briefly appearing from weapons held by other players

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed the shop search breaking when using certain special characters (by @NickCloudAT)
 - Fixed propspec not working (by @wgetJane)
 - Fixed a regression in TTT voice chat team colors (see <https://github.com/Facepunch/garrysmod/commit/38b7394ced29ffe318213e580efa4b1090828ac7>)
+- Fixed ghost viewmodels briefly appearing from weapons held by other players (by @TW1STaL1CKY)
 
 ## [v0.14.3b](https://github.com/TTT-2/TTT2/tree/v0.14.3b) (2025-03-18)
 

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -886,7 +886,7 @@ if CLIENT then
     -- @realm client
     hook.Add("PreDrawViewModel", "TTT2ViewModelHider", function(viewModel, ply, wep)
         -- safeguard for ghost viewmodels appearing from weapons held by other players
-        if wep != ply:GetActiveWeapon() then
+        if wep ~= ply:GetActiveWeapon() then
             return true
         end
 

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -885,6 +885,11 @@ if CLIENT then
     -- affects @{GM:PostDrawViewModel}
     -- @realm client
     hook.Add("PreDrawViewModel", "TTT2ViewModelHider", function(viewModel, ply, wep)
+        -- safeguard for ghost viewmodels appearing from weapons held by other players
+        if wep != ply:GetActiveWeapon() then
+            return true
+        end
+
         -- note: while ShowDefaultViewModel is set to true in the weapon base, addons such as TFA
         -- do not use the weapon base and only implement parts of it to work with TTT. In a perfect
         -- world TFA would be updated to fix this issue, but we can also prevent it by explicitly


### PR DESCRIPTION
Sometimes, random pieces of viewmodels (arms, floating guns) would appear briefly during rounds. Today, I noticed I was able to reliably trigger the bug by making a mimic bot use ironsights while looking towards the center of the map.
I couldn't find exactly what the root cause was, but I did find it was the LocalPlayer's viewmodel entity briefly rendering another weapon...

This PR patches out the issue. Spectating players in first-person still works fine.

Demo of the bug (I'm spamming right-click to make the bot use ironsights):
https://github.com/user-attachments/assets/49c7dfa0-4823-47f5-95be-4858198b9e7d

