### PR TITLE
Bugfix: Fixed edgecases where ttt_flame entities break when their extra entities fail to initialise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed a regression in TTT voice chat team colors (see <https://github.com/Facepunch/garrysmod/commit/38b7394ced29ffe318213e580efa4b1090828ac7>)
 - Fixed ghost viewmodels briefly appearing from weapons held by other players (by @TW1STaL1CKY)
 - Fixed corpses not inheriting the bodygroups from the players model (by @NickCloudAT)
+- Fixed edgecases where ttt_flame entities break when their extra entities fail to initialise (by @TW1STaL1CKY)
 
 ## [v0.14.3b](https://github.com/TTT-2/TTT2/tree/v0.14.3b) (2025-03-18)
 

--- a/gamemodes/terrortown/entities/entities/ttt_flame.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_flame.lua
@@ -76,7 +76,10 @@ function ENT:Initialize()
             self.trail_lifetime,
             self.trail_texture
         )
-        self:DeleteOnRemove(self.trail)
+
+        if IsValid(self.trail) then
+            self:DeleteOnRemove(self.trail)
+        end
     end
 
     self.real_scale = self:GetFlameSize()
@@ -110,6 +113,7 @@ function ENT:Explode()
     if not IsValid(dmgowner) then
         dmgowner = self
     end
+
     util.BlastDamage(self, dmgowner, pos, 300, 40)
 end
 
@@ -143,11 +147,13 @@ if SERVER then
                 local dmg = DamageInfo()
                 dmg:SetDamageType(DMG_BURN)
                 dmg:SetDamage(self.hurt_base + math.random(-self.hurt_variance, self.hurt_variance))
+
                 if IsValid(self:GetDamageParent()) then
                     dmg:SetAttacker(self:GetDamageParent())
                 else
                     dmg:SetAttacker(self)
                 end
+
                 dmg:SetInflictor(self.firechild)
 
                 gameEffects.RadiusDamage(dmg, self:GetPos(), self.hurt_radius, self)
@@ -163,7 +169,7 @@ if SERVER then
                 self:SetDieTime(0)
             else
                 -- wait until we're still before creating a fire
-                if self:GetVelocity() == Vector(0, 0, 0) then
+                if self:GetVelocity() == vector_origin then
                     self:StartFire()
                 end
             end
@@ -184,14 +190,20 @@ function ENT:StartFire()
         self:GetDamageParent(),
         self
     )
-    self:DeleteOnRemove(self.firechild)
+
+    if IsValid(self.firechild) then
+        self:DeleteOnRemove(self.firechild)
+    end
 
     self:SetBurning(true)
 
     if self:GetImmobile() then
         self:SetMoveType(MOVETYPE_NONE)
-        local physobj = self:GetPhysicsObject()
-        physobj:EnableMotion(false)
+
+        local phys = self:GetPhysicsObject()
+        if IsValid(phys) then
+            phys:EnableMotion(false)
+        end
     end
 end
 


### PR DESCRIPTION
Added validity checks to ttt_flame when creating trails and env_fires.
This prevents edgecases where flames break due to values not being initialised after trails or env_fires fail to be created.