### PR TITLE
Fixed null physics object error for doors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 - Fixed ghost viewmodels briefly appearing from weapons held by other players (by @TW1STaL1CKY)
 - Fixed corpses not inheriting the bodygroups from the players model (by @NickCloudAT)
 - Fixed edgecases where ttt_flame entities break when their extra entities fail to initialise (by @TW1STaL1CKY)
+- Fixed null physics object error for doors (by @mexikoedi)
 
 ## [v0.14.3b](https://github.com/TTT-2/TTT2/tree/v0.14.3b) (2025-03-18)
 

--- a/gamemodes/terrortown/gamemode/shared/sh_door.lua
+++ b/gamemodes/terrortown/gamemode/shared/sh_door.lua
@@ -414,7 +414,11 @@ if SERVER then
 
             doorProp.isDoorProp = true
 
-            doorProp:GetPhysicsObject():ApplyForceCenter(pushForce or Vector(0, 0, 0))
+            local physObj = doorProp:GetPhysicsObject()
+
+            if IsValid(physObj) then
+                physObj:ApplyForceCenter(pushForce or Vector(0, 0, 0))
+            end
 
             ---
             -- @realm server


### PR DESCRIPTION
This PR fixes #1813 .
I tested it and I couldn't reproduce the error from the above issue again.