### PR TITLE
Fixed guns not applying themselves as their damage inflictor for FireBullets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ## Unreleased
 
+### Fixed
+
+- Fixed guns not applying themselves as their damage inflictor (by @TW1STaL1CKY)
+
 ## [v0.14.4b](https://github.com/TTT-2/TTT2/tree/v0.14.4b) (2025-06-15)
 
 ### Fixed

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_flaregun.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_flaregun.lua
@@ -190,6 +190,7 @@ end
 function SWEP:ShootFlare()
     local cone = self.Primary.Cone
     local bullet = {}
+    bullet.Inflictor = self
     bullet.Num = 1
     bullet.Src = self:GetOwner():GetShootPos()
     bullet.Dir = self:GetOwner():GetAimVector()

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_push.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_push.lua
@@ -127,6 +127,7 @@ function SWEP:FirePulse(force_fwd, force_up)
     local num = 6
 
     local bullet = {}
+    bullet.Inflictor = self
     bullet.Num = num
     bullet.Src = self:GetOwner():GetShootPos()
     bullet.Dir = self:GetOwner():GetAimVector()

--- a/gamemodes/terrortown/entities/weapons/weapon_ttt_stungun.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_ttt_stungun.lua
@@ -65,6 +65,7 @@ function SWEP:ShootBullet(dmg, recoil, numbul, cone)
     cone = sights and (cone * 0.9) or cone
 
     local bullet = {}
+    bullet.Inflictor = self
     bullet.Num = numbul
     bullet.Src = owner:GetShootPos()
     bullet.Dir = owner:GetAimVector()

--- a/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
+++ b/gamemodes/terrortown/entities/weapons/weapon_tttbase.lua
@@ -1077,6 +1077,7 @@ function SWEP:ShootBullet(dmg, recoil, numbul, cone)
     cone = cone or 0.02
 
     local bullet = {}
+    bullet.Inflictor = self
     bullet.Num = numbul
     bullet.Src = owner:GetShootPos()
     bullet.Dir = owner:GetAimVector()


### PR DESCRIPTION
I've noticed that guns in TTT2 don't set their Inflictor as themselves for FireBullets ([which is a new-ish addition](https://wiki.facepunch.com/gmod/Structures/Bullet#Inflictor)), so I've fixed that.

I'd like to note it seems `util.WeaponFromDamage` was partially used as a workaround for FireBullets not setting an Inflictor, do people think it's still needed?