### PR TITLE
Fixed not being able to use entities through water and clip brushes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 ### Fixed
 
 - Fixed guns not applying themselves as their damage inflictor (by @TW1STaL1CKY)
+- Fixed not being able to use entities through water and clip brushes (by @TW1STaL1CKY)
 
 ## [v0.14.4b](https://github.com/TTT-2/TTT2/tree/v0.14.4b) (2025-06-15)
 

--- a/gamemodes/terrortown/gamemode/client/cl_keys.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_keys.lua
@@ -80,11 +80,13 @@ function GM:PlayerBindPress(ply, bindName, pressed)
         local useEnt = markerVision.GetFocusedEntity()
         local isRemote = IsValid(useEnt)
         if not isRemote then
+            local shootPos = ply:GetShootPos()
+
             local tr = util.TraceLine({
-                start = ply:GetShootPos(),
-                endpos = ply:GetShootPos() + ply:GetAimVector() * 100,
+                start = shootPos,
+                endpos = shootPos + ply:GetAimVector() * 100,
                 filter = ply,
-                mask = MASK_ALL,
+                mask = bit.bor(MASK_SOLID, CONTENTS_DEBRIS),
             })
 
             useEnt = tr.Entity


### PR DESCRIPTION
Currently, trying to use entities and pick up weapons through water and clip brushes doesn't work, even though your TargetId HUD says you can.
This was happening because the clientside trace was using MASK_ALL. I've now changed to MASK_SOLID + CONTENTS_DEBRIS, which is roughly the same mask that the TargetId HUD uses.

I'm aware #1821 exists which I assume would fix this problem when it's eventually merged in, but I thought I would patch this issue specifially while that PR is still in the works.