### PR TITLE
Bodysearch: Improvements and fixes to the GM:TTTBodySearchPopulate hook and how its data is handled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,21 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ## Unreleased
 
+### Changed
+
+- Made improvements to how data returned from the `GM:TTTBodySearchPopulate` hook is handled to make custom bodysearch entry creation better (by @TW1STaL1CKY)
+  - Added support for icon text (like the timer on the Death Time entry)
+  - Added support for specifying the ordering so custom entries can be placed between existing entries
+  - Added support for coloring the entry's background box
+  - Added support for specifying a custom height for an entry
+  - Gave `GM:TTTBodySearchPopulate` hook a new boolean argument named `scoreboard` which becomes true if the hook is being called to populate the bodysearch info on the scoreboard
+
 ### Fixed
 
 - Fixed guns not applying themselves as their damage inflictor (by @TW1STaL1CKY)
 - Fixed not being able to use entities through water and clip brushes (by @TW1STaL1CKY)
+- Fixed `GM:TTTBodySearchPopulate` failing to create custom bodysearch entries properly (by @TW1STaL1CKY)
+- Fixed scoreboard breaking if a custom bodysearch entry has no icon (by @TW1STaL1CKY)
 
 ## [v0.14.4b](https://github.com/TTT-2/TTT2/tree/v0.14.4b) (2025-06-15)
 

--- a/gamemodes/terrortown/gamemode/client/cl_search.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_search.lua
@@ -327,7 +327,7 @@ function SEARCHSCREEN:Show(data)
                 iconText = isfunction(v.text_icon) and v.text_icon or nil,
                 text = istable(v.text) and v.text
                     or { title = { body = v.title }, text = { { body = v.text } } },
-                colorBox = v.bg_color
+                colorBox = v.bg_color,
             }, v.height, order)
         end
     end

--- a/gamemodes/terrortown/gamemode/client/cl_search.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_search.lua
@@ -325,8 +325,8 @@ function SEARCHSCREEN:Show(data)
             self:MakeInfoItem(contentAreaScroll, k, {
                 iconMaterial = v.img and Material(v.img) or nil,
                 iconText = isfunction(v.text_icon) and v.text_icon or nil,
-                text = istable(v.text) and v.text or
-                    { title = { body = v.title }, text = { { body = v.text } } },
+                text = istable(v.text) and v.text
+                    or { title = { body = v.title }, text = { { body = v.text } } },
                 colorBox = v.bg_color
             }, v.height, order)
         end

--- a/gamemodes/terrortown/gamemode/client/cl_search.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_search.lua
@@ -322,14 +322,13 @@ function SEARCHSCREEN:Show(data)
 
             local order = v.order or (defaultItemsNum + customItemsIndex)
 
-            self:MakeInfoItem(contentAreaScroll, k,
-                {
-                    iconMaterial = v.img and Material(v.img) or nil,
-                    iconText = isfunction(v.text_icon) and v.text_icon or nil,
-                    text = istable(v.text) and v.text or { title = { body = v.title }, text = { { body = v.text } } },
-                    colorBox = v.bg_color
-                },
-                v.height, order)
+            self:MakeInfoItem(contentAreaScroll, k, {
+                iconMaterial = v.img and Material(v.img) or nil,
+                iconText = isfunction(v.text_icon) and v.text_icon or nil,
+                text = istable(v.text) and v.text or
+                    { title = { body = v.title }, text = { { body = v.text } } },
+                colorBox = v.bg_color
+            }, v.height, order)
         end
     end
 

--- a/gamemodes/terrortown/gamemode/client/vgui/cl_sb_info.lua
+++ b/gamemodes/terrortown/gamemode/client/vgui/cl_sb_info.lua
@@ -131,9 +131,6 @@ function PANEL:UpdatePlayerData()
             ic = vgui.Create("SimpleIconAvatar", self.List)
             ic:SetPlayer(info.ply)
             ic:SetAvatarSize(24)
-        elseif t == "dtime" then
-            ic = vgui.Create("SimpleIconLabelled", self.List)
-            ic:SetIconText(info.text_icon)
         elseif t == "role" then
             ic = vgui.Create("SimpleRoleIcon", self.List)
 
@@ -142,8 +139,19 @@ function PANEL:UpdatePlayerData()
             ic.Icon:SetRoleIconImage(icon)
 
             icon = "vgui/ttt/dynamic/icon_base"
+        elseif isfunction(info.text_icon) then
+            ic = vgui.Create("SimpleIconLabelled", self.List)
+            ic:SetIconText(info.text_icon())
+        elseif isstring(info.text_icon) then
+            ic = vgui.Create("SimpleIconLabelled", self.List)
+            ic:SetIconText(info.text_icon)
         else
             ic = vgui.Create("SimpleIcon", self.List)
+        end
+
+        -- Prevent the scoreboard from breaking if the search result has no icon
+        if not icon then
+            icon = "vgui/ttt/dynamic/icon_base"
         end
 
         ic:SetIconSize(64)

--- a/lua/ttt2/libraries/bodysearch.lua
+++ b/lua/ttt2/libraries/bodysearch.lua
@@ -1020,7 +1020,7 @@ if CLIENT then
 
         ---
         -- @realm client
-        hook.Run("TTTBodySearchPopulate", search, raw)
+        hook.Run("TTTBodySearchPopulate", search, raw, true)
 
         return search
     end
@@ -1211,9 +1211,10 @@ if CLIENT then
     -- This hook can be used to populate the body search panel.
     -- @param table search The search data table
     -- @param table raw The raw search data
+    -- @param boolean scoreboard Whether the hook is being called to popluate the scoreboard (legacy)
     -- @hook
     -- @realm client
-    function GM:TTTBodySearchPopulate(search, raw) end
+    function GM:TTTBodySearchPopulate(search, raw, scoreboard) end
 
     ---
     -- This hook can be used to modify the equipment info of a corpse.


### PR DESCRIPTION
Today, I tried creating custom bodysearch entries using `GM:TTTBodySearchPopulate` and found that it didn't seem to be possible without changing the gamemode's code.

This commit contains the changes I made to fix it, along with improvements such as letting custom bodysearch entries access features that built-in ones have (icon text, background color). The changelog details everything I've done.