### PR TITLE
TargetId: Let GM:TTTModifyTargetedEntity modify the target distance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ## Unreleased
 
+### Changed
+
+- `GM:TTTModifyTargetedEntity` can now return a second value to modify the distance of a new target entity (by @TW1STaL1CKY)
+
 ### Fixed
 
 - Fixed guns not applying themselves as their damage inflictor (by @TW1STaL1CKY)

--- a/gamemodes/terrortown/gamemode/client/cl_targetid.lua
+++ b/gamemodes/terrortown/gamemode/client/cl_targetid.lua
@@ -296,11 +296,15 @@ function GM:HUDDrawTargetID()
 
     ---
     -- @realm client
-    local changedEnt = hook.Run("TTTModifyTargetedEntity", ent, distance)
+    local changedEnt, changedDistance = hook.Run("TTTModifyTargetedEntity", ent, distance)
 
     if changedEnt then
         unchangedEnt = ent
         ent = changedEnt
+
+        if isnumber(changedDistance) then
+            distance = changedDistance
+        end
     end
 
     -- make sure it is a valid entity


### PR DESCRIPTION
You can modify the target entity, but the distance value would remain the same since it couldn't be changed. This can make targetids to appear and disappear unexpectedly if the target entity was changed.

I've made `GM:TTTModifyTargetedEntity` read a second return value for distance so devs can correct the distance or do as they please with it. I've checked and it doesn't let you use entities from far away if you force target them with distance set to 0.