### PR TITLE
Addonchecker: Added new entry

### DIFF
--- a/gamemodes/terrortown/gamemode/server/sv_addonchecker.lua
+++ b/gamemodes/terrortown/gamemode/server/sv_addonchecker.lua
@@ -211,6 +211,10 @@ addonChecker.curatedList = {
         reason = "This addon messes with some core TTT(2) functions, creating issues like corpses being recognized as 'fake' even though they are not.",
         type = ADDON_INCOMPATIBLE,
     },
+    ["1595332211"] = { -- GmodAdminSuite by Methylenedioxymethamphetamine
+        reason = "Breaks the weapon pickup.",
+        type = ADDON_INCOMPATIBLE,
+    },
     ["456247192"] = { -- TTT Coffee-Cup Hunt by Niandra!
         alternative = "2150924507",
         reason = "Addon is broken and doesn't do anything.",


### PR DESCRIPTION
A user reported on Discord that he can't pickup weapons if the "GmodAdminSuite" addon is being used.
I added the addon to the addonchecker.