### PR TITLE
Markervision: Fixed null entity error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to TTT2 will be documented here. Inspired by [keep a changel
 
 ## Unreleased
 
+### Fixed
+
+- Fixed markerVision null entity error (by @mexikoedi)
+
 ## [v0.14.5b](https://github.com/TTT-2/TTT2/tree/v0.14.5b) (2025-08-18)
 
 ### Changed

--- a/lua/ttt2/libraries/marker_vision.lua
+++ b/lua/ttt2/libraries/marker_vision.lua
@@ -106,7 +106,7 @@ function markerVision.Remove(ent, identifier)
     -- Restore the old value for UpdateTransmitState and clear ttt2MVTransmitOldFunc.
     if IsValid(ent) then
         ent.UpdateTransmitState = ent.ttt2MVTransmitOldFunc
-        ent:AddEFlags(EFL_FORCE_CHECK_TRANSMIT)
+        ent:RemoveEFlags(EFL_FORCE_CHECK_TRANSMIT)
         ent.ttt2MVTransmitOldFunc = nil
     end
 end

--- a/lua/ttt2/libraries/marker_vision.lua
+++ b/lua/ttt2/libraries/marker_vision.lua
@@ -104,9 +104,11 @@ function markerVision.Remove(ent, identifier)
     end
 
     -- Restore the old value for UpdateTransmitState and clear ttt2MVTransmitOldFunc.
-    ent.UpdateTransmitState = ent.ttt2MVTransmitOldFunc
-    ent:AddEFlags(EFL_FORCE_CHECK_TRANSMIT)
-    ent.ttt2MVTransmitOldFunc = nil
+    if IsValid(ent) then
+        ent.UpdateTransmitState = ent.ttt2MVTransmitOldFunc
+        ent:AddEFlags(EFL_FORCE_CHECK_TRANSMIT)
+        ent.ttt2MVTransmitOldFunc = nil
+    end
 end
 
 local entmeta = assert(FindMetaTable("Entity"), "[TTT2] FAILED TO FIND ENTITY TABLE")


### PR DESCRIPTION
This PR fixes #1834 .
The null entity error was introduced in #1825 .

I tested it and I couldn't reproduce the error from the above issue again.

Error reason:
markerVision.Remove is called twice.
The first time ent is valid but the second time it's a null entity and that caused the error.